### PR TITLE
feat(dashboards): add block lag panels to TON dashboards

### DIFF
--- a/dashboards/dashboards/compare-dashboard-ton-eu.json
+++ b/dashboards/dashboards/compare-dashboard-ton-eu.json
@@ -89,7 +89,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "#### Description\n\nThis dashboard provides real-time and historical performance analytics for RPC nodes across major providers.\n\n* Click region buttons to view metrics from different locations\n* Adjust time range for historical analysis\n* Hover over info icons for detailed metric descriptions\n\n&nbsp;\n\n#### Data collection\n\nResponse times are measured by our Python service on [Vercel serverless functions](https://github.com/chainstacklabs/compare-dashboard-functions), sending requests every 1-3 minutes from three regions.\n\nResponse times exceeding 55 seconds are considered failures and excluded from charts.\n\nAll requests use latest blocks except \"archive\" methods (\u231b), which query historical blocks (1-2 days ago).\n\n\u2139\ufe0f If not specified, the first paid RPC provider plan (named Growth as a rule) is used for monitoring.\n\n&nbsp;\n\n#### How we rank providers\n\nWe evaluate RPC providers based on their **speed** (response time) and **reliability** (success rate) across three regions.\n\n* The **lower** the score, the **better** the provider\n* Even small success rate drops (99% vs 97%) significantly impact the final score\n* Performance is measured equally across all regions\n\n```plaintext\nScore = 1 / ((1/ResponseTime) \u00d7 (SuccessRate\u00b3))\n```",
+        "content": "#### Description\n\nThis dashboard provides real-time and historical performance analytics for RPC nodes across major providers.\n\n* Click region buttons to view metrics from different locations\n* Adjust time range for historical analysis\n* Hover over info icons for detailed metric descriptions\n\n&nbsp;\n\n#### Data collection\n\nResponse times are measured by our Python service on [Vercel serverless functions](https://github.com/chainstacklabs/compare-dashboard-functions), sending requests every 1-3 minutes from three regions.\n\nResponse times exceeding 55 seconds are considered failures and excluded from charts.\n\nAll requests use latest blocks except \"archive\" methods (⌛), which query historical blocks (1-2 days ago).\n\nℹ️ If not specified, the first paid RPC provider plan (named Growth as a rule) is used for monitoring.\n\n&nbsp;\n\n#### How we rank providers\n\nWe evaluate RPC providers based on their **speed** (response time) and **reliability** (success rate) across three regions.\n\n* The **lower** the score, the **better** the provider\n* Even small success rate drops (99% vs 97%) significantly impact the final score\n* Performance is measured equally across all regions\n\n```plaintext\nScore = 1 / ((1/ResponseTime) × (SuccessRate³))\n```",
         "mode": "markdown"
       },
       "pluginVersion": "12.4.0-19938312174",
