### PR TITLE
fix(hyperliquid): enforce 55s timeout for entire metric collection

### DIFF
--- a/common/metric_types.py
+++ b/common/metric_types.py
@@ -89,8 +89,9 @@ class WebSocketMetric(BaseMetric):
         finally:
             if websocket:
                 try:
-                    await self.unsubscribe(websocket)
-                    await websocket.close()
+                    # Shield cleanup from cancellation to ensure proper resource cleanup
+                    await asyncio.shield(self.unsubscribe(websocket))
+                    await asyncio.shield(websocket.close())
                 except Exception as e:
                     logging.error(f"Error closing websocket: {e!s}")
 
@@ -255,12 +256,7 @@ class HttpCallLatencyMetricBase(HttpMetric):
 
             total_time = response_time * 1000
 
-            # Log breakdown
-            provider = self.labels.get_label(MetricLabelKey.PROVIDER)
-            method = self.labels.get_label(MetricLabelKey.API_METHOD)
-            print(
-                f"[{provider}] {method} timing: DNS={dns_time:.0f}ms, Connect={conn_time:.0f}ms, Total={total_time:.0f}ms, Endpoint={endpoint}"
-            )
+            # Log breakdown removed - use proper logging if needed
 
             if not response:
                 raise ValueError("No response received")

--- a/common/state/blockchain_fetcher.py
+++ b/common/state/blockchain_fetcher.py
@@ -47,7 +47,7 @@ class BlockchainDataFetcher:
 
         for attempt in range(1, self._max_retries + 1):
             try:
-                async with aiohttp.ClientSession(timeout=self._timeout) as session:
+                async with aiohttp.ClientSession() as session:
                     async with session.post(
                         self.http_endpoint, headers=self._headers, json=request
                     ) as response:


### PR DESCRIPTION
- Wrap HTTP and WebSocket metric collection in asyncio.wait_for
- Remove redundant inner timeout configurations in aiohttp
- Reduce MAX_RETRIES from 3 to 2 and Retry-After from 15s to 3s
- Ensure total execution cannot exceed 55s including retries/sleeps

This prevents Hyperliquid metrics from exceeding the 59s Vercel limit by enforcing the timeout at the outer scope rather than per-request.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - More precise RPC latency reporting, now excluding connection time.

- Bug Fixes
  - Enforces explicit per-call timeouts for HTTP and WebSocket metric collection to prevent hangs.
  - Improves timeout/error handling and ensures clean unsubscribe/close with error logging.

- Refactor
  - Centralized timeout control moved to explicit bounded operations for reliability.

- Chores
  - Reduced default retries from 3 to 2.
  - Shortened default retry-wait for rate limits (429) from 15s to 3s.
  - Added HTTP timing instrumentation for richer metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->