### PR TITLE
fix: ensure unsubscribe only attempts on open WebSocket connections

### DIFF
--- a/common/metric_types.py
+++ b/common/metric_types.py
@@ -91,13 +91,16 @@ class WebSocketMetric(BaseMetric):
 
         finally:
             if websocket:
-                try:
-                    await asyncio.shield(self.unsubscribe(websocket))
-                except asyncio.CancelledError:
-                    logging.info("Unsubscribe completed despite cancellation")
-                except Exception as e:
-                    logging.warning(f"Error during unsubscribe (non-critical): {e!s}")
+                # Only try to unsubscribe if connection is still open
+                if websocket.open:
+                    try:
+                        await asyncio.shield(self.unsubscribe(websocket))
+                    except asyncio.CancelledError:
+                        logging.info("Unsubscribe completed despite cancellation")
+                    except Exception as e:
+                        logging.warning(f"Error during unsubscribe (non-critical): {e!s}")
 
+                # Close can be called even on closed connections (it's idempotent)
                 try:
                     await asyncio.shield(websocket.close())
                 except asyncio.CancelledError:

--- a/tests/test_api_read.py
+++ b/tests/test_api_read.py
@@ -29,7 +29,7 @@ def main() -> None:
     setup_environment()
 
     # Import handler after environment setup
-    from api.read.hyperliquid import handler
+    from api.read.arbitrum import handler
 
     server = HTTPServer(("localhost", 8000), handler)
     print("Server started at http://localhost:8000")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability of WebSocket metric cleanup by safely handling closed connections and preventing unnecessary operations that could cause errors.

* **Tests**
  * Updated test infrastructure configuration for improved test coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->