@@ -97,7 +97,7 @@
       "type": "text"
     },
     {
-      "description": "We evaluate RPC providers based on their speed (response time) and reliability (success rate) across three regions.\n\nScore = 1 / ((1/ResponseTime) \u00d7 (SuccessRate\u00b3))",
+      "description": "We evaluate RPC providers based on their speed (response time) and reliability (success rate) across three regions.\n\nScore = 1 / ((1/ResponseTime) × (SuccessRate³))",
       "gridPos": {
         "h": 1,
         "w": 5,
@@ -656,6 +656,339 @@
         "x": 0,
         "y": 25
       },
+      "id": 1008,
+      "title": "Block lag",
+      "type": "row",
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Measures masterchain block sequence number (seqno) from getMasterchainInfo. The tip is the highest seqno seen across all providers at each measurement. Lag = tip − provider seqno. Lag ≤ 2 blocks is treated as at-tip to filter measurement jitter (3-min sampling vs ~0.4s block time).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "blue",
+                "mode": "thresholds"
+              },
+              "decimals": 1,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 80
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 90
+                  },
+                  {
+                    "color": "green",
+                    "value": 99
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 26
+          },
+          "id": 1005,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "13.0.0-23605486576",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "100 * (1 - avg_over_time((clamp_min(scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", source_region=\"fra1\", response_status=\"success\"})) - max by (provider) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", source_region=\"fra1\", response_status=\"success\"}), 0) > bool 2)[$__range:$__interval]))",
+              "legendFormat": "{{provider}}",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "% of time at tip",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (≤2 blocks), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Masterchain seqno lag. 0 = at the tip.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 3
+                  },
+                  {
+                    "color": "orange",
+                    "value": 10
+                  },
+                  {
+                    "color": "red",
+                    "value": 20
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 19,
+            "x": 0,
+            "y": 30
+          },
+          "id": 1006,
+          "options": {
+            "alignValue": "left",
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.0.0-23605486576",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", source_region=\"fra1\", response_status=\"success\"})) - max by (provider) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", source_region=\"fra1\", response_status=\"success\"})",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Block lag timeline",
+          "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "getMasterchainInfo success rate — the method used for block lag tracking.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "super-light-blue",
+                "mode": "continuous-YlBl"
+              },
+              "decimals": 2,
+              "mappings": [
+                {
+                  "options": {
+                    "from": 0.99991,
+                    "result": {
+                      "index": 0,
+                      "text": "100.0%"
+                    },
+                    "to": 1
+                  },
+                  "type": "range"
+                }
+              ],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 5,
+            "x": 19,
+            "y": 30
+          },
+          "id": 1007,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "13.0.0-23605486576",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"fra1\", api_method=\"getMasterchainInfo\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"fra1\", api_method=\"getMasterchainInfo\"}[$__range])) by (provider)",
+              "instant": true,
+              "range": false,
+              "legendFormat": "{{provider}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Success rate",
+          "type": "stat"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
       "id": 7,
       "panels": [
         {
@@ -737,7 +1070,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 24
+            "y": 41
           },
           "id": 3,
           "options": {
@@ -820,7 +1153,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 24
+            "y": 41
           },
           "id": 33,
           "options": {
@@ -946,7 +1279,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 32
+            "y": 49
           },
           "id": 20,
           "options": {
@@ -1029,7 +1362,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 32
+            "y": 49
           },
           "id": 34,
           "options": {
@@ -1155,7 +1488,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 40
+            "y": 57
           },
           "id": 47,
           "options": {
@@ -1238,7 +1571,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 40
+            "y": 57
           },
           "id": 48,
           "options": {
@@ -1364,7 +1697,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 48
+            "y": 65
           },
           "id": 21,
           "options": {
@@ -1400,7 +1733,7 @@
               "refId": "C"
             }
           ],
