### PR TITLE
feat: emit raw block numbers for lag tracking across all chains

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ api/test
 endpoints*.json
 endpoints
 
+uv.lock
+

--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ __pycache__
 venv
 *.env
 *.local
+*.backup
 
 .vscode
 

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,13 +1,15 @@
 dashboards
 tests
-readme.md
+README.md
 endpoints.json
 
 *.local*
 *.example*
 
 pyproject.toml
+coderabbit.yaml
 .vscode
 
 AGENTS.md
+CLAUDE.md
 LICENSE

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,15 +6,15 @@ Python-based Vercel Functions that measure RPC node response times across multip
 
 ```bash
 # Code quality (run before completing any task)
-black .
-ruff check .
-ruff check . --fix
-mypy .
+uvx black .
+uvx ruff check .
+uvx ruff check . --fix
+uvx mypy .
 
 # Local testing
-python tests/test_api_read.py    # Read metrics (latency)
-python tests/test_api_write.py   # Write metrics (Solana landing rate)
-python tests/test_update_state.py  # State update via blob storage
+uv run python tests/test_api_read.py    # Read metrics (latency)
+uv run python tests/test_api_write.py   # Write metrics (Solana landing rate)
+uv run python tests/test_update_state.py  # State update via blob storage
 ```
 
 ## Environment Setup
@@ -59,6 +59,10 @@ tests/         # Local test scripts (not unit tests)
 **Error handling:** HTTP 401/403/404/429 errors are silently ignored (plan restrictions / rate limits). Other errors zero the metric and log with `mark_failure()`.
 
 **Metrics output:** Influx line protocol — `metric_name,tag1=v1,tag2=v2 value=X`
+
+## Subprojects
+
+**`dashboards/`** — isolated subproject for managing Grafana dashboard JSON definitions. Not deployed to Vercel (Vercel-ignored). Has its own `grafana_sync.py` CLI and `README.md`. Dependencies (`requests`, `python-dotenv`) are self-contained and not part of the main `pyproject.toml`. Do not modify this directory as part of Vercel function work.
 
 ## Gotchas
 

--- a/README.md
+++ b/README.md
@@ -181,9 +181,7 @@ For local development, create `endpoints.json` in the project root. For Vercel d
 ```bash
 git clone https://github.com/chainstacklabs/chainstack-rpc-dashboard-functions.git
 cd chainstack-rpc-dashboard-functions
-python -m venv venv
-source venv/bin/activate  # Windows: venv\Scripts\activate
-pip install -r requirements.txt
+uv sync
 ```
 
 ### Local Configuration

