### PR TITLE
Use newHeads subscription for Arbitrum, Base, Ethereum

### DIFF
--- a/api/read/arbitrum.py
+++ b/api/read/arbitrum.py
@@ -9,15 +9,15 @@ from metrics.arbitrum import (
     HTTPTxReceiptLatencyMetric,
 )
 from metrics.ethereum import (
-    # WSBlockLatencyMetric,
-    WSLogLatencyMetric,
+    WSBlockLatencyMetric,
+    # WSLogLatencyMetric,
 )
 
 metric_name = f"{MetricsServiceConfig.METRIC_PREFIX}response_latency_seconds"
 
 METRICS = [
-    # (WSBlockLatencyMetric, metric_name),
-    (WSLogLatencyMetric, metric_name),
+    (WSBlockLatencyMetric, metric_name),
+    # (WSLogLatencyMetric, metric_name),
     (HTTPBlockNumberLatencyMetric, metric_name),
     (HTTPEthCallLatencyMetric, metric_name),
     (HTTPAccBalanceLatencyMetric, metric_name),

--- a/api/read/base.py
+++ b/api/read/base.py
@@ -9,15 +9,15 @@ from metrics.base import (
     HTTPTxReceiptLatencyMetric,
 )
 from metrics.ethereum import (
-    # WSBlockLatencyMetric,
-    WSLogLatencyMetric,
+    WSBlockLatencyMetric,
+    # WSLogLatencyMetric,
 )
 
 metric_name = f"{MetricsServiceConfig.METRIC_PREFIX}response_latency_seconds"
 
 METRICS = [
-    # (WSBlockLatencyMetric, metric_name),
-    (WSLogLatencyMetric, metric_name),
+    (WSBlockLatencyMetric, metric_name),
+    # (WSLogLatencyMetric, metric_name),
     (HTTPBlockNumberLatencyMetric, metric_name),
     (HTTPEthCallLatencyMetric, metric_name),
     (HTTPAccBalanceLatencyMetric, metric_name),

--- a/api/read/ethereum.py
+++ b/api/read/ethereum.py
@@ -7,15 +7,15 @@ from metrics.ethereum import (
     HTTPDebugTraceTxLatencyMetric,
     HTTPEthCallLatencyMetric,
     HTTPTxReceiptLatencyMetric,
-    # WSBlockLatencyMetric,
-    WSLogLatencyMetric,
+    WSBlockLatencyMetric,
+    # WSLogLatencyMetric,
 )
 
 metric_name = f"{MetricsServiceConfig.METRIC_PREFIX}response_latency_seconds"
 
 METRICS = [
-    # (WSBlockLatencyMetric, metric_name),
-    (WSLogLatencyMetric, metric_name),
+    (WSBlockLatencyMetric, metric_name),
+    # (WSLogLatencyMetric, metric_name),
     (HTTPBlockNumberLatencyMetric, metric_name),
     (HTTPEthCallLatencyMetric, metric_name),
     (HTTPAccBalanceLatencyMetric, metric_name),

--- a/vercel.json
+++ b/vercel.json
@@ -40,31 +40,31 @@
   "crons": [
     {
       "path": "/api/read/ethereum",
-      "schedule": "* * * * *"
+      "schedule": "*/5 * * * *"
     },
     {
       "path": "/api/read/base",
-      "schedule": "* * * * *"
+      "schedule": "*/5 * * * *"
     },
     {
       "path": "/api/read/solana",
-      "schedule": "* * * * *"
+      "schedule": "*/5 * * * *"
     },
     {
       "path": "/api/read/ton",
-      "schedule": "* * * * *"
+      "schedule": "*/5 * * * *"
     },
     {
       "path": "/api/read/arbitrum",
-      "schedule": "* * * * *"
+      "schedule": "*/5 * * * *"
     },
     {
       "path": "/api/read/bnbsc",
-      "schedule": "* * * * *"
+      "schedule": "*/5 * * * *"
     },
     {
       "path": "/api/read/test_blockchain",
-      "schedule": "* * * * *"
+      "schedule": "*/5 * * * *"
     },
     {
       "path": "/api/write/solana",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Switched tracked WebSocket latency metric from log latency to block latency for Ethereum, Base, and Arbitrum networks.
- **Chores**
	- Updated scheduled tasks for multiple API endpoints to run every 5 minutes instead of every minute.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->