-          "title": "getBlockHeader \u231b",
+          "title": "getBlockHeader ⌛",
           "type": "timeseries"
         },
         {
@@ -1447,7 +1780,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 48
+            "y": 65
           },
           "id": 35,
           "options": {
@@ -1573,7 +1906,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 56
+            "y": 73
           },
           "id": 49,
           "options": {
@@ -1656,7 +1989,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 56
+            "y": 73
           },
           "id": 50,
           "options": {
@@ -1709,7 +2042,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 43
       },
       "id": 999,
       "panels": [
@@ -1794,7 +2127,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 21
+            "y": 38
           },
           "id": 24,
           "options": {
@@ -1938,7 +2271,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 21
+            "y": 38
           },
           "id": 25,
           "options": {
@@ -2082,7 +2415,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 196
+            "y": 213
           },
           "id": 26,
           "options": {
@@ -2226,7 +2559,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 196
+            "y": 213
           },
           "id": 51,
           "options": {
@@ -2370,7 +2703,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 201
+            "y": 218
           },
           "id": 52,
           "options": {
@@ -2444,7 +2777,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 44
       },
       "id": 23,
       "panels": [
@@ -2529,7 +2862,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 21
+            "y": 38
           },
           "id": 1000,
           "options": {
@@ -2673,7 +3006,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 21
+            "y": 38
           },
           "id": 1001,
           "options": {
@@ -2817,7 +3150,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 196
+            "y": 213
           },
           "id": 1002,
           "options": {
@@ -2961,7 +3294,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 196
+            "y": 213
           },
           "id": 1003,
           "options": {
@@ -3105,7 +3438,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 201
+            "y": 218
           },
           "id": 1004,
           "options": {
@@ -3179,7 +3512,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 28
+        "y": 45
       },
       "id": 55,
       "panels": [
@@ -3264,7 +3597,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 22
+            "y": 39
           },
           "id": 56,
           "options": {
@@ -3408,7 +3741,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 22
+            "y": 39
           },
           "id": 59,
           "options": {
@@ -3552,7 +3885,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 182
+            "y": 199
           },
           "id": 57,
           "options": {
@@ -3696,7 +4029,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 182
+            "y": 199
           },
           "id": 60,
           "options": {
@@ -3840,7 +4173,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 187
+            "y": 204
           },
           "id": 58,
           "options": {

--- a/dashboards/dashboards/compare-dashboard-ton-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-ton-singapore.json
@@ -89,7 +89,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "#### Description\n\nThis dashboard provides real-time and historical performance analytics for RPC nodes across major providers.\n\n* Click region buttons to view metrics from different locations\n* Adjust time range for historical analysis\n* Hover over info icons for detailed metric descriptions\n\n&nbsp;\n\n#### Data collection\n\nResponse times are measured by our Python service on [Vercel serverless functions](https://github.com/chainstacklabs/compare-dashboard-functions), sending requests every 1-3 minutes from three regions.\n\nResponse times exceeding 55 seconds are considered failures and excluded from charts.\n\nAll requests use latest blocks except \"archive\" methods (\u231b), which query historical blocks (1-2 days ago).\n\n\u2139\ufe0f If not specified, the first paid RPC provider plan (named Growth as a rule) is used for monitoring.\n\n&nbsp;\n\n#### How we rank providers\n\nWe evaluate RPC providers based on their **speed** (response time) and **reliability** (success rate) across three regions.\n\n* The **lower** the score, the **better** the provider\n* Even small success rate drops (99% vs 97%) significantly impact the final score\n* Performance is measured equally across all regions\n\n```plaintext\nScore = 1 / ((1/ResponseTime) \u00d7 (SuccessRate\u00b3))\n```",
+        "content": "#### Description\n\nThis dashboard provides real-time and historical performance analytics for RPC nodes across major providers.\n\n* Click region buttons to view metrics from different locations\n* Adjust time range for historical analysis\n* Hover over info icons for detailed metric descriptions\n\n&nbsp;\n\n#### Data collection\n\nResponse times are measured by our Python service on [Vercel serverless functions](https://github.com/chainstacklabs/compare-dashboard-functions), sending requests every 1-3 minutes from three regions.\n\nResponse times exceeding 55 seconds are considered failures and excluded from charts.\n\nAll requests use latest blocks except \"archive\" methods (⌛), which query historical blocks (1-2 days ago).\n\nℹ️ If not specified, the first paid RPC provider plan (named Growth as a rule) is used for monitoring.\n\n&nbsp;\n\n#### How we rank providers\n\nWe evaluate RPC providers based on their **speed** (response time) and **reliability** (success rate) across three regions.\n\n* The **lower** the score, the **better** the provider\n* Even small success rate drops (99% vs 97%) significantly impact the final score\n* Performance is measured equally across all regions\n\n```plaintext\nScore = 1 / ((1/ResponseTime) × (SuccessRate³))\n```",
         "mode": "markdown"
       },
       "pluginVersion": "12.4.0-19938312174",
