### PR TITLE
[Promotion] Deploy dev to production (more strict timeouts)

### DIFF
--- a/common/metric_types.py
+++ b/common/metric_types.py
@@ -49,8 +49,9 @@ class WebSocketMetric(BaseMetric):
         """Creates WebSocket connection."""
         websocket: websockets.WebSocketClientProtocol = await websockets.connect(
             self.ws_endpoint,  # type: ignore
-            ping_timeout=self.config.timeout,
-            close_timeout=self.config.timeout,
+            ping_timeout=10,  # self.config.timeout,
+            open_timeout=10,  # self.config.timeout,
+            close_timeout=10,  # self.config.timeout,
         )
         return websocket
 


### PR DESCRIPTION
# Promoting to production
This PR promotes all changes from dev to master.

## Changes included
- Added more strict timeouts for WebSocket connection https://github.com/chainstacklabs/compare-dashboard-functions/commit/8322ab66549e0228c65cbe8f693412ccaac011b0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced consistent timeout handling for WebSocket operations, ensuring send and receive actions have a standardized timeout period.
- **Improvements**
  - WebSocket connection and messaging now use fixed 10-second timeouts for improved reliability and predictability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->