--- a/api/read/arbitrum.py
+++ b/api/read/arbitrum.py
@@ -1,3 +1,5 @@
+"""Vercel cron entry point for Arbitrum metrics collection."""
+
 from common.metrics_handler import BaseVercelHandler, MetricsHandler
 from config.defaults import MetricsServiceConfig
 from metrics.arbitrum import (
@@ -28,4 +30,6 @@ METRICS = [
 
 
 class handler(BaseVercelHandler):
+    """Vercel HTTP handler for Arbitrum metric collection."""
+
     metrics_handler = MetricsHandler("Arbitrum", METRICS)

--- a/api/read/base.py
+++ b/api/read/base.py
@@ -1,3 +1,5 @@
+"""Vercel cron entry point for Base metrics collection."""
+
 from common.metrics_handler import BaseVercelHandler, MetricsHandler
 from config.defaults import MetricsServiceConfig
 from metrics.base import (
@@ -28,4 +30,6 @@ METRICS = [
 
 
 class handler(BaseVercelHandler):
+    """Vercel HTTP handler for Base metric collection."""
+
     metrics_handler = MetricsHandler("Base", METRICS)

--- a/api/read/bnbsc.py
+++ b/api/read/bnbsc.py
@@ -1,3 +1,5 @@
+"""Vercel cron entry point for BNB Smart Chain metrics collection."""
+
 from common.metrics_handler import BaseVercelHandler, MetricsHandler
 from config.defaults import MetricsServiceConfig
 from metrics.bnbsc import (
@@ -28,4 +30,6 @@ METRICS = [
 
 
 class handler(BaseVercelHandler):
+    """Vercel HTTP handler for BNB Smart Chain metric collection."""
+
     metrics_handler = MetricsHandler("BNB", METRICS)

--- a/api/read/ethereum.py
+++ b/api/read/ethereum.py
@@ -1,3 +1,5 @@
+"""Vercel cron entry point for Ethereum metrics collection."""
+
 from common.metrics_handler import BaseVercelHandler, MetricsHandler
 from config.defaults import MetricsServiceConfig
 from metrics.ethereum import (
@@ -26,4 +28,6 @@ METRICS = [
 
 
 class handler(BaseVercelHandler):
+    """Vercel HTTP handler for Ethereum metric collection."""
+
     metrics_handler = MetricsHandler("Ethereum", METRICS)

--- a/api/read/hyperliquid.py
+++ b/api/read/hyperliquid.py
@@ -1,3 +1,5 @@
+"""Vercel cron entry point for Hyperliquid metrics collection."""
+
 from common.metrics_handler import BaseVercelHandler, MetricsHandler
 from config.defaults import MetricsServiceConfig
 from metrics.hyperliquid import (
@@ -26,4 +28,6 @@ METRICS = [
 
 
 class handler(BaseVercelHandler):
+    """Vercel HTTP handler for Hyperliquid metric collection."""
+
     metrics_handler = MetricsHandler("Hyperliquid", METRICS)

--- a/api/read/monad.py
+++ b/api/read/monad.py
@@ -1,3 +1,5 @@
+"""Vercel cron entry point for Monad metrics collection."""
+
 from common.metrics_handler import BaseVercelHandler, MetricsHandler
 from config.defaults import MetricsServiceConfig
 from metrics.ethereum import (
@@ -28,4 +30,6 @@ METRICS = [
 
 
 class handler(BaseVercelHandler):
+    """Vercel HTTP handler for Monad metric collection."""
+
     metrics_handler = MetricsHandler("Monad", METRICS)

--- a/api/read/solana.py
+++ b/api/read/solana.py
@@ -1,3 +1,5 @@
+"""Vercel cron entry point for Solana metrics collection."""
+
 from common.metrics_handler import BaseVercelHandler, MetricsHandler
 from config.defaults import MetricsServiceConfig
 from metrics.solana import (
@@ -22,4 +24,6 @@ METRICS = [
 
 
 class handler(BaseVercelHandler):
+    """Vercel HTTP handler for Solana metric collection."""
+
     metrics_handler = MetricsHandler("Solana", METRICS)

--- a/api/read/ton.py
+++ b/api/read/ton.py
@@ -1,3 +1,5 @@
+"""Vercel cron entry point for TON metrics collection."""
+
 from common.metrics_handler import BaseVercelHandler, MetricsHandler
 from config.defaults import MetricsServiceConfig
 from metrics.ton import (
@@ -22,4 +24,6 @@ METRICS = [
 
 
 class handler(BaseVercelHandler):
+    """Vercel HTTP handler for TON metric collection."""
+
     metrics_handler = MetricsHandler("TON", METRICS)

--- a/api/read/ton.py
+++ b/api/read/ton.py
@@ -4,6 +4,7 @@ from metrics.ton import (
     HTTPGetAddressBalanceLatencyMetric,
     HTTPGetBlockHeaderLatencyMetric,
     HTTPGetBlockTxsLatencyMetric,
+    HTTPGetMasterchainInfoLatencyMetric,
     HTTPGetWalletTxsLatencyMetric,
     HTTPRunGetMethodLatencyMetric,
 )
@@ -11,6 +12,7 @@ from metrics.ton import (
 METRIC_NAME = f"{MetricsServiceConfig.METRIC_PREFIX}response_latency_seconds"
 
 METRICS = [
+    (HTTPGetMasterchainInfoLatencyMetric, METRIC_NAME),
     (HTTPGetBlockHeaderLatencyMetric, METRIC_NAME),
     (HTTPRunGetMethodLatencyMetric, METRIC_NAME),
     (HTTPGetAddressBalanceLatencyMetric, METRIC_NAME),

--- a/api/support/update_state.py
+++ b/api/support/update_state.py
@@ -34,6 +34,7 @@ class MissingEndpointsError(Exception):
     """Raised when required blockchain endpoints are not found."""
 
     def __init__(self, missing_chains: set[str]) -> None:
+        """Initialise with the set of chains that have no configured endpoint."""
         self.missing_chains: set[str] = missing_chains
         chains: str = ", ".join(missing_chains)
         super().__init__(f"Missing Chainstack endpoints for: {chains}")
@@ -42,12 +43,13 @@ class MissingEndpointsError(Exception):
 class StateUpdateManager:
     """Manages the collection, processing, and storage of blockchain state data.
 
-    This class orchestrates the retrieval of blockchain state data from configured endpoints,
-    handles fallback to previous data in case of errors, and updates the centralized blob storage.
-    It enforces provider and region filtering to optimize RPC calls and ensures data consistency.
+    Orchestrates state retrieval from configured endpoints, handles fallback to
+    previous data on errors, and writes the result to blob storage.
+    Enforces provider and region filtering to minimise RPC call volume.
     """
 
     def __init__(self) -> None:
+        """Initialise blob storage config from environment variables."""
         store_id: str | None = os.getenv("STORE_ID")
         token: str | None = os.getenv("VERCEL_BLOB_TOKEN")
         if not all([store_id, token]):
@@ -142,6 +144,7 @@ class StateUpdateManager:
         }
 
     async def update(self) -> str:
+        """Collect fresh blockchain state and persist it to blob storage."""
         if os.getenv("VERCEL_REGION") not in ALLOWED_REGIONS:
             return "Region not authorized for state updates"
 
@@ -177,6 +180,8 @@ class StateUpdateManager:
 
 
 class handler(BaseHTTPRequestHandler):
+    """Vercel HTTP handler for triggering blockchain state updates."""
+
     def _check_auth(self) -> bool:
         if os.getenv("SKIP_AUTH", "").lower() == "true":
             return True
@@ -184,6 +189,7 @@ class handler(BaseHTTPRequestHandler):
         return token == f"Bearer {os.getenv('CRON_SECRET', '')}"
 
     def do_GET(self) -> None:
+        """Handle GET request: authenticate then run state update."""
         if not self._check_auth():
             self.send_response(401)
             self.end_headers()

--- a/api/support/update_state.py
+++ b/api/support/update_state.py
@@ -148,9 +148,9 @@ class StateUpdateManager:
         try:
             previous_data: dict[str, Any] = await self._get_previous_data()
 
-            chainstack_endpoints: dict[
-                str, str
-            ] = await self._get_chainstack_endpoints()
+            chainstack_endpoints: dict[str, str] = (
+                await self._get_chainstack_endpoints()
+            )
             blockchain_data = await self._collect_blockchain_data(
                 chainstack_endpoints, previous_data
             )

--- a/api/support/update_state.py
+++ b/api/support/update_state.py
@@ -148,9 +148,9 @@ class StateUpdateManager:
         try:
             previous_data: dict[str, Any] = await self._get_previous_data()
 
-            chainstack_endpoints: dict[str, str] = (
-                await self._get_chainstack_endpoints()
-            )
+            chainstack_endpoints: dict[
+                str, str
+            ] = await self._get_chainstack_endpoints()
             blockchain_data = await self._collect_blockchain_data(
                 chainstack_endpoints, previous_data
             )

--- a/api/write/solana.py
+++ b/api/write/solana.py
@@ -1,4 +1,6 @@
-import os  # noqa: D100
+"""Vercel cron entry point for Solana transaction landing rate metrics."""
+
+import os
 
 from common.metrics_handler import BaseVercelHandler, MetricsHandler
 from config.defaults import MetricsServiceConfig
@@ -16,4 +18,6 @@ METRICS: list[tuple[type[SolanaLandingMetric], str]] = (
 
 
 class handler(BaseVercelHandler):
+    """Vercel HTTP handler for Solana landing rate metric collection."""
+
     metrics_handler = MetricsHandler("Solana", METRICS)

--- a/common/__init__.py
+++ b/common/__init__.py
@@ -1,0 +1,1 @@
+"""Shared utilities for metric collection, configuration, and state management."""

--- a/common/base_metric.py
+++ b/common/base_metric.py
@@ -44,7 +44,6 @@ class BaseMetric(ABC):
         self.ws_endpoint: str | None = ws_endpoint
         self.http_endpoint: str | None = http_endpoint
         self.values: dict[str, MetricValue] = {}
-        self._captured_block_number: Optional[int] = None
         handler._instances.append(self)
 
     @abstractmethod
@@ -108,7 +107,6 @@ class BaseMetric(ABC):
     def mark_failure(self) -> None:
         """Sets failure status and zeros all existing metric types."""
         self.labels.update_label(MetricLabelKey.RESPONSE_STATUS, "failed")
-        self._captured_block_number = None
         value_types = list(self.values.keys())
         for value_type in value_types:
             self.update_metric_value(0, value_type)

--- a/common/base_metric.py
+++ b/common/base_metric.py
@@ -107,6 +107,7 @@ class BaseMetric(ABC):
     def mark_failure(self) -> None:
         """Sets failure status and zeros all existing metric types."""
         self.labels.update_label(MetricLabelKey.RESPONSE_STATUS, "failed")
+        self._captured_block_number = None
         value_types = list(self.values.keys())
         for value_type in value_types:
             self.update_metric_value(0, value_type)

--- a/common/base_metric.py
+++ b/common/base_metric.py
@@ -43,6 +43,7 @@ class BaseMetric(ABC):
         self.ws_endpoint: str | None = ws_endpoint
         self.http_endpoint: str | None = http_endpoint
         self.values: dict[str, MetricValue] = {}
+        self._captured_block_number: Optional[int] = None
         handler._instances.append(self)
 
     @abstractmethod

--- a/common/base_metric.py
+++ b/common/base_metric.py
@@ -25,7 +25,7 @@ class MetricValue:
 
 
 class BaseMetric(ABC):
-    """Base class for collecting and formatting metrics in single-invocation environments."""
+    """Base class for metric collection in single-invocation environments."""
 
     def __init__(
         self,
@@ -36,6 +36,7 @@ class BaseMetric(ABC):
         ws_endpoint: Optional[str] = None,
         http_endpoint: Optional[str] = None,
     ) -> None:
+        """Initialise metric with handler, name, labels, config, and endpoints."""
         self.metric_id = str(uuid.uuid4())
         self.metric_name: str = metric_name
         self.labels: MetricLabels = labels
@@ -118,7 +119,8 @@ class BaseMetric(ABC):
             status_code: int = error.status
             if status_code in MetricsServiceConfig.IGNORED_HTTP_ERRORS:
                 logging.warning(
-                    f"Ignoring HTTP error [{status_code}] for {self.labels.get_prometheus_labels()}"
+                    f"Ignoring HTTP error [{status_code}] for "
+                    f"{self.labels.get_prometheus_labels()}"
                 )
                 return  # Skip metric submission for ignored errors
 
@@ -126,7 +128,8 @@ class BaseMetric(ABC):
             status_code = error.status_code
             if status_code in MetricsServiceConfig.IGNORED_HTTP_ERRORS:
                 logging.warning(
-                    f"Ignoring WebSocket connection error [{status_code}] for {self.labels.get_prometheus_labels()}"
+                    f"Ignoring WebSocket connection error [{status_code}] for "
+                    f"{self.labels.get_prometheus_labels()}"
                 )
                 return  # Skip metric submission for ignored errors
 
@@ -137,6 +140,7 @@ class BaseMetric(ABC):
         error_details = getattr(error, "error_msg", str(error))
 
         logging.error(
-            f"Metric error [{error_type}] {self.labels.get_prometheus_labels()}: {error_details}",
+            f"Metric error [{error_type}] {self.labels.get_prometheus_labels()}: "
+            f"{error_details}",
             exc_info=True,
         )

--- a/common/factory.py
+++ b/common/factory.py
@@ -2,6 +2,7 @@
 
 import copy
 from dataclasses import dataclass
+from typing import ClassVar
 
 from common.base_metric import BaseMetric
 from common.metric_config import EndpointConfig, MetricConfig, MetricLabels
@@ -18,12 +19,12 @@ class MetricRegistration:
 class MetricFactory:
     """Creates metric instances for blockchains.
 
-    For SolanaLandingMetric, a special logic is applied where both the default http endpoint
-    and an enhanced transaction endpoint (if available) are used to create separate metric
-    instances, allowing for differentiated provider names and richer data collection.
+    For SolanaLandingMetric, both the default HTTP endpoint and an optional
+    TX endpoint are used to create separate metric instances with distinct
+    provider names for richer data collection.
     """
 
-    _registry: dict[str, list[MetricRegistration]] = {}
+    _registry: ClassVar[dict[str, list[MetricRegistration]]] = {}
 
     @classmethod
     def register(
@@ -56,7 +57,8 @@ class MetricFactory:
         if blockchain_name not in cls._registry:
             available = list(cls._registry.keys())
             raise ValueError(
-                f"No metric classes registered for blockchain '{blockchain_name}'. Available blockchains: {available}"
+                f"No metric classes registered for blockchain "
+                f"'{blockchain_name}'. Available blockchains: {available}"
             )
 
         cls._setup_endpoint_config(config, kwargs)

--- a/common/metric_config.py
+++ b/common/metric_config.py
@@ -25,6 +25,7 @@ class EndpointConfig:
         tx_endpoint: Optional[str] = None,
         ws_endpoint: Optional[str] = None,
     ) -> None:
+        """Initialise endpoint config with optional HTTP, TX, and WebSocket URLs."""
         self.main_endpoint: str | None = main_endpoint
         self.tx_endpoint: str | None = tx_endpoint
         self.ws_endpoint: str | None = ws_endpoint
@@ -44,6 +45,7 @@ class MetricConfig:
         extra_params: Optional[dict[str, Any]] = None,
         endpoints: Optional[EndpointConfig] = None,
     ) -> None:
+        """Initialise metric config with timeout, latency cap, params, and endpoints."""
         self.timeout: int = timeout
         self.max_latency: int = max_latency
         self.endpoints: EndpointConfig = endpoints or EndpointConfig()
@@ -54,6 +56,7 @@ class MetricLabel:
     """Single metric label container."""
 
     def __init__(self, key: MetricLabelKey, value: str) -> None:
+        """Initialise label, raising ValueError if key is not a MetricLabelKey."""
         if not isinstance(key, MetricLabelKey):
             raise ValueError(
                 f"Invalid key, must be an instance of MetricLabelKey Enum: {key}"
@@ -74,6 +77,7 @@ class MetricLabels:
         api_method: str = "default",
         response_status: str = "pending",
     ) -> None:
+        """Initialise the standard set of metric labels for a provider endpoint."""
         self.labels: list[MetricLabel] = [
             MetricLabel(MetricLabelKey.SOURCE_REGION, source_region),
             MetricLabel(MetricLabelKey.TARGET_REGION, target_region),

--- a/common/metric_types.py
+++ b/common/metric_types.py
@@ -1,6 +1,7 @@
 """Base classes for WebSocket and HTTP metric collection."""
 
 import asyncio
+import contextlib
 import logging
 import time
 from abc import abstractmethod
@@ -319,7 +320,6 @@ class HttpCallLatencyMetricBase(HttpMetric):
         Override in subclasses to capture response fields (e.g. block number).
         The default implementation does nothing.
         """
-        pass
 
     def process_data(self, value: float) -> float:
         """Process raw latency measurement."""
@@ -343,9 +343,8 @@ class EVMBlockNumberLatencyMetric(HttpCallLatencyMetricBase):
         return []
 
     def _on_json_response(self, json_response: dict[str, Any]) -> None:
+        """Parse hex block number from eth_blockNumber response."""
         result = json_response.get("result")
         if isinstance(result, str):
-            try:
+            with contextlib.suppress(ValueError):
                 self._captured_block_number = int(result, 16)
-            except ValueError:
-                pass

--- a/common/metric_types.py
+++ b/common/metric_types.py
@@ -264,6 +264,8 @@ class HttpCallLatencyMetricBase(HttpMetric):
                 if "error" in json_response:
                     raise ValueError(f"JSON-RPC error: {json_response['error']}")
 
+                self._on_json_response(json_response)
+
                 # Return RPC time only (exclude connection time)
                 rpc_time = response_time - conn_time
                 if rpc_time < 0:
@@ -288,6 +290,38 @@ class HttpCallLatencyMetricBase(HttpMetric):
             json=self._base_request,
         )
 
+    def _on_json_response(self, json_response: dict[str, Any]) -> None:
+        """Hook called after a successful JSON-RPC response.
+
+        Override in subclasses to capture response fields (e.g. block number).
+        The default implementation does nothing.
+        """
+        pass
+
     def process_data(self, value: float) -> float:
         """Process raw latency measurement."""
         return value
+
+
+class EVMBlockNumberLatencyMetric(HttpCallLatencyMetricBase):
+    """Shared eth_blockNumber metric used by all EVM chains.
+
+    Captures the returned block number for cross-provider lag computation.
+    """
+
+    @property
+    def method(self) -> str:
+        return "eth_blockNumber"
+
+    @staticmethod
+    def get_params_from_state(state_data: dict[str, Any]) -> list[Any]:
+        """Return empty params list for eth_blockNumber."""
+        return []
+
+    def _on_json_response(self, json_response: dict[str, Any]) -> None:
+        result = json_response.get("result")
+        if isinstance(result, str):
+            try:
+                self._captured_block_number = int(result, 16)
+            except ValueError:
+                pass

--- a/common/metric_types.py
+++ b/common/metric_types.py
@@ -248,7 +248,7 @@ class HttpCallLatencyMetricBase(HttpMetric):
                 )
             return rpc_time
         finally:
-            await response.release()
+            response.release()
 
     async def fetch_data(self) -> float:
         """Measure single request latency with detailed timing."""
@@ -284,7 +284,7 @@ class HttpCallLatencyMetricBase(HttpMetric):
 
                 if response.status == 429 and retry_count < MAX_RETRIES - 1:
                     wait_time = int(response.headers.get("Retry-After", 3))
-                    await response.release()
+                    response.release()
                     await asyncio.sleep(wait_time)
                     continue
 

--- a/common/metric_types.py
+++ b/common/metric_types.py
@@ -28,24 +28,27 @@ class WebSocketMetric(BaseMetric):
         ws_endpoint: Optional[str] = None,
         http_endpoint: Optional[str] = None,
     ) -> None:
+        """Initialise WebSocket metric and set up subscription ID tracking."""
         super().__init__(
             handler, metric_name, labels, config, ws_endpoint, http_endpoint
         )
         self.subscription_id: Optional[int] = None
 
     @abstractmethod
-    async def subscribe(self, websocket: Any) -> None:
+    async def subscribe(self, websocket: websockets.WebSocketClientProtocol) -> None:
         """Sets up WebSocket subscription."""
 
     @abstractmethod
-    async def unsubscribe(self, websocket: Any) -> None:
+    async def unsubscribe(self, websocket: websockets.WebSocketClientProtocol) -> None:
         """Cleans up WebSocket subscription."""
 
     @abstractmethod
-    async def listen_for_data(self, websocket: Any) -> Optional[Any]:
+    async def listen_for_data(
+        self, websocket: websockets.WebSocketClientProtocol
+    ) -> Optional[dict[str, Any]]:
         """Receives WebSocket data."""
 
-    async def connect(self) -> Any:
+    async def connect(self) -> websockets.WebSocketClientProtocol:
         """Creates WebSocket connection."""
         websocket: websockets.WebSocketClientProtocol = await websockets.connect(
             self.ws_endpoint,  # type: ignore
@@ -59,7 +62,7 @@ class WebSocketMetric(BaseMetric):
         """Collects single WebSocket message."""
         websocket = None
 
-        async def _collect_ws_data():
+        async def _collect_ws_data() -> Any:
             nonlocal websocket
             websocket = await self.connect()
             await self.subscribe(websocket)
@@ -81,7 +84,8 @@ class WebSocketMetric(BaseMetric):
             self.mark_failure()
             self.handle_error(
                 TimeoutError(
-                    f"WebSocket metric collection exceeded {self.config.timeout}s timeout"
+                    f"WebSocket metric collection exceeded "
+                    f"{self.config.timeout}s timeout"
                 )
             )
 
@@ -112,7 +116,7 @@ class HttpMetric(BaseMetric):
     """HTTP metric for API data collection."""
 
     @abstractmethod
-    async def fetch_data(self) -> Optional[Any]:
+    async def fetch_data(self) -> Optional[float]:
         """Fetches HTTP endpoint data."""
 
     def get_endpoint(self) -> str:
@@ -120,6 +124,7 @@ class HttpMetric(BaseMetric):
         return str(self.config.endpoints.get_endpoint())
 
     async def collect_metric(self) -> None:
+        """Collect a single HTTP metric, applying timeout and error handling."""
         try:
             data = await asyncio.wait_for(
                 self.fetch_data(), timeout=self.config.timeout
@@ -164,6 +169,7 @@ class HttpCallLatencyMetricBase(HttpMetric):
         method_params: Optional[Union[dict[str, Any], list[Any]]] = None,
         **kwargs: Any,
     ) -> None:
+        """Initialise metric, validate state, and build the base JSON-RPC request."""
         state_data = kwargs.get("state_data", {})
         if not self.validate_state(state_data):
             raise ValueError(f"Invalid state data for {self.method}")
@@ -206,18 +212,59 @@ class HttpCallLatencyMetricBase(HttpMetric):
         """Get RPC method parameters from state data."""
         return {}
 
+    async def _process_response(
+        self,
+        response: aiohttp.ClientResponse,
+        response_time: float,
+        conn_time: float,
+    ) -> float:
+        """Validate response and return RPC time excluding connection overhead."""
+        try:
+            if response.status != 200:
+                raise aiohttp.ClientResponseError(
+                    request_info=response.request_info,
+                    history=(),
+                    status=response.status,
+                    message=f"Status code: {response.status}",
+                    headers=response.headers,
+                )
+
+            json_response = await response.json()
+            if "error" in json_response:
+                raise ValueError(f"JSON-RPC error: {json_response['error']}")
+
+            try:
+                self._on_json_response(json_response)
+            except Exception:
+                logging.debug(f"Block capture failed for {self.method}", exc_info=True)
+                self._captured_block_number = None
+
+            rpc_time = response_time - conn_time
+            if rpc_time < 0:
+                raise ValueError(
+                    f"Negative RPC time: {rpc_time:.6f}s "
+                    f"(response={response_time:.6f}s, conn={conn_time:.6f}s)"
+                )
+            return rpc_time
+        finally:
+            await response.release()
+
     async def fetch_data(self) -> float:
         """Measure single request latency with detailed timing."""
         endpoint: str | None = self.config.endpoints.get_endpoint()
 
         # Add trace config for detailed timing
         trace_config = aiohttp.TraceConfig()
-        timing = {}
+        timing: dict[str, float] = {}
 
-        async def on_connection_create_start(session, context, params) -> None:
+        async def on_connection_create_start(
+            session: Any, context: Any, params: Any
+        ) -> None:
             timing["conn_start"] = time.monotonic()
 
-        async def on_connection_create_end(session, context, params) -> None:
+        async def on_connection_create_end(
+            session: Any, context: Any, params: Any
+        ) -> None:
             timing["conn_end"] = time.monotonic()
 
         trace_config.on_connection_create_start.append(on_connection_create_start)
@@ -231,10 +278,8 @@ class HttpCallLatencyMetricBase(HttpMetric):
 
             for retry_count in range(MAX_RETRIES):
                 start_time: float = time.monotonic()
-                response: aiohttp.ClientResponse = await self._send_request(
-                    session, endpoint
-                )
-                response_time: float = time.monotonic() - start_time
+                response = await self._send_request(session, endpoint)
+                response_time = time.monotonic() - start_time
 
                 if response.status == 429 and retry_count < MAX_RETRIES - 1:
                     wait_time = int(response.headers.get("Retry-After", 3))
@@ -244,46 +289,16 @@ class HttpCallLatencyMetricBase(HttpMetric):
 
                 break
 
-            if "conn_start" in timing and "conn_end" in timing:
-                conn_time = timing["conn_end"] - timing["conn_start"]
-            else:
-                conn_time = 0
+            conn_time = (
+                timing["conn_end"] - timing["conn_start"]
+                if "conn_start" in timing and "conn_end" in timing
+                else 0
+            )
 
             if not response:
                 raise ValueError("No response received")
 
-            try:
-                if response.status != 200:
-                    raise aiohttp.ClientResponseError(
-                        request_info=response.request_info,
-                        history=(),
-                        status=response.status,
-                        message=f"Status code: {response.status}",
-                        headers=response.headers,
-                    )
-
-                json_response = await response.json()
-                if "error" in json_response:
-                    raise ValueError(f"JSON-RPC error: {json_response['error']}")
-
-                try:
-                    self._on_json_response(json_response)
-                except Exception:
-                    logging.debug(
-                        f"Block capture failed for {self.method}", exc_info=True
-                    )
-                    self._captured_block_number = None
-
-                # Return RPC time only (exclude connection time)
-                rpc_time = response_time - conn_time
-                if rpc_time < 0:
-                    raise ValueError(
-                        f"Negative RPC time: {rpc_time:.6f}s "
-                        f"(response={response_time:.6f}s, conn={conn_time:.6f}s)"
-                    )
-                return rpc_time
-            finally:
-                await response.release()
+            return await self._process_response(response, response_time, conn_time)
 
     async def _send_request(
         self, session: aiohttp.ClientSession, endpoint: str
@@ -319,6 +334,7 @@ class EVMBlockNumberLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the eth_blockNumber RPC method name."""
         return "eth_blockNumber"
 
     @staticmethod

--- a/common/metric_types.py
+++ b/common/metric_types.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import time
 from abc import abstractmethod
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 import aiohttp
 import websockets
@@ -161,7 +161,7 @@ class HttpCallLatencyMetricBase(HttpMetric):
         metric_name: str,
         labels: MetricLabels,
         config: MetricConfig,
-        method_params: Optional[dict[str, Any]] = None,
+        method_params: Optional[Union[dict[str, Any], list[Any]]] = None,
         **kwargs: Any,
     ) -> None:
         state_data = kwargs.get("state_data", {})
@@ -175,7 +175,7 @@ class HttpCallLatencyMetricBase(HttpMetric):
             config=config,
         )
 
-        self.method_params: dict[str, Any] = (
+        self.method_params: Union[dict[str, Any], list[Any]] = (
             self.get_params_from_state(state_data)
             if method_params is None
             else method_params
@@ -200,7 +200,9 @@ class HttpCallLatencyMetricBase(HttpMetric):
         return True
 
     @staticmethod
-    def get_params_from_state(state_data: dict[str, Any]) -> dict[str, Any]:
+    def get_params_from_state(
+        state_data: dict[str, Any],
+    ) -> Union[dict[str, Any], list[Any]]:
         """Get RPC method parameters from state data."""
         return {}
 
@@ -264,7 +266,13 @@ class HttpCallLatencyMetricBase(HttpMetric):
                 if "error" in json_response:
                     raise ValueError(f"JSON-RPC error: {json_response['error']}")
 
-                self._on_json_response(json_response)
+                try:
+                    self._on_json_response(json_response)
+                except Exception:
+                    logging.debug(
+                        f"Block capture failed for {self.method}", exc_info=True
+                    )
+                    self._captured_block_number = None
 
                 # Return RPC time only (exclude connection time)
                 rpc_time = response_time - conn_time
@@ -315,7 +323,7 @@ class EVMBlockNumberLatencyMetric(HttpCallLatencyMetricBase):
 
     @staticmethod
     def get_params_from_state(state_data: dict[str, Any]) -> list[Any]:
-        """Return empty params list for eth_blockNumber."""
+        """Return empty params list for eth_blockNumber (JSON-RPC positional params)."""
         return []
 
     def _on_json_response(self, json_response: dict[str, Any]) -> None:

--- a/common/metric_types.py
+++ b/common/metric_types.py
@@ -189,6 +189,12 @@ class HttpCallLatencyMetricBase(HttpMetric):
         )
         self.labels.update_label(MetricLabelKey.API_METHOD, self.method)
         self._base_request = self._build_base_request()
+        self._captured_block_number: Optional[int] = None
+
+    def mark_failure(self) -> None:
+        """Mark metric as failed and clear any captured block number."""
+        super().mark_failure()
+        self._captured_block_number = None
 
     def _build_base_request(self) -> dict[str, Any]:
         """Build the base JSON-RPC request object."""
@@ -237,7 +243,9 @@ class HttpCallLatencyMetricBase(HttpMetric):
             try:
                 self._on_json_response(json_response)
             except Exception:
-                logging.debug(f"Block capture failed for {self.method}", exc_info=True)
+                logging.warning(
+                    f"Block capture failed for {self.method}", exc_info=True
+                )
                 self._captured_block_number = None
 
             rpc_time = response_time - conn_time

--- a/common/metrics_handler.py
+++ b/common/metrics_handler.py
@@ -43,16 +43,16 @@ class MetricsHandler:
 
         Stores the block number as metric_type="block_number" so Grafana can
         compute relative lag at query time using max(block_number) - provider_value.
-        Instances without a captured block number are skipped.
+        Only HTTP JSON-RPC metrics (HttpCallLatencyMetricBase subclasses) carry
+        the _captured_block_number attribute; others are skipped via getattr.
 
         Returns:
             None
         """
         for instance in self._instances:
-            if instance._captured_block_number is not None:
-                instance.update_metric_value(
-                    instance._captured_block_number, "block_number"
-                )
+            block_number = getattr(instance, "_captured_block_number", None)
+            if block_number is not None:
+                instance.update_metric_value(block_number, "block_number")
 
     def get_metrics_influx_format(self) -> list[str]:
         """Returns all metric values in Influx format."""

--- a/common/metrics_handler.py
+++ b/common/metrics_handler.py
@@ -11,7 +11,7 @@ import aiohttp
 
 from common.base_metric import BaseMetric
 from common.factory import MetricFactory
-from common.metric_config import MetricConfig
+from common.metric_config import MetricConfig, MetricLabelKey
 from common.state.blockchain_state import BlockchainState
 from config.defaults import MetricsServiceConfig
 
@@ -36,6 +36,35 @@ class MetricsHandler:
             "metric_request_timeout": MetricsServiceConfig.METRIC_REQUEST_TIMEOUT,
             "metric_max_latency": MetricsServiceConfig.METRIC_MAX_LATENCY,
         }
+
+    def _compute_block_lag(self) -> None:
+        """Compute relative block lag across providers and attach to each instance.
+
+        Groups instances by blockchain, finds the consensus tip (max block number),
+        and stores (tip - provider_block) as a "block_lag" metric value on each instance.
+        Instances that did not successfully capture a block number are skipped.
+        """
+        groups: dict[str, list[BaseMetric]] = {}
+        for instance in self._instances:
+            if instance._captured_block_number is not None:
+                blockchain = instance.labels.get_label(MetricLabelKey.BLOCKCHAIN) or ""
+                if blockchain not in groups:
+                    groups[blockchain] = []
+                groups[blockchain].append(instance)
+
+        for instances in groups.values():
+            block_numbers: list[int] = [
+                i._captured_block_number
+                for i in instances
+                if i._captured_block_number is not None
+            ]
+            if not block_numbers:
+                continue
+            tip = max(block_numbers)
+            for instance in instances:
+                if instance._captured_block_number is not None:
+                    lag = tip - instance._captured_block_number
+                    instance.update_metric_value(lag, "block_lag")
 
     def get_metrics_influx_format(self) -> list[str]:
         """Returns all metric values in Influx format."""
@@ -124,6 +153,8 @@ class MetricsHandler:
                 for provider in rpc_providers
             ]
             await asyncio.gather(*collection_tasks, return_exceptions=True)
+
+            self._compute_block_lag()
 
             metrics_text: str = self.get_metrics_text()
             if metrics_text:

--- a/common/metrics_handler.py
+++ b/common/metrics_handler.py
@@ -11,7 +11,7 @@ import aiohttp
 
 from common.base_metric import BaseMetric
 from common.factory import MetricFactory
-from common.metric_config import MetricConfig, MetricLabelKey
+from common.metric_config import MetricConfig
 from common.state.blockchain_state import BlockchainState
 from config.defaults import MetricsServiceConfig
 
@@ -37,34 +37,18 @@ class MetricsHandler:
             "metric_max_latency": MetricsServiceConfig.METRIC_MAX_LATENCY,
         }
 
-    def _compute_block_lag(self) -> None:
-        """Compute relative block lag across providers and attach to each instance.
+    def _emit_block_numbers(self) -> None:
+        """Emit raw block numbers for each instance that captured one.
 
-        Groups instances by blockchain, finds the consensus tip (max block number),
-        and stores (tip - provider_block) as a "block_lag" metric value on each instance.
+        Stores the block number as metric_type="block_number" so Grafana can
+        compute relative lag across providers at query time (max - provider_value).
         Instances that did not successfully capture a block number are skipped.
         """
-        groups: dict[str, list[BaseMetric]] = {}
         for instance in self._instances:
             if instance._captured_block_number is not None:
-                blockchain = instance.labels.get_label(MetricLabelKey.BLOCKCHAIN) or ""
-                if blockchain not in groups:
-                    groups[blockchain] = []
-                groups[blockchain].append(instance)
-
-        for instances in groups.values():
-            block_numbers: list[int] = [
-                i._captured_block_number
-                for i in instances
-                if i._captured_block_number is not None
-            ]
-            if not block_numbers:
-                continue
-            tip = max(block_numbers)
-            for instance in instances:
-                if instance._captured_block_number is not None:
-                    lag = tip - instance._captured_block_number
-                    instance.update_metric_value(lag, "block_lag")
+                instance.update_metric_value(
+                    instance._captured_block_number, "block_number"
+                )
 
     def get_metrics_influx_format(self) -> list[str]:
         """Returns all metric values in Influx format."""
@@ -154,7 +138,7 @@ class MetricsHandler:
             ]
             await asyncio.gather(*collection_tasks, return_exceptions=True)
 
-            self._compute_block_lag()
+            self._emit_block_numbers()
 
             metrics_text: str = self.get_metrics_text()
             if metrics_text:

--- a/common/metrics_handler.py
+++ b/common/metrics_handler.py
@@ -20,6 +20,7 @@ class MetricsHandler:
     """Manages collection and pushing of blockchain metrics."""
 
     def __init__(self, blockchain: str, metrics: list[tuple[type, str]]) -> None:
+        """Initialise handler with blockchain name and metric class list."""
         self._instances: list[BaseMetric] = []
         self.blockchain: str = blockchain
         self.metrics: list[tuple[type, str]] = metrics
@@ -59,6 +60,7 @@ class MetricsHandler:
         return metrics
 
     def get_metrics_text(self) -> str:
+        """Returns all metrics as a newline-joined Influx line protocol string."""
         current_time = int(time.time_ns())
         metrics: list[str] = self.get_metrics_influx_format()
         return "\n".join(f"{metric} {current_time}" for metric in metrics)
@@ -66,6 +68,7 @@ class MetricsHandler:
     async def collect_metrics(
         self, provider: dict, config: dict, state_data: dict
     ) -> None:
+        """Create and run all metric instances for a single provider."""
         metric_config = MetricConfig(
             timeout=self.grafana_config["metric_request_timeout"],
             max_latency=self.grafana_config["metric_max_latency"],
@@ -89,6 +92,7 @@ class MetricsHandler:
         await asyncio.gather(*(m.collect_metric() for m in metrics))
 
     async def push_to_grafana(self, metrics_text: str) -> None:
+        """Push metrics text to Grafana via HTTP with retry logic."""
         if not all(
             [
                 self.grafana_config["url"],
@@ -159,6 +163,7 @@ class BaseVercelHandler(BaseHTTPRequestHandler):
     metrics_handler: MetricsHandler = None  # type: ignore
 
     def validate_token(self) -> bool:
+        """Return True if the Authorization header matches the CRON_SECRET."""
         auth_token: str | None = self.headers.get("Authorization")
         expected_token: str | None = os.environ.get(
             "CRON_SECRET"
@@ -166,6 +171,7 @@ class BaseVercelHandler(BaseHTTPRequestHandler):
         return auth_token == f"Bearer {expected_token}"
 
     def do_GET(self) -> None:
+        """Handle GET request: authenticate, run metrics, respond with results."""
         skip_auth: bool = os.environ.get("SKIP_AUTH", "false").lower() == "true"
         if not skip_auth and not self.validate_token():
             self.send_response(401)

--- a/common/metrics_handler.py
+++ b/common/metrics_handler.py
@@ -42,8 +42,11 @@ class MetricsHandler:
         """Emit raw block numbers for each instance that captured one.
 
         Stores the block number as metric_type="block_number" so Grafana can
-        compute relative lag across providers at query time (max - provider_value).
-        Instances that did not successfully capture a block number are skipped.
+        compute relative lag at query time using max(block_number) - provider_value.
+        Instances without a captured block number are skipped.
+
+        Returns:
+            None
         """
         for instance in self._instances:
             if instance._captured_block_number is not None:

--- a/common/state/__init__.py
+++ b/common/state/__init__.py
@@ -1,0 +1,1 @@
+"""Blockchain state retrieval and blob storage helpers."""

--- a/common/state/blob_storage.py
+++ b/common/state/blob_storage.py
@@ -12,6 +12,8 @@ from config.defaults import BlobStorageConfig
 
 @dataclass
 class BlobConfig:
+    """Configuration for Vercel Blob Storage access."""
+
     store_id: str
     token: str
     base_url: str = BlobStorageConfig.BLOB_BASE_URL
@@ -22,7 +24,10 @@ class BlobConfig:
 
 
 class BlobStorageHandler:
+    """Handles read and write operations against Vercel Blob Storage."""
+
     def __init__(self, config: BlobConfig) -> None:
+        """Initialise handler with blob storage config and set auth headers."""
         self.config: BlobConfig = config
         self._headers: dict[str, str] = {
             "Authorization": f"Bearer {config.token}",
@@ -50,23 +55,27 @@ class BlobStorageHandler:
                 return await resp.json()
 
     async def list_files(self) -> list[dict[str, str]]:
+        """Return all blobs in the configured folder."""
         list_url: str = f"{self.config.base_url}?prefix={self.config.folder}/"
         response = await self._make_request("GET", list_url)
         return response.get("blobs", [])
 
     async def delete_blobs(self, urls: list[str]) -> None:
+        """Delete blobs at the given URLs."""
         if not urls:
             return
         delete_url = f"{self.config.base_url}/delete"
         await self._make_request("POST", delete_url, {"urls": urls})
 
     async def delete_all_files(self) -> None:
+        """Delete all blobs in the configured folder."""
         files: list[dict[str, str]] = await self.list_files()
         if files:
             urls: list[str] = [file["url"] for file in files]
             await self.delete_blobs(urls)
 
     async def update_data(self, blockchain_data: dict[str, dict[str, str]]) -> None:
+        """Replace all blobs with a fresh snapshot of blockchain_data."""
         await self.delete_all_files()
         data = {**blockchain_data, "updated_at": int(time.time())}
         blob_url: str = (

--- a/common/state/blockchain_fetcher.py
+++ b/common/state/blockchain_fetcher.py
@@ -127,7 +127,9 @@ class BlockchainDataFetcher:
             tx_hash = (
                 transactions[0].get("hash", "")
                 if isinstance(transactions[0], dict)
-                else transactions[0] if transactions else ""
+                else transactions[0]
+                if transactions
+                else ""
             )
 
             return BlockchainData(

--- a/common/state/blockchain_fetcher.py
+++ b/common/state/blockchain_fetcher.py
@@ -128,7 +128,7 @@ class BlockchainDataFetcher:
             transactions = latest_block.get("transactions", [])
             tx_hash = (
                 transactions[0].get("hash", "")
-                if isinstance(transactions[0], dict)
+                if transactions and isinstance(transactions[0], dict)
                 else transactions[0]
                 if transactions
                 else ""

--- a/common/state/blockchain_fetcher.py
+++ b/common/state/blockchain_fetcher.py
@@ -21,6 +21,7 @@ class BlockchainData:
 
     @classmethod
     def empty(cls) -> "BlockchainData":
+        """Return a BlockchainData instance with all fields set to empty strings."""
         return cls(block_id="", transaction_id="", old_block_id="")
 
 
@@ -28,6 +29,7 @@ class BlockchainDataFetcher:
     """Fetches blockchain data from RPC nodes using JSON-RPC protocol."""
 
     def __init__(self, http_endpoint: str) -> None:
+        """Initialise fetcher with the HTTP endpoint URL and retry settings."""
         self.http_endpoint: str = http_endpoint
         self._headers: dict[str, str] = {"Content-Type": "application/json"}
         self._timeout = aiohttp.ClientTimeout(total=15)

--- a/common/state/blockchain_fetcher.py
+++ b/common/state/blockchain_fetcher.py
@@ -127,9 +127,7 @@ class BlockchainDataFetcher:
             tx_hash = (
                 transactions[0].get("hash", "")
                 if isinstance(transactions[0], dict)
-                else transactions[0]
-                if transactions
-                else ""
+                else transactions[0] if transactions else ""
             )
 
             return BlockchainData(

--- a/config/defaults.py
+++ b/config/defaults.py
@@ -1,12 +1,13 @@
 """Default configuration."""
 
 import os
+from typing import ClassVar
 
 
 class MetricsServiceConfig:
     """Default configuration for metrics collection and processing."""
 
-    IGNORED_HTTP_ERRORS = [
+    IGNORED_HTTP_ERRORS: ClassVar[list[int]] = [
         403,  # Forbidden - usually related to plan restrictions
         429,  # Too Many Requests - rate limit exceeded
         401,  # Unauthorized - if authentication failure is plan-related
@@ -32,7 +33,7 @@ class MetricsServiceConfig:
     )  # System env var, standard name
 
     # Block offset configuration (N blocks back from latest)
-    BLOCK_OFFSET_RANGES = {  # noqa: RUF012
+    BLOCK_OFFSET_RANGES: ClassVar[dict[str, tuple[int, int]]] = {
         "ethereum": (7200, 10000),
         "base": (7200, 10000),
         "solana": (432000, 648000),

--- a/dashboards/grafana_sync.py
+++ b/dashboards/grafana_sync.py
@@ -51,7 +51,10 @@ def compute_checksum(data: dict) -> str:
 
 
 def _headers(cfg: dict) -> dict:
-    return {"Authorization": f"Bearer {cfg['token']}", "Content-Type": "application/json"}
+    return {
+        "Authorization": f"Bearer {cfg['token']}",
+        "Content-Type": "application/json",
+    }
 
 
 def api_get(cfg: dict, path: str) -> dict | list:
@@ -84,6 +87,7 @@ def make_slug(title: str, uid: str, existing: set) -> str:
     if slug in existing:
         slug = f"{slug}-{uid}"
     return slug
+
 
 def cmd_pull(cfg: dict) -> None:
     folder_uid = resolve_folder_uid(cfg)
@@ -143,11 +147,15 @@ def compute_diff(state: dict, remote_meta: dict) -> tuple[list, list]:
         if current_checksum == entry["checksum"]:
             continue
 
-        remote_updated = remote_meta.get(uid, {}).get("updated", entry["remote_updated"])
+        remote_updated = remote_meta.get(uid, {}).get(
+            "updated", entry["remote_updated"]
+        )
         if remote_updated != entry["remote_updated"]:
             conflicts.append({"uid": uid, "slug": slug, "entry": entry})
         else:
-            changed.append({"uid": uid, "slug": slug, "entry": entry, "data": current_data})
+            changed.append(
+                {"uid": uid, "slug": slug, "entry": entry, "data": current_data}
+            )
 
     return changed, conflicts
 
@@ -170,7 +178,9 @@ def cmd_push(cfg: dict, message: str = "") -> None:
     changed, conflicts = compute_diff(state, remote_meta)
 
     for item in conflicts:
-        print(f"[WARN]  {item['slug']} → conflict: remote changed since last pull, skipping")
+        print(
+            f"[WARN]  {item['slug']} → conflict: remote changed since last pull, skipping"
+        )
 
     for item in changed:
         uid = item["uid"]

--- a/dashboards/grafana_sync.py
+++ b/dashboards/grafana_sync.py
@@ -5,13 +5,15 @@
 #   "python-dotenv",
 # ]
 # ///
+"""CLI tool to pull, push, and diff Grafana dashboards via the Grafana HTTP API."""
 
-import sys
-import os
-import re
 import hashlib
 import json
+import os
+import re
+import sys
 from pathlib import Path
+
 import requests
 from dotenv import load_dotenv
 
@@ -22,6 +24,7 @@ STATE_FILE = ".grafana_state.json"
 
 
 def load_config() -> dict:
+    """Load and validate required Grafana config from environment variables."""
     missing = [v for v in REQUIRED_VARS if not os.getenv(v)]
     if missing:
         for v in missing:
@@ -35,6 +38,7 @@ def load_config() -> dict:
 
 
 def load_state() -> dict:
+    """Load local state from the state file, returning empty dict if absent."""
     p = Path(STATE_FILE)
     if not p.exists():
         return {}
@@ -42,10 +46,12 @@ def load_state() -> dict:
 
 
 def save_state(state: dict) -> None:
+    """Persist state dict to the state file as formatted JSON."""
     Path(STATE_FILE).write_text(json.dumps(state, indent=2))
 
 
 def compute_checksum(data: dict) -> str:
+    """Return a deterministic SHA-256 hex digest of the JSON-serialised data."""
     serialized = json.dumps(data, sort_keys=True, ensure_ascii=False)
     return hashlib.sha256(serialized.encode()).hexdigest()
 
@@ -58,6 +64,7 @@ def _headers(cfg: dict) -> dict:
 
 
 def api_get(cfg: dict, path: str) -> dict | list:
+    """Perform a GET request against the Grafana API, raising on non-200."""
     resp = requests.get(f"{cfg['url']}{path}", headers=_headers(cfg))
     if resp.status_code != 200:
         print(f"[ERROR] GET {path} → {resp.status_code}: {resp.text}")
@@ -66,6 +73,7 @@ def api_get(cfg: dict, path: str) -> dict | list:
 
 
 def api_post(cfg: dict, path: str, payload: dict) -> dict:
+    """Perform a POST request against the Grafana API, raising on non-200/201."""
     resp = requests.post(f"{cfg['url']}{path}", headers=_headers(cfg), json=payload)
     if resp.status_code not in (200, 201):
         print(f"[ERROR] POST {path} → {resp.status_code}: {resp.text}")
@@ -74,6 +82,7 @@ def api_post(cfg: dict, path: str, payload: dict) -> dict:
 
 
 def resolve_folder_uid(cfg: dict) -> str:
+    """Return the Grafana folder UID for the configured folder name, or exit."""
     results = api_get(cfg, "/api/search?type=dash-db&limit=200")
     for d in results:
         if d.get("folderTitle") == cfg["folder"]:
@@ -83,6 +92,7 @@ def resolve_folder_uid(cfg: dict) -> str:
 
 
 def make_slug(title: str, uid: str, existing: set) -> str:
+    """Generate a URL-safe slug from title, appending uid if already taken."""
     slug = re.sub(r"[^a-z0-9]+", "-", title.lower()).strip("-")
     if slug in existing:
         slug = f"{slug}-{uid}"
@@ -90,6 +100,7 @@ def make_slug(title: str, uid: str, existing: set) -> str:
 
 
 def cmd_pull(cfg: dict) -> None:
+    """Pull all dashboards from Grafana and write them to the local dashboards/ dir."""
     folder_uid = resolve_folder_uid(cfg)
     results = api_get(cfg, f"/api/search?type=dash-db&folderUIDs={folder_uid}")
     Path("dashboards").mkdir(exist_ok=True)
@@ -125,6 +136,7 @@ def cmd_pull(cfg: dict) -> None:
 
 
 def compute_diff(state: dict, remote_meta: dict) -> tuple[list, list]:
+    """Return (changed, conflicts) lists by comparing local files to state/remote."""
     slug_to_uid = {v["slug"]: k for k, v in state.items()}
     changed = []
     conflicts = []
@@ -161,6 +173,7 @@ def compute_diff(state: dict, remote_meta: dict) -> tuple[list, list]:
 
 
 def cmd_push(cfg: dict, message: str = "") -> None:
+    """Push locally changed dashboards to Grafana, skipping conflicts."""
     if not Path(STATE_FILE).exists():
         print("[ERROR] No state file found. Run `pull` first.")
         sys.exit(1)
@@ -179,7 +192,8 @@ def cmd_push(cfg: dict, message: str = "") -> None:
 
     for item in conflicts:
         print(
-            f"[WARN]  {item['slug']} → conflict: remote changed since last pull, skipping"
+            f"[WARN]  {item['slug']} → conflict: remote changed since last pull,"
+            " skipping"
         )
 
     for item in changed:
@@ -205,6 +219,7 @@ def cmd_push(cfg: dict, message: str = "") -> None:
 
 
 def cmd_status(cfg: dict) -> None:
+    """Print a diff of local vs remote dashboards without making any changes."""
     if not Path(STATE_FILE).exists():
         print("[ERROR] No state file found. Run `pull` first.")
         sys.exit(1)
@@ -231,7 +246,8 @@ def cmd_status(cfg: dict) -> None:
         print(f"[conflict] {item['slug']} → remote changed since last pull")
 
 
-def main():
+def main() -> None:
+    """Parse CLI args and dispatch to pull, push, or status command."""
     if len(sys.argv) < 2 or sys.argv[1] not in ("pull", "push", "status"):
         print("Usage: uv run grafana_sync.py <pull|push|status> [-m 'message']")
         sys.exit(1)

--- a/dashboards/pyproject.toml
+++ b/dashboards/pyproject.toml
@@ -1,0 +1,13 @@
+[project]
+name = "grafana-sync"
+version = "0.1.0"
+requires-python = ">=3.9"
+dependencies = [
+    "requests>=2.32.0",
+    "python-dotenv>=1.0.0",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0.0",
+]

--- a/dashboards/tests/__init__.py
+++ b/dashboards/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for Grafana dashboard sync utilities."""

--- a/dashboards/tests/test_grafana_sync.py
+++ b/dashboards/tests/test_grafana_sync.py
@@ -86,9 +86,8 @@ def test_resolve_folder_uid_exits_if_not_found(monkeypatch):
         m,
         "api_get",
         return_value=[{"uid": "d1", "folderTitle": "Other", "folderUid": "abc"}],
-    ):
-        with pytest.raises(SystemExit):
-            m.resolve_folder_uid(m.load_config())
+    ), pytest.raises(SystemExit):
+        m.resolve_folder_uid(m.load_config())
 
 
 STATE_FILE = ".grafana_state.json"

--- a/dashboards/tests/test_grafana_sync.py
+++ b/dashboards/tests/test_grafana_sync.py
@@ -1,7 +1,9 @@
 # Tests for grafana_sync.py
+import json
 import sys
-import pytest
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 
 # Helper to import without running main()
@@ -88,8 +90,6 @@ def test_resolve_folder_uid_exits_if_not_found(monkeypatch):
         with pytest.raises(SystemExit):
             m.resolve_folder_uid(m.load_config())
 
-
-import json
 
 STATE_FILE = ".grafana_state.json"
 
@@ -251,7 +251,7 @@ def test_compute_diff_warns_file_not_in_state(tmp_path, monkeypatch, capsys):
     m = import_module()
     (tmp_path / "dashboards").mkdir()
     (tmp_path / "dashboards" / "unknown.json").write_text("{}")
-    changed, conflicts = m.compute_diff({}, {})
+    m.compute_diff({}, {})
     captured = capsys.readouterr()
     assert "[WARN]" in captured.out
     assert "unknown" in captured.out

--- a/dashboards/tests/test_grafana_sync.py
+++ b/dashboards/tests/test_grafana_sync.py
@@ -3,12 +3,15 @@ import sys
 import pytest
 from unittest.mock import MagicMock, patch
 
+
 # Helper to import without running main()
 def import_module():
     if "grafana_sync" in sys.modules:
         return sys.modules["grafana_sync"]
     import grafana_sync
+
     return grafana_sync
+
 
 def test_load_config_returns_all_vars(monkeypatch):
     monkeypatch.setenv("GRAFANA_URL", "https://test.grafana.net")
@@ -20,6 +23,7 @@ def test_load_config_returns_all_vars(monkeypatch):
     assert cfg["token"] == "token123"
     assert cfg["folder"] == "MyFolder"
 
+
 def test_load_config_exits_on_missing_var(monkeypatch):
     monkeypatch.delenv("GRAFANA_URL", raising=False)
     monkeypatch.delenv("GRAFANA_TOKEN", raising=False)
@@ -27,6 +31,7 @@ def test_load_config_exits_on_missing_var(monkeypatch):
     m = import_module()
     with pytest.raises(SystemExit):
         m.load_config()
+
 
 def test_api_get_returns_json(monkeypatch):
     monkeypatch.setenv("GRAFANA_URL", "https://test.grafana.net")
@@ -39,6 +44,7 @@ def test_api_get_returns_json(monkeypatch):
     with patch("requests.get", return_value=mock_resp):
         result = m.api_get(m.load_config(), "/api/folders")
     assert result == {"key": "value"}
+
 
 def test_api_get_prints_error_on_non_200(monkeypatch, capsys):
     monkeypatch.setenv("GRAFANA_URL", "https://test.grafana.net")
@@ -54,33 +60,45 @@ def test_api_get_prints_error_on_non_200(monkeypatch, capsys):
     captured = capsys.readouterr()
     assert "401" in captured.out
 
+
 def test_resolve_folder_uid_finds_match(monkeypatch):
     monkeypatch.setenv("GRAFANA_URL", "https://test.grafana.net")
     monkeypatch.setenv("GRAFANA_TOKEN", "tok")
     monkeypatch.setenv("GRAFANA_FOLDER", "MyFolder")
     m = import_module()
-    search_results = [{"uid": "d1", "folderTitle": "Other", "folderUid": "abc"}, {"uid": "d2", "folderTitle": "MyFolder", "folderUid": "xyz"}]
+    search_results = [
+        {"uid": "d1", "folderTitle": "Other", "folderUid": "abc"},
+        {"uid": "d2", "folderTitle": "MyFolder", "folderUid": "xyz"},
+    ]
     with patch.object(m, "api_get", return_value=search_results):
         uid = m.resolve_folder_uid(m.load_config())
     assert uid == "xyz"
+
 
 def test_resolve_folder_uid_exits_if_not_found(monkeypatch):
     monkeypatch.setenv("GRAFANA_URL", "https://test.grafana.net")
     monkeypatch.setenv("GRAFANA_TOKEN", "tok")
     monkeypatch.setenv("GRAFANA_FOLDER", "Missing")
     m = import_module()
-    with patch.object(m, "api_get", return_value=[{"uid": "d1", "folderTitle": "Other", "folderUid": "abc"}]):
+    with patch.object(
+        m,
+        "api_get",
+        return_value=[{"uid": "d1", "folderTitle": "Other", "folderUid": "abc"}],
+    ):
         with pytest.raises(SystemExit):
             m.resolve_folder_uid(m.load_config())
+
 
 import json
 
 STATE_FILE = ".grafana_state.json"
 
+
 def test_load_state_returns_empty_if_missing(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     m = import_module()
     assert m.load_state() == {}
+
 
 def test_load_state_reads_existing_file(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
@@ -88,6 +106,7 @@ def test_load_state_reads_existing_file(tmp_path, monkeypatch):
     (tmp_path / STATE_FILE).write_text(json.dumps(data))
     m = import_module()
     assert m.load_state() == data
+
 
 def test_save_state_writes_file(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
@@ -97,24 +116,29 @@ def test_save_state_writes_file(tmp_path, monkeypatch):
     written = json.loads((tmp_path / STATE_FILE).read_text())
     assert written == data
 
+
 def test_compute_checksum_is_deterministic():
     m = import_module()
     data = {"key": "value", "nested": {"a": 1}}
     assert m.compute_checksum(data) == m.compute_checksum(data)
     assert m.compute_checksum(data) != m.compute_checksum({"key": "other"})
 
+
 def test_make_slug_basic():
     m = import_module()
     assert m.make_slug("My Dashboard", "abc123", set()) == "my-dashboard"
+
 
 def test_make_slug_strips_special_chars():
     m = import_module()
     assert m.make_slug("CPU Usage (%)!", "abc123", set()) == "cpu-usage"
 
+
 def test_make_slug_deduplicates_with_uid():
     m = import_module()
     existing = {"my-dashboard"}
     assert m.make_slug("My Dashboard", "abc123", existing) == "my-dashboard-abc123"
+
 
 def test_cmd_pull_writes_files_and_state(tmp_path, monkeypatch, capsys):
     monkeypatch.chdir(tmp_path)
@@ -125,11 +149,21 @@ def test_cmd_pull_writes_files_and_state(tmp_path, monkeypatch, capsys):
 
     dashboard_json = {"uid": "abc", "title": "My Board", "panels": []}
     search_results = [{"uid": "abc", "title": "My Board"}]
-    detail = {"dashboard": dashboard_json, "meta": {"updated": "2026-01-01T00:00:00Z", "folderUid": "xyz"}}
+    detail = {
+        "dashboard": dashboard_json,
+        "meta": {"updated": "2026-01-01T00:00:00Z", "folderUid": "xyz"},
+    }
 
     def fake_api_get(cfg, path):
         if "/api/search" in path and "type=dash-db&limit=200" in path:
-            return [{"uid": "abc", "title": "My Board", "folderTitle": "MyFolder", "folderUid": "xyz"}]
+            return [
+                {
+                    "uid": "abc",
+                    "title": "My Board",
+                    "folderTitle": "MyFolder",
+                    "folderUid": "xyz",
+                }
+            ]
         if "/api/search" in path:
             return search_results
         if "/api/dashboards/uid/" in path:
@@ -156,10 +190,18 @@ def test_compute_diff_unchanged(tmp_path, monkeypatch):
     checksum = m.compute_checksum(dashboard)
     (tmp_path / "dashboards").mkdir()
     (tmp_path / "dashboards" / "x.json").write_text(json.dumps(dashboard))
-    state = {"abc": {"slug": "x", "checksum": checksum, "remote_updated": "2026-01-01T00:00:00Z", "folder_uid": "f1"}}
+    state = {
+        "abc": {
+            "slug": "x",
+            "checksum": checksum,
+            "remote_updated": "2026-01-01T00:00:00Z",
+            "folder_uid": "f1",
+        }
+    }
     changed, conflicts = m.compute_diff(state, {})
     assert changed == []
     assert conflicts == []
+
 
 def test_compute_diff_detects_local_change_no_conflict(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
@@ -168,12 +210,20 @@ def test_compute_diff_detects_local_change_no_conflict(tmp_path, monkeypatch):
     modified = {"uid": "abc", "title": "X modified"}
     (tmp_path / "dashboards").mkdir()
     (tmp_path / "dashboards" / "x.json").write_text(json.dumps(modified))
-    state = {"abc": {"slug": "x", "checksum": m.compute_checksum(original), "remote_updated": "2026-01-01T00:00:00Z", "folder_uid": "f1"}}
+    state = {
+        "abc": {
+            "slug": "x",
+            "checksum": m.compute_checksum(original),
+            "remote_updated": "2026-01-01T00:00:00Z",
+            "folder_uid": "f1",
+        }
+    }
     remote_meta = {"abc": {"updated": "2026-01-01T00:00:00Z"}}
     changed, conflicts = m.compute_diff(state, remote_meta)
     assert len(changed) == 1
     assert changed[0]["uid"] == "abc"
     assert conflicts == []
+
 
 def test_compute_diff_detects_conflict(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
@@ -182,11 +232,19 @@ def test_compute_diff_detects_conflict(tmp_path, monkeypatch):
     modified = {"uid": "abc", "title": "X modified"}
     (tmp_path / "dashboards").mkdir()
     (tmp_path / "dashboards" / "x.json").write_text(json.dumps(modified))
-    state = {"abc": {"slug": "x", "checksum": m.compute_checksum(original), "remote_updated": "2026-01-01T00:00:00Z", "folder_uid": "f1"}}
+    state = {
+        "abc": {
+            "slug": "x",
+            "checksum": m.compute_checksum(original),
+            "remote_updated": "2026-01-01T00:00:00Z",
+            "folder_uid": "f1",
+        }
+    }
     remote_meta = {"abc": {"updated": "2026-03-01T00:00:00Z"}}
     changed, conflicts = m.compute_diff(state, remote_meta)
     assert changed == []
     assert len(conflicts) == 1
+
 
 def test_compute_diff_warns_file_not_in_state(tmp_path, monkeypatch, capsys):
     monkeypatch.chdir(tmp_path)
@@ -197,6 +255,7 @@ def test_compute_diff_warns_file_not_in_state(tmp_path, monkeypatch, capsys):
     captured = capsys.readouterr()
     assert "[WARN]" in captured.out
     assert "unknown" in captured.out
+
 
 def test_cmd_push_uploads_changed_skips_conflicts(tmp_path, monkeypatch, capsys):
     monkeypatch.chdir(tmp_path)
@@ -215,29 +274,50 @@ def test_cmd_push_uploads_changed_skips_conflicts(tmp_path, monkeypatch, capsys)
     (tmp_path / "dashboards" / "y.json").write_text(json.dumps(conflict_modified))
 
     state = {
-        "abc": {"slug": "x", "checksum": m.compute_checksum(original), "remote_updated": "2026-01-01T00:00:00Z", "folder_uid": "f1"},
-        "def": {"slug": "y", "checksum": m.compute_checksum(conflict_original), "remote_updated": "2026-01-01T00:00:00Z", "folder_uid": "f1"},
+        "abc": {
+            "slug": "x",
+            "checksum": m.compute_checksum(original),
+            "remote_updated": "2026-01-01T00:00:00Z",
+            "folder_uid": "f1",
+        },
+        "def": {
+            "slug": "y",
+            "checksum": m.compute_checksum(conflict_original),
+            "remote_updated": "2026-01-01T00:00:00Z",
+            "folder_uid": "f1",
+        },
     }
     m.save_state(state)
 
     abc_call_count = {"n": 0}
+
     def fake_api_get(cfg, path):
         if "abc" in path:
             abc_call_count["n"] += 1
             # Second call is the re-fetch after push — return new timestamp
-            ts = "2026-01-01T12:00:00Z" if abc_call_count["n"] > 1 else "2026-01-01T00:00:00Z"
+            ts = (
+                "2026-01-01T12:00:00Z"
+                if abc_call_count["n"] > 1
+                else "2026-01-01T00:00:00Z"
+            )
             return {"dashboard": original, "meta": {"updated": ts}}
         if "def" in path:
-            return {"dashboard": conflict_original, "meta": {"updated": "2026-03-01T00:00:00Z"}}
+            return {
+                "dashboard": conflict_original,
+                "meta": {"updated": "2026-03-01T00:00:00Z"},
+            }
         return []
 
     posted = []
+
     def fake_api_post(cfg, path, payload):
         posted.append(payload)
         return {"status": "success"}
 
-    with patch.object(m, "api_get", side_effect=fake_api_get), \
-         patch.object(m, "api_post", side_effect=fake_api_post):
+    with (
+        patch.object(m, "api_get", side_effect=fake_api_get),
+        patch.object(m, "api_post", side_effect=fake_api_post),
+    ):
         m.cmd_push(m.load_config())
 
     captured = capsys.readouterr()
@@ -248,6 +328,7 @@ def test_cmd_push_uploads_changed_skips_conflicts(tmp_path, monkeypatch, capsys)
     updated_state = m.load_state()
     assert updated_state["abc"]["remote_updated"] == "2026-01-01T12:00:00Z"
 
+
 def test_cmd_push_exits_if_no_state_file(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
     monkeypatch.setenv("GRAFANA_URL", "https://test.grafana.net")
@@ -256,6 +337,7 @@ def test_cmd_push_exits_if_no_state_file(tmp_path, monkeypatch):
     m = import_module()
     with pytest.raises(SystemExit):
         m.cmd_push(m.load_config())
+
 
 def test_cmd_status_prints_diff_without_modifying(tmp_path, monkeypatch, capsys):
     monkeypatch.chdir(tmp_path)
@@ -269,7 +351,14 @@ def test_cmd_status_prints_diff_without_modifying(tmp_path, monkeypatch, capsys)
     (tmp_path / "dashboards").mkdir()
     (tmp_path / "dashboards" / "x.json").write_text(json.dumps(modified))
 
-    state = {"abc": {"slug": "x", "checksum": m.compute_checksum(original), "remote_updated": "2026-01-01T00:00:00Z", "folder_uid": "f1"}}
+    state = {
+        "abc": {
+            "slug": "x",
+            "checksum": m.compute_checksum(original),
+            "remote_updated": "2026-01-01T00:00:00Z",
+            "folder_uid": "f1",
+        }
+    }
     m.save_state(state)
 
     def fake_api_get(cfg, path):

--- a/dashboards/tests/test_grafana_sync.py
+++ b/dashboards/tests/test_grafana_sync.py
@@ -290,7 +290,7 @@ def test_cmd_push_uploads_changed_skips_conflicts(tmp_path, monkeypatch, capsys)
 
     abc_call_count = {"n": 0}
 
-    def fake_api_get(cfg, path):
+    def fake_api_get(_cfg, path):
         if "abc" in path:
             abc_call_count["n"] += 1
             # Second call is the re-fetch after push — return new timestamp
@@ -309,7 +309,7 @@ def test_cmd_push_uploads_changed_skips_conflicts(tmp_path, monkeypatch, capsys)
 
     posted = []
 
-    def fake_api_post(cfg, path, payload):
+    def fake_api_post(_cfg, _path, payload):
         posted.append(payload)
         return {"status": "success"}
 

--- a/metrics/__init__.py
+++ b/metrics/__init__.py
@@ -1,0 +1,1 @@
+"""Chain-specific metric implementations."""

--- a/metrics/arbitrum.py
+++ b/metrics/arbitrum.py
@@ -8,6 +8,7 @@ class HTTPEthCallLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "eth_call"
 
     @staticmethod
@@ -16,7 +17,7 @@ class HTTPEthCallLatencyMetric(HttpCallLatencyMetricBase):
         return [
             {
                 "to": "0xa97684ead0e402dC232d5A977953DF7ECBaB3CDb",
-                "data": "0x026b1d5f0000000000000000000000000000000000000000000000000000000000000000",
+                "data": "0x026b1d5f0000000000000000000000000000000000000000000000000000000000000000",  # noqa: E501
             },
             "latest",
         ]
@@ -27,6 +28,7 @@ class HTTPTxReceiptLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "eth_getTransactionReceipt"
 
     @staticmethod
@@ -45,6 +47,7 @@ class HTTPAccBalanceLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "eth_getBalance"
 
     @staticmethod
@@ -63,6 +66,7 @@ class HTTPDebugTraceTxLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "debug_traceTransaction"
 
     @staticmethod
@@ -81,6 +85,7 @@ class HTTPDebugTraceBlockByNumberLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "debug_traceBlockByNumber"
 
     @staticmethod
@@ -90,7 +95,7 @@ class HTTPDebugTraceBlockByNumberLatencyMetric(HttpCallLatencyMetricBase):
 
 
 class HTTPBlockNumberLatencyMetric(EVMBlockNumberLatencyMetric):
-    """Collects call latency for eth_blockNumber and captures block number for lag tracking."""
+    """eth_blockNumber latency; captures raw block number for lag tracking."""
 
 
 class HTTPGetLogsLatencyMetric(HttpCallLatencyMetricBase):
@@ -98,6 +103,7 @@ class HTTPGetLogsLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "eth_getLogs"
 
     @staticmethod
@@ -117,9 +123,11 @@ class HTTPGetLogsLatencyMetric(HttpCallLatencyMetricBase):
             {
                 "fromBlock": from_block_hex,
                 "toBlock": to_block_hex,
-                "address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",  # USDC on Arbitrum
+                # USDC on Arbitrum
+                "address": "0xaf88d065e77c8cC2239327C5EDb3A432268e5831",
                 "topics": [
-                    "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"  # Transfer event
+                    # ERC-20 Transfer event topic
+                    "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
                 ],
             }
         ]

--- a/metrics/arbitrum.py
+++ b/metrics/arbitrum.py
@@ -1,6 +1,6 @@
 """Base EVM metrics implementation for HTTP endpoints."""
 
-from common.metric_types import HttpCallLatencyMetricBase
+from common.metric_types import EVMBlockNumberLatencyMetric, HttpCallLatencyMetricBase
 
 
 class HTTPEthCallLatencyMetric(HttpCallLatencyMetricBase):
@@ -89,17 +89,8 @@ class HTTPDebugTraceBlockByNumberLatencyMetric(HttpCallLatencyMetricBase):
         return ["latest", {"tracer": "callTracer"}]
 
 
-class HTTPBlockNumberLatencyMetric(HttpCallLatencyMetricBase):
-    """Collects call latency for the `eth_blockNumber` method."""
-
-    @property
-    def method(self) -> str:
-        return "eth_blockNumber"
-
-    @staticmethod
-    def get_params_from_state(state_data: dict) -> list:
-        """Get empty parameter list for block number query."""
-        return []
+class HTTPBlockNumberLatencyMetric(EVMBlockNumberLatencyMetric):
+    """Collects call latency for eth_blockNumber and captures block number for lag tracking."""
 
 
 class HTTPGetLogsLatencyMetric(HttpCallLatencyMetricBase):

--- a/metrics/base.py
+++ b/metrics/base.py
@@ -8,6 +8,7 @@ class HTTPEthCallLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "eth_call"
 
     @staticmethod
@@ -16,7 +17,7 @@ class HTTPEthCallLatencyMetric(HttpCallLatencyMetricBase):
         return [
             {
                 "to": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",
-                "data": "0x70a082310000000000000000000000001985ea6e9c68e1c272d8209f3b478ac2fdb25c87",
+                "data": "0x70a082310000000000000000000000001985ea6e9c68e1c272d8209f3b478ac2fdb25c87",  # noqa: E501
             },
             "latest",
         ]
@@ -27,6 +28,7 @@ class HTTPTxReceiptLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "eth_getTransactionReceipt"
 
     @staticmethod
@@ -45,6 +47,7 @@ class HTTPAccBalanceLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "eth_getBalance"
 
     @staticmethod
@@ -63,6 +66,7 @@ class HTTPDebugTraceTxLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "debug_traceTransaction"
 
     @staticmethod
@@ -81,6 +85,7 @@ class HTTPDebugTraceBlockByNumberLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "debug_traceBlockByNumber"
 
     @staticmethod
@@ -90,7 +95,7 @@ class HTTPDebugTraceBlockByNumberLatencyMetric(HttpCallLatencyMetricBase):
 
 
 class HTTPBlockNumberLatencyMetric(EVMBlockNumberLatencyMetric):
-    """Collects call latency for eth_blockNumber and captures block number for lag tracking."""
+    """eth_blockNumber latency; captures raw block number for lag tracking."""
 
 
 class HTTPGetLogsLatencyMetric(HttpCallLatencyMetricBase):
@@ -98,6 +103,7 @@ class HTTPGetLogsLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "eth_getLogs"
 
     @staticmethod
@@ -114,7 +120,8 @@ class HTTPGetLogsLatencyMetric(HttpCallLatencyMetricBase):
                 "toBlock": to_block_hex,
                 "address": "0x833589fcd6edb6e08f4c7c32d4f71b54bda02913",  # USDC on Base
                 "topics": [
-                    "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"  # Transfer event
+                    # ERC-20 Transfer event topic
+                    "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
                 ],
             }
         ]

--- a/metrics/base.py
+++ b/metrics/base.py
@@ -1,6 +1,6 @@
 """Base EVM metrics implementation for HTTP endpoints."""
 
-from common.metric_types import HttpCallLatencyMetricBase
+from common.metric_types import EVMBlockNumberLatencyMetric, HttpCallLatencyMetricBase
 
 
 class HTTPEthCallLatencyMetric(HttpCallLatencyMetricBase):
@@ -89,17 +89,8 @@ class HTTPDebugTraceBlockByNumberLatencyMetric(HttpCallLatencyMetricBase):
         return ["latest", {"tracer": "callTracer"}]
 
 
-class HTTPBlockNumberLatencyMetric(HttpCallLatencyMetricBase):
-    """Collects call latency for the `eth_blockNumber` method."""
-
-    @property
-    def method(self) -> str:
-        return "eth_blockNumber"
-
-    @staticmethod
-    def get_params_from_state(state_data: dict) -> list:
-        """Get empty parameter list for block number query."""
-        return []
+class HTTPBlockNumberLatencyMetric(EVMBlockNumberLatencyMetric):
+    """Collects call latency for eth_blockNumber and captures block number for lag tracking."""
 
 
 class HTTPGetLogsLatencyMetric(HttpCallLatencyMetricBase):

--- a/metrics/bnbsc.py
+++ b/metrics/bnbsc.py
@@ -8,6 +8,7 @@ class HTTPEthCallLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "eth_call"
 
     @staticmethod
@@ -16,7 +17,7 @@ class HTTPEthCallLatencyMetric(HttpCallLatencyMetricBase):
         return [
             {
                 "to": "0xff75B6da14FfbbfD355Daf7a2731456b3562Ba6D",
-                "data": "0x026b1d5f0000000000000000000000000000000000000000000000000000000000000000",
+                "data": "0x026b1d5f0000000000000000000000000000000000000000000000000000000000000000",  # noqa: E501
             },
             "latest",
         ]
@@ -27,6 +28,7 @@ class HTTPTxReceiptLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "eth_getTransactionReceipt"
 
     @staticmethod
@@ -45,6 +47,7 @@ class HTTPAccBalanceLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "eth_getBalance"
 
     @staticmethod
@@ -63,6 +66,7 @@ class HTTPDebugTraceTxLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "debug_traceTransaction"
 
     @staticmethod
@@ -81,6 +85,7 @@ class HTTPDebugTraceBlockByNumberLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "debug_traceBlockByNumber"
 
     @staticmethod
@@ -90,7 +95,7 @@ class HTTPDebugTraceBlockByNumberLatencyMetric(HttpCallLatencyMetricBase):
 
 
 class HTTPBlockNumberLatencyMetric(EVMBlockNumberLatencyMetric):
-    """Collects call latency for eth_blockNumber and captures block number for lag tracking."""
+    """eth_blockNumber latency; captures raw block number for lag tracking."""
 
 
 class HTTPGetLogsLatencyMetric(HttpCallLatencyMetricBase):
@@ -98,6 +103,7 @@ class HTTPGetLogsLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "eth_getLogs"
 
     @staticmethod
@@ -117,9 +123,11 @@ class HTTPGetLogsLatencyMetric(HttpCallLatencyMetricBase):
             {
                 "fromBlock": from_block_hex,
                 "toBlock": to_block_hex,
-                "address": "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",  # Wrapped BNB on BSC
+                # Wrapped BNB on BSC
+                "address": "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",
                 "topics": [
-                    "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"  # Transfer event
+                    # ERC-20 Transfer event topic
+                    "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
                 ],
             }
         ]

--- a/metrics/bnbsc.py
+++ b/metrics/bnbsc.py
@@ -1,6 +1,6 @@
 """Base EVM metrics implementation for HTTP endpoints."""
 
-from common.metric_types import HttpCallLatencyMetricBase
+from common.metric_types import EVMBlockNumberLatencyMetric, HttpCallLatencyMetricBase
 
 
 class HTTPEthCallLatencyMetric(HttpCallLatencyMetricBase):
@@ -89,17 +89,8 @@ class HTTPDebugTraceBlockByNumberLatencyMetric(HttpCallLatencyMetricBase):
         return ["latest", {"tracer": "callTracer"}]
 
 
-class HTTPBlockNumberLatencyMetric(HttpCallLatencyMetricBase):
-    """Collects call latency for the `eth_blockNumber` method."""
-
-    @property
-    def method(self) -> str:
-        return "eth_blockNumber"
-
-    @staticmethod
-    def get_params_from_state(state_data: dict) -> list:
-        """Get empty parameter list for block number query."""
-        return []
+class HTTPBlockNumberLatencyMetric(EVMBlockNumberLatencyMetric):
+    """Collects call latency for eth_blockNumber and captures block number for lag tracking."""
 
 
 class HTTPGetLogsLatencyMetric(HttpCallLatencyMetricBase):

--- a/metrics/ethereum.py
+++ b/metrics/ethereum.py
@@ -202,7 +202,8 @@ class WSBlockLatencyMetric(WebSocketMetric):
     ) -> str:
         """Receive a message with a timeout."""
         try:
-            message = await asyncio.wait_for(websocket.recv(), timeout)
+            raw = await asyncio.wait_for(websocket.recv(), timeout)
+            message: str = raw.decode("utf-8") if isinstance(raw, bytes) else raw
             # Log incoming message size in bytes
             message_size: int = len(message.encode("utf-8"))
             logging.info(

--- a/metrics/ethereum.py
+++ b/metrics/ethereum.py
@@ -4,6 +4,9 @@ import asyncio
 import json
 import logging
 from datetime import datetime, timezone
+from typing import Any, Optional
+
+import websockets
 
 from common.metric_config import MetricConfig, MetricLabelKey, MetricLabels
 from common.metric_types import (
@@ -20,6 +23,7 @@ class HTTPEthCallLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "eth_call"
 
     @staticmethod
@@ -35,7 +39,7 @@ class HTTPEthCallLatencyMetric(HttpCallLatencyMetricBase):
 
 
 class HTTPBlockNumberLatencyMetric(EVMBlockNumberLatencyMetric):
-    """Collects call latency for eth_blockNumber and captures block number for lag tracking."""
+    """eth_blockNumber latency; captures raw block number for lag tracking."""
 
 
 class HTTPTxReceiptLatencyMetric(HttpCallLatencyMetricBase):
@@ -43,6 +47,7 @@ class HTTPTxReceiptLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "eth_getTransactionReceipt"
 
     @staticmethod
@@ -61,6 +66,7 @@ class HTTPAccBalanceLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "eth_getBalance"
 
     @staticmethod
@@ -79,6 +85,7 @@ class HTTPDebugTraceBlockByNumberLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "debug_traceBlockByNumber"
 
     @staticmethod
@@ -92,6 +99,7 @@ class HTTPDebugTraceTxLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "debug_traceTransaction"
 
     @staticmethod
@@ -110,6 +118,7 @@ class HTTPGetLogsLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "eth_getLogs"
 
     @staticmethod
@@ -131,17 +140,19 @@ class HTTPGetLogsLatencyMetric(HttpCallLatencyMetricBase):
                 "toBlock": to_block_hex,
                 "address": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",  # USDC
                 "topics": [
-                    "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"  # Transfer event
+                    # ERC-20 Transfer event topic
+                    "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
                 ],
             }
         ]
 
 
 class WSBlockLatencyMetric(WebSocketMetric):
-    """Collects block latency for EVM providers using a WebSocket connection.
+    """Collects block latency for EVM providers via a WebSocket connection.
 
-    Suitable for serverless invocation: connects, subscribes, collects one message, and disconnects.
-    """  # noqa: E501
+    Suitable for serverless use: connects, subscribes, collects one message,
+    and disconnects.
+    """
 
     def __init__(
         self,
@@ -149,7 +160,7 @@ class WSBlockLatencyMetric(WebSocketMetric):
         metric_name: str,
         labels: MetricLabels,
         config: MetricConfig,
-        **kwargs,
+        **kwargs: object,
     ) -> None:
         """Initialize WebSocket block latency metric.
 
@@ -170,31 +181,41 @@ class WSBlockLatencyMetric(WebSocketMetric):
         )
         self.labels.update_label(MetricLabelKey.API_METHOD, "eth_subscribe")
 
-    async def send_with_timeout(self, websocket, message: str, timeout: float) -> None:
+    async def send_with_timeout(
+        self,
+        websocket: websockets.WebSocketClientProtocol,
+        message: str,
+        timeout: float,
+    ) -> None:
         """Send a message with a timeout."""
         try:
             await asyncio.wait_for(websocket.send(message), timeout)
-        except asyncio.TimeoutError:
+        except asyncio.TimeoutError as e:
             raise TimeoutError(
                 f"WebSocket message send timed out after {timeout} seconds"
-            )
+            ) from e
 
-    async def recv_with_timeout(self, websocket, timeout: float) -> str:
+    async def recv_with_timeout(
+        self,
+        websocket: websockets.WebSocketClientProtocol,
+        timeout: float,
+    ) -> str:
         """Receive a message with a timeout."""
         try:
             message = await asyncio.wait_for(websocket.recv(), timeout)
             # Log incoming message size in bytes
             message_size: int = len(message.encode("utf-8"))
             logging.info(
-                f"WebSocket received {message_size} bytes from {self.labels.get_prometheus_labels()}"
+                f"WebSocket received {message_size} bytes from "
+                f"{self.labels.get_prometheus_labels()}"
             )
             return message
-        except asyncio.TimeoutError:
+        except asyncio.TimeoutError as e:
             raise TimeoutError(
                 f"WebSocket message reception timed out after {timeout} seconds"
-            )
+            ) from e
 
-    async def subscribe(self, websocket) -> None:
+    async def subscribe(self, websocket: websockets.WebSocketClientProtocol) -> None:
         """Subscribe to the newHeads event on the WebSocket endpoint.
 
         Args:
@@ -204,7 +225,8 @@ class WSBlockLatencyMetric(WebSocketMetric):
             ValueError: If subscription to newHeads fails
         """
         # Use standard eth_subscribe format without optional parameters
-        # The False parameter caused Quicknode to accept the subscription but never send data
+        # The False parameter caused Quicknode to silently accept but never
+        # send data
         subscription_msg: str = json.dumps(
             {
                 "id": 1,
@@ -224,7 +246,7 @@ class WSBlockLatencyMetric(WebSocketMetric):
 
         self.subscription_id = subscription_data["result"]
 
-    async def unsubscribe(self, websocket) -> None:
+    async def unsubscribe(self, websocket: websockets.WebSocketClientProtocol) -> None:
         """Unsubscribe from the WebSocket connection.
 
         Args:
@@ -245,14 +267,16 @@ class WSBlockLatencyMetric(WebSocketMetric):
         await self.send_with_timeout(websocket, unsubscribe_msg, WS_DEFAULT_TIMEOUT)
         await self.recv_with_timeout(websocket, WS_DEFAULT_TIMEOUT)
 
-    async def listen_for_data(self, websocket):
-        """Listen for a single data message from the WebSocket and process block latency.
+    async def listen_for_data(
+        self, websocket: websockets.WebSocketClientProtocol
+    ) -> Optional[dict[str, Any]]:
+        """Listen for a single data message from the WebSocket.
 
         Args:
             websocket: WebSocket connection instance
 
         Returns:
-            dict: Block data if received successfully, None otherwise
+            Block data dict if received successfully, None otherwise
 
         Raises:
             asyncio.TimeoutError: If no message received within timeout period
@@ -264,7 +288,7 @@ class WSBlockLatencyMetric(WebSocketMetric):
             return block
         return None
 
-    def process_data(self, block) -> float:
+    def process_data(self, block: dict[str, Any]) -> float:
         """Calculate block latency in seconds.
 
         Args:

--- a/metrics/ethereum.py
+++ b/metrics/ethereum.py
@@ -6,7 +6,11 @@ import logging
 from datetime import datetime, timezone
 
 from common.metric_config import MetricConfig, MetricLabelKey, MetricLabels
-from common.metric_types import HttpCallLatencyMetricBase, WebSocketMetric
+from common.metric_types import (
+    EVMBlockNumberLatencyMetric,
+    HttpCallLatencyMetricBase,
+    WebSocketMetric,
+)
 
 WS_DEFAULT_TIMEOUT = 20
 
@@ -30,17 +34,8 @@ class HTTPEthCallLatencyMetric(HttpCallLatencyMetricBase):
         ]
 
 
-class HTTPBlockNumberLatencyMetric(HttpCallLatencyMetricBase):
-    """Collects call latency for the eth_blockNumber method."""
-
-    @property
-    def method(self) -> str:
-        return "eth_blockNumber"
-
-    @staticmethod
-    def get_params_from_state(state_data: dict) -> list:
-        """Returns empty parameters list for eth_blockNumber."""
-        return []
+class HTTPBlockNumberLatencyMetric(EVMBlockNumberLatencyMetric):
+    """Collects call latency for eth_blockNumber and captures block number for lag tracking."""
 
 
 class HTTPTxReceiptLatencyMetric(HttpCallLatencyMetricBase):

--- a/metrics/hyperliquid.py
+++ b/metrics/hyperliquid.py
@@ -4,7 +4,7 @@ For Hyperliquid Info API metrics (clearinghouseState, openOrders, etc.),
 see metrics.hyperliquid_info module.
 """
 
-from common.metric_types import HttpCallLatencyMetricBase
+from common.metric_types import EVMBlockNumberLatencyMetric, HttpCallLatencyMetricBase
 
 
 class HTTPEthCallLatencyMetric(HttpCallLatencyMetricBase):
@@ -61,17 +61,8 @@ class HTTPAccBalanceLatencyMetric(HttpCallLatencyMetricBase):
         ]  # Only latest block is supported
 
 
-class HTTPBlockNumberLatencyMetric(HttpCallLatencyMetricBase):
-    """Collects call latency for the `eth_blockNumber` method."""
-
-    @property
-    def method(self) -> str:
-        return "eth_blockNumber"
-
-    @staticmethod
-    def get_params_from_state(state_data: dict) -> list:
-        """Get empty parameter list for block number query."""
-        return []
+class HTTPBlockNumberLatencyMetric(EVMBlockNumberLatencyMetric):
+    """Collects call latency for eth_blockNumber and captures block number for lag tracking."""
 
 
 class HTTPGetLogsLatencyMetric(HttpCallLatencyMetricBase):

--- a/metrics/hyperliquid.py
+++ b/metrics/hyperliquid.py
@@ -12,6 +12,7 @@ class HTTPEthCallLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "eth_call"
 
     @staticmethod
@@ -31,6 +32,7 @@ class HTTPTxReceiptLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "eth_getTransactionReceipt"
 
     @staticmethod
@@ -49,6 +51,7 @@ class HTTPAccBalanceLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "eth_getBalance"
 
     @staticmethod
@@ -62,7 +65,7 @@ class HTTPAccBalanceLatencyMetric(HttpCallLatencyMetricBase):
 
 
 class HTTPBlockNumberLatencyMetric(EVMBlockNumberLatencyMetric):
-    """Collects call latency for eth_blockNumber and captures block number for lag tracking."""
+    """eth_blockNumber latency; captures raw block number for lag tracking."""
 
 
 class HTTPGetLogsLatencyMetric(HttpCallLatencyMetricBase):
@@ -70,6 +73,7 @@ class HTTPGetLogsLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "eth_getLogs"
 
     @staticmethod
@@ -91,7 +95,7 @@ class HTTPGetLogsLatencyMetric(HttpCallLatencyMetricBase):
                 "toBlock": to_block_hex,
                 "address": "0x5555555555555555555555555555555555555555",  # Wrapped HYPE
                 # "topics": [
-                #    " 0x7fcf532c15f0a6db0bd6d0e038bea71d30d808c7d98cb3bf7268a95bf5081b65"  # Withdrawal event
+                #    " 0x7fcf532c15f0a6db0bd6d0e038bea71d30d808c7d98cb3bf7268a95bf5081b65"  # noqa: E501
                 # ],
             }
         ]

--- a/metrics/monad.py
+++ b/metrics/monad.py
@@ -1,6 +1,6 @@
 """Monad EVM metrics implementation for HTTP endpoints."""
 
-from common.metric_types import HttpCallLatencyMetricBase
+from common.metric_types import EVMBlockNumberLatencyMetric, HttpCallLatencyMetricBase
 
 
 class HTTPEthCallLatencyMetric(HttpCallLatencyMetricBase):
@@ -89,17 +89,8 @@ class HTTPDebugTraceBlockByNumberLatencyMetric(HttpCallLatencyMetricBase):
         return ["latest", {"tracer": "callTracer"}]
 
 
-class HTTPBlockNumberLatencyMetric(HttpCallLatencyMetricBase):
-    """Collects call latency for the `eth_blockNumber` method."""
-
-    @property
-    def method(self) -> str:
-        return "eth_blockNumber"
-
-    @staticmethod
-    def get_params_from_state(state_data: dict) -> list:
-        """Get empty parameter list for block number query."""
-        return []
+class HTTPBlockNumberLatencyMetric(EVMBlockNumberLatencyMetric):
+    """Collects call latency for eth_blockNumber and captures block number for lag tracking."""
 
 
 class HTTPGetLogsLatencyMetric(HttpCallLatencyMetricBase):

--- a/metrics/monad.py
+++ b/metrics/monad.py
@@ -8,6 +8,7 @@ class HTTPEthCallLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "eth_call"
 
     @staticmethod
@@ -16,7 +17,7 @@ class HTTPEthCallLatencyMetric(HttpCallLatencyMetricBase):
         return [
             {
                 "to": "0x754704Bc059F8C67012fEd69BC8A327a5aafb603",
-                "data": "0x70a082310000000000000000000000001985ea6e9c68e1c272d8209f3b478ac2fdb25c87",
+                "data": "0x70a082310000000000000000000000001985ea6e9c68e1c272d8209f3b478ac2fdb25c87",  # noqa: E501
             },
             "latest",
         ]
@@ -27,6 +28,7 @@ class HTTPTxReceiptLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "eth_getTransactionReceipt"
 
     @staticmethod
@@ -45,6 +47,7 @@ class HTTPAccBalanceLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "eth_getBalance"
 
     @staticmethod
@@ -63,6 +66,7 @@ class HTTPDebugTraceTxLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "debug_traceTransaction"
 
     @staticmethod
@@ -81,6 +85,7 @@ class HTTPDebugTraceBlockByNumberLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "debug_traceBlockByNumber"
 
     @staticmethod
@@ -90,7 +95,7 @@ class HTTPDebugTraceBlockByNumberLatencyMetric(HttpCallLatencyMetricBase):
 
 
 class HTTPBlockNumberLatencyMetric(EVMBlockNumberLatencyMetric):
-    """Collects call latency for eth_blockNumber and captures block number for lag tracking."""
+    """eth_blockNumber latency; captures raw block number for lag tracking."""
 
 
 class HTTPGetLogsLatencyMetric(HttpCallLatencyMetricBase):
@@ -98,6 +103,7 @@ class HTTPGetLogsLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "eth_getLogs"
 
     @staticmethod
@@ -112,9 +118,11 @@ class HTTPGetLogsLatencyMetric(HttpCallLatencyMetricBase):
             {
                 "fromBlock": from_block_hex,
                 "toBlock": to_block_hex,
-                "address": "0x754704Bc059F8C67012fEd69BC8A327a5aafb603",  # USDC on Monad
+                # USDC on Monad
+                "address": "0x754704Bc059F8C67012fEd69BC8A327a5aafb603",
                 "topics": [
-                    "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"  # Transfer event
+                    # ERC-20 Transfer event topic
+                    "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
                 ],
             }
         ]

--- a/metrics/solana.py
+++ b/metrics/solana.py
@@ -10,6 +10,7 @@ class HTTPSimulateTxLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "simulateTransaction"
 
     @staticmethod
@@ -17,7 +18,7 @@ class HTTPSimulateTxLatencyMetric(HttpCallLatencyMetricBase):
         """Get parameters for simulating a token transfer."""
         return [
             "AQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAABAAEDArczbMia1tLmq7zz4DinMNN0pJ1JtLdqIJPUw3YrGCzYAMHBsgN27lcgB6H2WQvFgyZuJYHa46puOQo9yQ8CVQbd9uHXZaGT2cvhRs7reawctIXtX1s3kTqM9YV+/wCp20C7Wj2aiuk5TReAXo+VTVg8QTHjs0UjNMMKCvpzZ+ABAgEBARU=",
-            # The transaction recent blockhash will be replaced with the most recent blockhash.
+            # blockhash is replaced with the latest at send time
             {"encoding": "base64", "replaceRecentBlockhash": True},
         ]
 
@@ -30,6 +31,7 @@ class HTTPGetRecentBlockhashLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "getLatestBlockhash"
 
     @staticmethod
@@ -52,6 +54,7 @@ class HTTPGetTxLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "getTransaction"
 
     @staticmethod
@@ -73,6 +76,7 @@ class HTTPGetBalanceLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "getBalance"
 
     @staticmethod
@@ -86,6 +90,7 @@ class HTTPGetBlockLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "getBlock"
 
     @staticmethod
@@ -112,6 +117,7 @@ class HTTPGetProgramAccsLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "getProgramAccounts"
 
     @staticmethod

--- a/metrics/solana.py
+++ b/metrics/solana.py
@@ -40,6 +40,7 @@ class HTTPGetRecentBlockhashLatencyMetric(HttpCallLatencyMetricBase):
         return []
 
     def _on_json_response(self, json_response: dict[str, Any]) -> None:
+        """Capture slot from result.context.slot for block lag tracking."""
         result = json_response.get("result")
         if isinstance(result, dict):
             context = result.get("context")

--- a/metrics/solana.py
+++ b/metrics/solana.py
@@ -1,5 +1,7 @@
 """Solana metrics implementation for HTTP endpoints."""
 
+from typing import Any
+
 from common.metric_types import HttpCallLatencyMetricBase
 
 
@@ -21,7 +23,10 @@ class HTTPSimulateTxLatencyMetric(HttpCallLatencyMetricBase):
 
 
 class HTTPGetRecentBlockhashLatencyMetric(HttpCallLatencyMetricBase):
-    """Collects call latency for the getLatestBlockhash method."""
+    """Collects call latency for the getLatestBlockhash method.
+
+    Also captures the current slot from the response context for block lag tracking.
+    """
 
     @property
     def method(self) -> str:
@@ -31,6 +36,15 @@ class HTTPGetRecentBlockhashLatencyMetric(HttpCallLatencyMetricBase):
     def get_params_from_state(state_data: dict) -> list:
         """Get empty parameters list for blockhash retrieval."""
         return []
+
+    def _on_json_response(self, json_response: dict[str, Any]) -> None:
+        result = json_response.get("result")
+        if isinstance(result, dict):
+            context = result.get("context")
+            if isinstance(context, dict):
+                slot = context.get("slot")
+                if isinstance(slot, int):
+                    self._captured_block_number = slot
 
 
 class HTTPGetTxLatencyMetric(HttpCallLatencyMetricBase):

--- a/metrics/solana_landing_rate.py
+++ b/metrics/solana_landing_rate.py
@@ -47,6 +47,8 @@ def generate_fixed_memo(region: str) -> str:
 
 
 class SolanaLandingMetric(HttpMetric):
+    """Measures Solana transaction landing rate and slot latency via memo tx."""
+
     POLL_INTERVAL = 5.0  # seconds for polling getSignatureStatuses
     MEMO_PROGRAM_ID = "Memo1UhkJRfHyvLMcVucJwxXeuD728EqVDDwQDxFMNo"
 
@@ -56,8 +58,9 @@ class SolanaLandingMetric(HttpMetric):
         metric_name: str,
         labels: MetricLabels,
         config: MetricConfig,
-        **kwargs,
+        **kwargs: object,
     ) -> None:
+        """Initialize with handler, metric name, labels, config, and endpoint kwargs."""
         http_endpoint = kwargs.get("http_endpoint")
         super().__init__(
             handler=handler,
@@ -148,6 +151,12 @@ class SolanaLandingMetric(HttpMetric):
         )
 
     async def fetch_data(self) -> Optional[float]:
+        """Send a memo transaction and return elapsed wall-clock time.
+
+        Initializes both response_time and slot_latency metric types, submits
+        a signed memo transaction, waits for confirmation, and stores the slot
+        difference as slot_latency.
+        """
         # Since we use here an additional value (metric_type),
         # let's initialize all used metric types.
         self.update_metric_value(0, "response_time")
@@ -190,4 +199,5 @@ class SolanaLandingMetric(HttpMetric):
                 await client.close()
 
     def process_data(self, value: float) -> float:
+        """Return the raw latency value unchanged."""
         return value

--- a/metrics/ton.py
+++ b/metrics/ton.py
@@ -14,6 +14,7 @@ class HTTPGetMasterchainInfoLatencyMetric(HttpCallLatencyMetricBase):
         return "getMasterchainInfo"
 
     def _on_json_response(self, json_response: dict[str, Any]) -> None:
+        """Capture result.last.seqno for block lag tracking."""
         result = json_response.get("result")
         if isinstance(result, dict):
             last = result.get("last")

--- a/metrics/ton.py
+++ b/metrics/ton.py
@@ -1,6 +1,25 @@
 """TON (The Open Network) metrics implementation for HTTP endpoints."""
 
+from typing import Any
+
 from common.metric_types import HttpCallLatencyMetricBase
+
+
+class HTTPGetMasterchainInfoLatencyMetric(HttpCallLatencyMetricBase):
+    """Collects latency for getMasterchainInfo and captures current seqno for lag tracking."""
+
+    @property
+    def method(self) -> str:
+        return "getMasterchainInfo"
+
+    def _on_json_response(self, json_response: dict[str, Any]) -> None:
+        result = json_response.get("result")
+        if isinstance(result, dict):
+            last = result.get("last")
+            if isinstance(last, dict):
+                seqno = last.get("seqno")
+                if isinstance(seqno, int):
+                    self._captured_block_number = seqno
 
 
 class HTTPRunGetMethodLatencyMetric(HttpCallLatencyMetricBase):

--- a/metrics/ton.py
+++ b/metrics/ton.py
@@ -6,10 +6,11 @@ from common.metric_types import HttpCallLatencyMetricBase
 
 
 class HTTPGetMasterchainInfoLatencyMetric(HttpCallLatencyMetricBase):
-    """Collects latency for getMasterchainInfo and captures current seqno for lag tracking."""
+    """getMasterchainInfo latency; captures seqno for lag tracking."""
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "getMasterchainInfo"
 
     def _on_json_response(self, json_response: dict[str, Any]) -> None:
@@ -27,6 +28,7 @@ class HTTPRunGetMethodLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "runGetMethod"
 
     @staticmethod
@@ -49,6 +51,7 @@ class HTTPGetBlockHeaderLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "getBlockHeader"
 
     @staticmethod
@@ -72,6 +75,7 @@ class HTTPGetWalletTxsLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "getWalletInformation"
 
     @staticmethod
@@ -85,6 +89,7 @@ class HTTPGetAddressBalanceLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "getAddressBalance"
 
     @staticmethod
@@ -98,6 +103,7 @@ class HTTPGetBlockTxsLatencyMetric(HttpCallLatencyMetricBase):
 
     @property
     def method(self) -> str:
+        """Return the RPC method name."""
         return "getBlockTransactions"
 
     @staticmethod

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,20 @@
+[project]
+name = "monitoring-vercel"
+version = "0.1.0"
+requires-python = ">=3.9"
+dependencies = [
+    "aiohttp==3.13.4",
+    "websockets==12.0",
+    "solders==0.23.0",
+    "solana==0.36.2",
+    "base58==2.1.1",
+]
+
+[dependency-groups]
+dev = [
+    "python-dotenv>=1.0.0",
+]
+
 [tool.black]
 line-length = 88
 target-version = ["py39"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,9 @@ include = '\.pyi?$'
 [tool.ruff]
 line-length = 88
 target-version = "py39"
+exclude = [".claude"]
+
+[tool.ruff.lint]
 select = [
     "E",   # pycodestyle
     "F",   # pyflakes
@@ -19,20 +22,21 @@ select = [
     "ANN", # annotations
     "RUF"  # ruff-specific rules
 ]
-ignore = ["D203", "D213"]
+ignore = ["D203", "D213", "ANN401"]
 
-[tool.ruff.isort]
+[tool.ruff.lint.isort]
 known-first-party = ["common", "metrics"]
 
-[tool.ruff.mccabe]
+[tool.ruff.lint.mccabe]
 max-complexity = 10
 
-[tool.ruff.pydocstyle]
+[tool.ruff.lint.pydocstyle]
 convention = "google"
 
-[tool.ruff.per-file-ignores]
+[tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["F401"]
 "test_*.py" = ["D", "ANN"]
+"api/**/*.py" = ["N801"]
 
 [tool.mypy]
 python_version = "3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ include = '\.pyi?$'
 [tool.ruff]
 line-length = 88
 target-version = "py39"
-exclude = [".claude"]
+extend-exclude = [".claude"]
 
 [tool.ruff.lint]
 select = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aiohttp==3.13.3
+aiohttp==3.13.4
 websockets==12.0
 solders==0.23.0
 solana==0.36.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,0 @@
-aiohttp==3.13.4
-websockets==12.0
-solders==0.23.0
-solana==0.36.2
-base58==2.1.1

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"

--- a/uv.lock
+++ b/uv.lock
@@ -1,3 +1,0 @@
-version = 1
-revision = 3
-requires-python = ">=3.13"


### PR DESCRIPTION
## Why
Grafana needs raw block numbers per provider to compute block lag (how far each provider is behind the tip).

## What
Piggyback on existing latency calls to capture the block number and emit it as a new `metric_type=block_number` on the existing `response_latency_seconds` measurement.

| Chain | Method reused | Field captured |
|---|---|---|
| EVM (Ethereum, Base, BSC, Arbitrum, Monad, Hyperliquid) | `eth_blockNumber` | hex `result` |
| Solana | `getLatestBlockhash` | `result.context.slot` |
| TON | `getMasterchainInfo` (new call) | `result.last.seqno` |

Zero extra RPC calls except TON's `getMasterchainInfo` — which is also a useful new TON latency metric.

## Why raw, not pre-computed lag
Grafana computes `max(block_number) - provider_value` at query time. Keeps the tip formula (max / median-of-top-N / etc.) configurable without a redeploy.

## Output
```
dev_response_latency_seconds,blockchain=ethereum,provider=alchemy,api_method=eth_blockNumber,metric_type=block_number value=21800100
dev_response_latency_seconds,blockchain=ton,provider=chainstack,api_method=getMasterchainInfo,metric_type=block_number value=48200000
```

## Also bundled
Unrelated repo-hygiene changes piggybacked on the feature commits:
- **uv migration** — root `pyproject.toml` gets a `[project]` block with deps, `requirements.txt` deleted, `dashboards/` split into its own uv subproject (`dashboards/pyproject.toml`).
- **Docs/ignores** — `readme.md` → `README.md`, `CLAUDE.md` commands switched to `uvx` / `uv run`, `.vercelignore` casing + new entries.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded metrics: new latency metric for TON plus expanded block-number capture for EVM chains to surface block-lag metrics.

* **Bug Fixes / Reliability**
  * More robust JSON-RPC/HTTP handling and clearer failure/reset behavior to improve metric accuracy and stability.

* **Documentation**
  * Widespread docstring additions and clarifications across the codebase for easier maintenance and observability.

* **Chores**
  * Updated aiohttp pin and lint config tweaks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