@@ -97,7 +97,7 @@
       "type": "text"
     },
     {
-      "description": "We evaluate RPC providers based on their speed (response time) and reliability (success rate) across three regions.\n\nScore = 1 / ((1/ResponseTime) \u00d7 (SuccessRate\u00b3))",
+      "description": "We evaluate RPC providers based on their speed (response time) and reliability (success rate) across three regions.\n\nScore = 1 / ((1/ResponseTime) × (SuccessRate³))",
       "gridPos": {
         "h": 1,
         "w": 5,
@@ -656,6 +656,339 @@
         "x": 0,
         "y": 25
       },
+      "id": 72,
+      "title": "Block lag",
+      "type": "row",
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Measures masterchain block sequence number (seqno) from getMasterchainInfo. The tip is the highest seqno seen across all providers at each measurement. Lag = tip − provider seqno. Lag ≤ 2 blocks is treated as at-tip to filter measurement jitter (3-min sampling vs ~0.4s block time).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "blue",
+                "mode": "thresholds"
+              },
+              "decimals": 1,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 80
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 90
+                  },
+                  {
+                    "color": "green",
+                    "value": 99
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 26
+          },
+          "id": 69,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "13.0.0-23605486576",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "100 * (1 - avg_over_time((clamp_min(scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", source_region=\"sin1\", response_status=\"success\"})) - max by (provider) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", source_region=\"sin1\", response_status=\"success\"}), 0) > bool 2)[$__range:$__interval]))",
+              "legendFormat": "{{provider}}",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "% of time at tip",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (≤2 blocks), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Masterchain seqno lag. 0 = at the tip.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 3
+                  },
+                  {
+                    "color": "orange",
+                    "value": 10
+                  },
+                  {
+                    "color": "red",
+                    "value": 20
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 19,
+            "x": 0,
+            "y": 30
+          },
+          "id": 70,
+          "options": {
+            "alignValue": "left",
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.0.0-23605486576",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", source_region=\"sin1\", response_status=\"success\"})) - max by (provider) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", source_region=\"sin1\", response_status=\"success\"})",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Block lag timeline",
+          "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "getMasterchainInfo success rate — the method used for block lag tracking.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "super-light-blue",
+                "mode": "continuous-YlBl"
+              },
+              "decimals": 2,
+              "mappings": [
+                {
+                  "options": {
+                    "from": 0.99991,
+                    "result": {
+                      "index": 0,
+                      "text": "100.0%"
+                    },
+                    "to": 1
+                  },
+                  "type": "range"
+                }
+              ],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 5,
+            "x": 19,
+            "y": 30
+          },
+          "id": 71,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "13.0.0-23605486576",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"sin1\", api_method=\"getMasterchainInfo\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"sin1\", api_method=\"getMasterchainInfo\"}[$__range])) by (provider)",
+              "instant": true,
+              "range": false,
+              "legendFormat": "{{provider}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Success rate",
+          "type": "stat"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
       "id": 7,
       "panels": [
         {
@@ -737,7 +1070,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 24
+            "y": 41
           },
           "id": 3,
           "options": {
@@ -820,7 +1153,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 24
+            "y": 41
           },
           "id": 33,
           "options": {
@@ -946,7 +1279,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 32
+            "y": 49
           },
           "id": 20,
           "options": {
@@ -1029,7 +1362,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 32
+            "y": 49
           },
           "id": 34,
           "options": {
@@ -1155,7 +1488,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 40
+            "y": 57
           },
           "id": 47,
           "options": {
@@ -1238,7 +1571,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 40
+            "y": 57
           },
           "id": 48,
           "options": {
@@ -1364,7 +1697,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 48
+            "y": 65
           },
           "id": 21,
           "options": {
@@ -1400,7 +1733,7 @@
               "refId": "C"
             }
           ],
-          "title": "getBlockHeader \u231b",
+          "title": "getBlockHeader ⌛",
           "type": "timeseries"
         },
         {
@@ -1447,7 +1780,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 48
+            "y": 65
           },
           "id": 35,
           "options": {
@@ -1573,7 +1906,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 56
+            "y": 73
           },
           "id": 49,
           "options": {
@@ -1656,7 +1989,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 56
+            "y": 73
           },
           "id": 50,
           "options": {
@@ -1709,7 +2042,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 43
       },
       "id": 23,
       "panels": [
@@ -1794,7 +2127,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 21
+            "y": 38
           },
           "id": 24,
           "options": {
@@ -1938,7 +2271,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 21
+            "y": 38
           },
           "id": 25,
           "options": {
@@ -2082,7 +2415,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 186
+            "y": 203
           },
           "id": 26,
           "options": {
@@ -2226,7 +2559,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 186
+            "y": 203
           },
           "id": 51,
           "options": {
@@ -2370,7 +2703,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 191
+            "y": 208
           },
           "id": 52,
           "options": {
@@ -2444,7 +2777,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 44
       },
       "id": 63,
       "panels": [
@@ -2529,7 +2862,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 21
+            "y": 38
           },
           "id": 64,
           "options": {
@@ -2673,7 +3006,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 21
+            "y": 38
           },
           "id": 65,
           "options": {
@@ -2817,7 +3150,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 186
+            "y": 203
           },
           "id": 66,
           "options": {
@@ -2961,7 +3294,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 186
+            "y": 203
           },
           "id": 67,
           "options": {
@@ -3105,7 +3438,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 191
+            "y": 208
           },
           "id": 68,
           "options": {
@@ -3179,7 +3512,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 28
+        "y": 45
       },
       "id": 55,
       "panels": [
@@ -3264,7 +3597,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 197
+            "y": 214
           },
           "id": 56,
           "options": {
@@ -3408,7 +3741,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 197
+            "y": 214
           },
           "id": 59,
           "options": {
@@ -3552,7 +3885,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 202
+            "y": 219
           },
           "id": 57,
           "options": {
@@ -3696,7 +4029,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 202
+            "y": 219
           },
           "id": 60,
           "options": {
@@ -3840,7 +4173,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 207
+            "y": 224
           },
           "id": 58,
           "options": {

--- a/dashboards/dashboards/compare-dashboard-ton.json
+++ b/dashboards/dashboards/compare-dashboard-ton.json
@@ -81,7 +81,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "#### Description\n\nThis dashboard provides real-time and historical performance analytics for RPC nodes across major providers.\n\n* Click region buttons to view metrics from different locations\n* Adjust time range for historical analysis\n* Hover over info icons for detailed metric descriptions\n\n&nbsp;\n\n#### Data collection\n\nResponse times are measured by our Python service on [Vercel serverless functions](https://github.com/chainstacklabs/compare-dashboard-functions), sending requests every 1-3 minutes from three regions.\n\nResponse times exceeding 55 seconds are considered failures and excluded from charts.\n\nAll requests use latest blocks except \"archive\" methods (\u231b), which query historical blocks (1-2 days ago).\n\n\u2139\ufe0f If not specified, the first paid RPC provider plan (named Growth as a rule) is used for monitoring.\n\n&nbsp;\n\n#### How we rank providers\n\nWe evaluate RPC providers based on their **speed** (response time) and **reliability** (success rate) across three regions.\n\n* The **lower** the score, the **better** the provider\n* Even small success rate drops (99% vs 97%) significantly impact the final score\n* Performance is measured equally across all regions\n\n```plaintext\nScore = 1 / ((1/ResponseTime) \u00d7 (SuccessRate\u00b3))\n```",
+        "content": "#### Description\n\nThis dashboard provides real-time and historical performance analytics for RPC nodes across major providers.\n\n* Click region buttons to view metrics from different locations\n* Adjust time range for historical analysis\n* Hover over info icons for detailed metric descriptions\n\n&nbsp;\n\n#### Data collection\n\nResponse times are measured by our Python service on [Vercel serverless functions](https://github.com/chainstacklabs/compare-dashboard-functions), sending requests every 1-3 minutes from three regions.\n\nResponse times exceeding 55 seconds are considered failures and excluded from charts.\n\nAll requests use latest blocks except \"archive\" methods (⌛), which query historical blocks (1-2 days ago).\n\nℹ️ If not specified, the first paid RPC provider plan (named Growth as a rule) is used for monitoring.\n\n&nbsp;\n\n#### How we rank providers\n\nWe evaluate RPC providers based on their **speed** (response time) and **reliability** (success rate) across three regions.\n\n* The **lower** the score, the **better** the provider\n* Even small success rate drops (99% vs 97%) significantly impact the final score\n* Performance is measured equally across all regions\n\n```plaintext\nScore = 1 / ((1/ResponseTime) × (SuccessRate³))\n```",
         "mode": "markdown"
       },
       "pluginVersion": "13.0.0-23605486576",
@@ -91,7 +91,7 @@
       "type": "text"
     },
     {
-      "description": "We evaluate RPC providers based on their speed (response time) and reliability (success rate) across three regions.\n\nScore = 1 / ((1/ResponseTime) \u00d7 (SuccessRate\u00b3))",
+      "description": "We evaluate RPC providers based on their speed (response time) and reliability (success rate) across three regions.\n\nScore = 1 / ((1/ResponseTime) × (SuccessRate³))",
       "gridPos": {
         "h": 1,
         "w": 14,
@@ -1201,6 +1201,515 @@
         "x": 0,
         "y": 34
       },
+      "id": 100,
+      "title": "Block lag",
+      "type": "row",
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Measures masterchain block sequence number (seqno) from getMasterchainInfo. The tip is the highest seqno seen across all providers at each measurement. Lag = tip − provider seqno. Lag ≤ 2 blocks is treated as at-tip to filter measurement jitter (3-min sampling vs ~0.4s block time).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "blue",
+                "mode": "thresholds"
+              },
+              "decimals": 1,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 80
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 90
+                  },
+                  {
+                    "color": "green",
+                    "value": 99
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack - fra1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth - EU"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack - sin1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth - SG"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Quicknode-Growth - fra1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Quicknode-Growth - EU"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Quicknode-Growth - sin1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Quicknode-Growth - SG"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "TonCenter-WithAPIKey - fra1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "TonCenter-WithAPIKey - EU"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "TonCenter-WithAPIKey - sin1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "TonCenter-WithAPIKey - SG"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC - fra1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth - EU"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC - sin1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth - SG"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 35
+          },
+          "id": 103,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "13.0.0-23605486576",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "100 * (1 - avg_over_time((clamp_min(scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", response_status=\"success\"})) - max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", response_status=\"success\"}), 0) > bool 2)[$__range:$__interval]))",
+              "legendFormat": "{{provider}} - {{source_region}}",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "% of time at tip",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Each row is a provider-region. Color shows lag severity over time: green = at tip (≤2 blocks), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Masterchain seqno lag. 0 = at the tip.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 3
+                  },
+                  {
+                    "color": "orange",
+                    "value": 10
+                  },
+                  {
+                    "color": "red",
+                    "value": 20
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack - fra1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth - EU"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack - sin1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth - SG"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC - fra1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth - EU"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC - sin1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth - SG"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Quicknode-Growth - fra1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Quicknode-Growth - EU"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Quicknode-Growth - sin1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Quicknode-Growth - SG"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "TonCenter-WithAPIKey - fra1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "TonCenter-WithAPIKey - EU"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "TonCenter-WithAPIKey - sin1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "TonCenter-WithAPIKey - SG"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 19,
+            "x": 0,
+            "y": 39
+          },
+          "id": 111,
+          "options": {
+            "alignValue": "left",
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.0.0-23605486576",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", response_status=\"success\"})) - max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", response_status=\"success\"})",
+              "legendFormat": "{{provider}} - {{source_region}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Block lag timeline",
+          "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "getMasterchainInfo success rate — the method used for block lag tracking. Low success rate means the provider's block lag data is incomplete.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "super-light-blue",
+                "mode": "continuous-YlBl"
+              },
+              "custom": {
+                "align": "left",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "wrapHeaderText": false
+              },
+              "decimals": 2,
+              "mappings": [
+                {
+                  "options": {
+                    "from": 0.99991,
+                    "result": {
+                      "index": 0,
+                      "text": "100.0%"
+                    },
+                    "to": 1
+                  },
+                  "type": "range"
+                }
+              ],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "1"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 70
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 5,
+            "x": 19,
+            "y": 39
+          },
+          "id": 105,
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": false
+          },
+          "pluginVersion": "13.0.0-23605486576",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", api_method=\"getMasterchainInfo\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", api_method=\"getMasterchainInfo\"}[$__range])) by (provider, source_region)",
+              "instant": true,
+              "range": false,
+              "legendFormat": "{{provider}} - {{source_region}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Success rate",
+          "transformations": [
+            {
+              "id": "joinByField",
+              "options": {
+                "byField": "Time",
+                "mode": "outer"
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "includeByName": {},
+                "indexByName": {
+                  "Chainstack - fra1": 1,
+                  "Chainstack - sin1": 2,
+                  "Quicknode-Growth - fra1": 3,
+                  "Quicknode-Growth - sin1": 4,
+                  "TonCenter-WithAPIKey - fra1": 5,
+                  "TonCenter-WithAPIKey - sin1": 6,
+                  "dRPC - fra1": 7,
+                  "dRPC - sin1": 8,
+                  "Time": 0
+                },
+                "renameByName": {
+                  "Chainstack - fra1": "Chainstack-Growth - EU",
+                  "Chainstack - sin1": "Chainstack-Growth - SG",
+                  "Quicknode-Growth - fra1": "Quicknode-Growth - EU",
+                  "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
+                  "TonCenter-WithAPIKey - fra1": "TonCenter-WithAPIKey - EU",
+                  "TonCenter-WithAPIKey - sin1": "TonCenter-WithAPIKey - SG",
+                  "dRPC - fra1": "dRPC-Growth - EU",
+                  "dRPC - sin1": "dRPC-Growth - SG"
+                }
+              }
+            },
+            {
+              "id": "transpose",
+              "options": {}
+            }
+          ],
+          "type": "table"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 57
+      },
       "id": 87,
       "panels": [
         {
@@ -1269,7 +1778,7 @@
             "h": 12,
             "w": 19,
             "x": 0,
-            "y": 35
+            "y": 58
           },
           "id": 3,
           "options": {
@@ -1431,7 +1940,7 @@
             "h": 12,
             "w": 5,
             "x": 19,
-            "y": 35
+            "y": 58
           },
           "id": 83,
           "options": {
@@ -1582,7 +2091,7 @@
             "h": 12,
             "w": 19,
             "x": 0,
-            "y": 47
+            "y": 70
           },
           "id": 71,
           "options": {
@@ -1744,7 +2253,7 @@
             "h": 12,
             "w": 5,
             "x": 19,
-            "y": 47
+            "y": 70
           },
           "id": 72,
           "options": {
@@ -1895,7 +2404,7 @@
             "h": 12,
             "w": 19,
             "x": 0,
-            "y": 59
+            "y": 82
           },
           "id": 73,
           "options": {
@@ -2057,7 +2566,7 @@
             "h": 12,
             "w": 5,
             "x": 19,
-            "y": 59
+            "y": 82
           },
           "id": 74,
           "options": {
@@ -2208,7 +2717,7 @@
             "h": 12,
             "w": 19,
             "x": 0,
-            "y": 71
+            "y": 94
           },
           "id": 75,
           "options": {
@@ -2370,7 +2879,7 @@
             "h": 12,
             "w": 5,
             "x": 19,
-            "y": 71
+            "y": 94
           },
           "id": 76,
           "options": {
@@ -2521,7 +3030,7 @@
             "h": 12,
             "w": 19,
             "x": 0,
-            "y": 83
+            "y": 106
           },
           "id": 77,
           "options": {
@@ -2557,7 +3066,7 @@
               "refId": "C"
             }
           ],
-          "title": "getBlockHeader \u231b",
+          "title": "getBlockHeader ⌛",
           "transformations": [
             {
               "id": "joinByField",
@@ -2679,7 +3188,7 @@
             "h": 12,
             "w": 5,
             "x": 19,
-            "y": 83
+            "y": 106
           },
           "id": 78,
           "options": {


### PR DESCRIPTION
## Summary

- Add "Block lag" collapsible row to TON global, EU, and Singapore dashboards
- **% of time at tip** (stat) — shows how often each provider-region stays within 2 blocks of the chain tip, filtering measurement jitter from 3-min sampling vs ~0.4s block time
- **Block lag timeline** (state-timeline) — color-coded health timeline per provider: green (≤2), yellow (3-10), orange (10-20), red (>20 blocks behind)
- **Success rate** — getMasterchainInfo success rate to reveal providers whose block lag looks good only because failures are invisible
- Lag computed at query time: `scalar(max(seqno)) - provider_seqno` using masterchain seqno

## Test plan

- [x] Panels synced and verified in Grafana (TON global, EU, Singapore)
- [x] PromQL expressions audited for correctness (scalar matching, subquery semantics, edge cases)
- [x] Review panel rendering with different time ranges (1h, 6h, 24h, 7d)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new "Block lag" monitoring section with three panels: "% of time at tip" (metrics), "Block lag timeline" (visualization), and "Success rate" tracking across dashboards.

* **Refactor**
  * Updated dashboard formatting for scoring formulas and symbols; adjusted panel layouts to accommodate new monitoring sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->