### PR TITLE
feat(dashboards): add block lag panels to Solana dashboards

### DIFF
--- a/dashboards/dashboards/compare-dashboard-solana-eu.json
+++ b/dashboards/dashboards/compare-dashboard-solana-eu.json
@@ -89,7 +89,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "#### Description\n\nThis dashboard provides real-time and historical performance analytics for RPC nodes across major providers.\n\n* Click region buttons to view metrics from different locations\n* Adjust time range for historical analysis\n* Hover over info icons for detailed metric descriptions\n\n&nbsp;\n\n#### Data collection\n\nResponse times are measured by our Python service on [Vercel serverless functions](https://github.com/chainstacklabs/compare-dashboard-functions), sending requests every 1-3 minutes from three regions.\n\nResponse times exceeding 55 seconds are considered failures and excluded from charts.\n\nAll requests use latest blocks except \"archive\" methods (\u231b), which query historical blocks (1-2 days ago).\n\n\u2139\ufe0f If not specified, the first paid RPC provider plan (named Growth as a rule) is used for monitoring.\n\n&nbsp;\n\n#### How we rank providers\n\nWe evaluate RPC providers based on their **speed** (response time) and **reliability** (success rate) across three regions.\n\n* The **lower** the score, the **better** the provider\n* Even small success rate drops (99% vs 97%) significantly impact the final score\n* Performance is measured equally across all regions\n\n```plaintext\nScore = 1 / ((1/ResponseTime) \u00d7 (SuccessRate\u00b3))\n```",
+        "content": "#### Description\n\nThis dashboard provides real-time and historical performance analytics for RPC nodes across major providers.\n\n* Click region buttons to view metrics from different locations\n* Adjust time range for historical analysis\n* Hover over info icons for detailed metric descriptions\n\n&nbsp;\n\n#### Data collection\n\nResponse times are measured by our Python service on [Vercel serverless functions](https://github.com/chainstacklabs/compare-dashboard-functions), sending requests every 1-3 minutes from three regions.\n\nResponse times exceeding 55 seconds are considered failures and excluded from charts.\n\nAll requests use latest blocks except \"archive\" methods (⌛), which query historical blocks (1-2 days ago).\n\nℹ️ If not specified, the first paid RPC provider plan (named Growth as a rule) is used for monitoring.\n\n&nbsp;\n\n#### How we rank providers\n\nWe evaluate RPC providers based on their **speed** (response time) and **reliability** (success rate) across three regions.\n\n* The **lower** the score, the **better** the provider\n* Even small success rate drops (99% vs 97%) significantly impact the final score\n* Performance is measured equally across all regions\n\n```plaintext\nScore = 1 / ((1/ResponseTime) × (SuccessRate³))\n```",
         "mode": "markdown"
       },
       "pluginVersion": "12.4.0-19938312174",
@@ -97,7 +97,7 @@
       "type": "text"
     },
     {
-      "description": "We evaluate RPC providers based on their speed (response time) and reliability (success rate) across three regions.\n\nScore = 1 / ((1/ResponseTime) \u00d7 (SuccessRate\u00b3))",
+      "description": "We evaluate RPC providers based on their speed (response time) and reliability (success rate) across three regions.\n\nScore = 1 / ((1/ResponseTime) × (SuccessRate³))",
       "gridPos": {
         "h": 1,
         "w": 5,
@@ -687,6 +687,303 @@
         "x": 0,
         "y": 25
       },
+      "id": 1006,
+      "title": "Block lag",
+      "type": "row",
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Measures slot number from getLatestBlockhash. The tip is the highest slot seen across all providers at each measurement. Lag = tip − provider slot. Lag ≤ 2 slots is treated as at-tip to filter measurement jitter (3-min sampling vs ~0.4s slot time).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "blue",
+                "mode": "thresholds"
+              },
+              "decimals": 1,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 80
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 90
+                  },
+                  {
+                    "color": "green",
+                    "value": 99
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 26
+          },
+          "id": 1007,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "13.0.0-23605486576",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "100 * (1 - avg_over_time((clamp_min(scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", source_region=\"fra1\", response_status=\"success\"})) - max by (provider) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", source_region=\"fra1\", response_status=\"success\"}), 0) > bool 2)[$__range:$__interval]))",
+              "legendFormat": "{{provider}}",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "% of time at tip",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (≤2 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 3
+                  },
+                  {
+                    "color": "orange",
+                    "value": 10
+                  },
+                  {
+                    "color": "red",
+                    "value": 20
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 19,
+            "x": 0,
+            "y": 30
+          },
+          "id": 1008,
+          "options": {
+            "alignValue": "left",
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.0.0-23605486576",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", source_region=\"fra1\", response_status=\"success\"})) - max by (provider) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", source_region=\"fra1\", response_status=\"success\"})",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Block lag timeline",
+          "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "getLatestBlockhash success rate — the method used for block lag tracking.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "super-light-blue",
+                "mode": "continuous-YlBl"
+              },
+              "decimals": 2,
+              "mappings": [
+                {
+                  "options": {
+                    "from": 0.99991,
+                    "result": {
+                      "index": 0,
+                      "text": "100.0%"
+                    },
+                    "to": 1
+                  },
+                  "type": "range"
+                }
+              ],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 5,
+            "x": 19,
+            "y": 30
+          },
+          "id": 1009,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "13.0.0-23605486576",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"fra1\", api_method=\"getLatestBlockhash\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"fra1\", api_method=\"getLatestBlockhash\"}[$__range])) by (provider)",
+              "instant": true,
+              "range": false,
+              "legendFormat": "{{provider}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Success rate",
+          "type": "stat"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
       "id": 7,
       "panels": [
         {
@@ -768,7 +1065,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 24
+            "y": 41
           },
           "id": 3,
           "options": {
@@ -851,7 +1148,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 24
+            "y": 41
           },
           "id": 33,
           "options": {
@@ -977,7 +1274,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 57
+            "y": 74
           },
           "id": 20,
           "options": {
@@ -1060,7 +1357,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 57
+            "y": 74
           },
           "id": 34,
           "options": {
@@ -1186,7 +1483,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 65
+            "y": 82
           },
           "id": 52,
           "options": {
@@ -1269,7 +1566,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 65
+            "y": 82
           },
           "id": 53,
           "options": {
@@ -1395,7 +1692,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 73
+            "y": 90
           },
           "id": 21,
           "options": {
@@ -1478,7 +1775,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 73
+            "y": 90
           },
           "id": 60,
           "options": {
@@ -1604,7 +1901,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 81
+            "y": 98
           },
           "id": 63,
           "options": {
@@ -1687,7 +1984,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 81
+            "y": 98
           },
           "id": 64,
           "options": {
@@ -1813,7 +2110,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 89
+            "y": 106
           },
           "id": 50,
           "options": {
@@ -1849,7 +2146,7 @@
               "refId": "C"
             }
           ],
-          "title": "getBlock \u231b",
+          "title": "getBlock ⌛",
           "type": "timeseries"
         },
         {
@@ -1896,7 +2193,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 89
+            "y": 106
           },
           "id": 51,
           "options": {
@@ -1949,7 +2246,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 43
       },
       "id": 69,
       "panels": [
@@ -2066,7 +2363,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 25
+            "y": 42
           },
           "id": 70,
           "options": {
@@ -2186,7 +2483,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 25
+            "y": 42
           },
           "id": 72,
           "options": {
@@ -2234,7 +2531,7 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 33
+            "y": 50
           },
           "id": 78,
           "options": {
@@ -2304,7 +2601,7 @@
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 34
+            "y": 51
           },
           "id": 83,
           "options": {
@@ -2515,7 +2812,7 @@
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 34
+            "y": 51
           },
           "id": 86,
           "options": {
@@ -2726,7 +3023,7 @@
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 34
+            "y": 51
           },
           "id": 80,
           "options": {
@@ -2936,7 +3233,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 34
+            "y": 51
           },
           "id": 81,
           "options": {
@@ -3147,7 +3444,7 @@
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 42
+            "y": 59
           },
           "id": 79,
           "options": {
@@ -3314,7 +3611,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 44
       },
       "id": 23,
       "panels": [
@@ -3399,7 +3696,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 22
+            "y": 39
           },
           "id": 24,
           "options": {
@@ -3543,7 +3840,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 22
+            "y": 39
           },
           "id": 25,
           "options": {
@@ -3687,7 +3984,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 482
+            "y": 499
           },
           "id": 26,
           "options": {
@@ -3831,7 +4128,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 482
+            "y": 499
           },
           "id": 54,
           "options": {
@@ -3975,7 +4272,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 487
+            "y": 504
           },
           "id": 65,
           "options": {
@@ -4119,7 +4416,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 487
+            "y": 504
           },
           "id": 55,
           "options": {
@@ -4193,7 +4490,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 28
+        "y": 45
       },
       "id": 999,
       "panels": [
@@ -4278,7 +4575,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 22
+            "y": 39
           },
           "id": 1000,
           "options": {
@@ -4422,7 +4719,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 22
+            "y": 39
           },
           "id": 1001,
           "options": {
@@ -4566,7 +4863,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 482
+            "y": 499
           },
           "id": 1002,
           "options": {
@@ -4710,7 +5007,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 482
+            "y": 499
           },
           "id": 1003,
           "options": {
@@ -4854,7 +5151,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 487
+            "y": 504
           },
           "id": 1004,
           "options": {
@@ -4998,7 +5295,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 487
+            "y": 504
           },
           "id": 1005,
           "options": {
@@ -5072,7 +5369,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 29
+        "y": 46
       },
       "id": 43,
       "panels": [
@@ -5157,7 +5454,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 23
+            "y": 40
           },
           "id": 44,
           "options": {
@@ -5301,7 +5598,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 23
+            "y": 40
           },
           "id": 45,
           "options": {
@@ -5445,7 +5742,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 468
+            "y": 485
           },
           "id": 58,
           "options": {
@@ -5589,7 +5886,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 468
+            "y": 485
           },
           "id": 46,
           "options": {
@@ -5733,7 +6030,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 473
+            "y": 490
           },
           "id": 66,
           "options": {
@@ -5877,7 +6174,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 473
+            "y": 490
           },
           "id": 56,
           "options": {
@@ -5951,7 +6248,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 30
+        "y": 47
       },
       "id": 32,
       "panels": [
@@ -6036,7 +6333,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 370
+            "y": 387
           },
           "id": 47,
           "options": {
@@ -6180,7 +6477,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 370
+            "y": 387
           },
           "id": 49,
           "options": {
@@ -6324,7 +6621,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 454
+            "y": 471
           },
           "id": 59,
           "options": {
@@ -6468,7 +6765,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 454
+            "y": 471
           },
           "id": 48,
           "options": {
@@ -6612,7 +6909,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 459
+            "y": 476
           },
           "id": 67,
           "options": {
@@ -6756,7 +7053,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 459
+            "y": 476
           },
           "id": 57,
           "options": {

--- a/dashboards/dashboards/compare-dashboard-solana-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-solana-singapore.json
@@ -89,7 +89,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "#### Description\n\nThis dashboard provides real-time and historical performance analytics for RPC nodes across major providers.\n\n* Click region buttons to view metrics from different locations\n* Adjust time range for historical analysis\n* Hover over info icons for detailed metric descriptions\n\n&nbsp;\n\n#### Data collection\n\nResponse times are measured by our Python service on [Vercel serverless functions](https://github.com/chainstacklabs/compare-dashboard-functions), sending requests every 1-3 minutes from three regions.\n\nResponse times exceeding 55 seconds are considered failures and excluded from charts.\n\nAll requests use latest blocks except \"archive\" methods (\u231b), which query historical blocks (1-2 days ago).\n\n\u2139\ufe0f If not specified, the first paid RPC provider plan (named Growth as a rule) is used for monitoring.\n\n&nbsp;\n\n#### How we rank providers\n\nWe evaluate RPC providers based on their **speed** (response time) and **reliability** (success rate) across three regions.\n\n* The **lower** the score, the **better** the provider\n* Even small success rate drops (99% vs 97%) significantly impact the final score\n* Performance is measured equally across all regions\n\n```plaintext\nScore = 1 / ((1/ResponseTime) \u00d7 (SuccessRate\u00b3))\n```",
+        "content": "#### Description\n\nThis dashboard provides real-time and historical performance analytics for RPC nodes across major providers.\n\n* Click region buttons to view metrics from different locations\n* Adjust time range for historical analysis\n* Hover over info icons for detailed metric descriptions\n\n&nbsp;\n\n#### Data collection\n\nResponse times are measured by our Python service on [Vercel serverless functions](https://github.com/chainstacklabs/compare-dashboard-functions), sending requests every 1-3 minutes from three regions.\n\nResponse times exceeding 55 seconds are considered failures and excluded from charts.\n\nAll requests use latest blocks except \"archive\" methods (⌛), which query historical blocks (1-2 days ago).\n\nℹ️ If not specified, the first paid RPC provider plan (named Growth as a rule) is used for monitoring.\n\n&nbsp;\n\n#### How we rank providers\n\nWe evaluate RPC providers based on their **speed** (response time) and **reliability** (success rate) across three regions.\n\n* The **lower** the score, the **better** the provider\n* Even small success rate drops (99% vs 97%) significantly impact the final score\n* Performance is measured equally across all regions\n\n```plaintext\nScore = 1 / ((1/ResponseTime) × (SuccessRate³))\n```",
         "mode": "markdown"
       },
       "pluginVersion": "12.4.0-19938312174",
@@ -97,7 +97,7 @@
       "type": "text"
     },
     {
-      "description": "We evaluate RPC providers based on their speed (response time) and reliability (success rate) across three regions.\n\nScore = 1 / ((1/ResponseTime) \u00d7 (SuccessRate\u00b3))",
+      "description": "We evaluate RPC providers based on their speed (response time) and reliability (success rate) across three regions.\n\nScore = 1 / ((1/ResponseTime) × (SuccessRate³))",
       "gridPos": {
         "h": 1,
         "w": 5,
@@ -687,6 +687,303 @@
         "x": 0,
         "y": 25
       },
+      "id": 1010,
+      "title": "Block lag",
+      "type": "row",
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Measures slot number from getLatestBlockhash. The tip is the highest slot seen across all providers at each measurement. Lag = tip − provider slot. Lag ≤ 2 slots is treated as at-tip to filter measurement jitter (3-min sampling vs ~0.4s slot time).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "blue",
+                "mode": "thresholds"
+              },
+              "decimals": 1,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 80
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 90
+                  },
+                  {
+                    "color": "green",
+                    "value": 99
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 26
+          },
+          "id": 1011,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "13.0.0-23605486576",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "100 * (1 - avg_over_time((clamp_min(scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", source_region=\"sin1\", response_status=\"success\"})) - max by (provider) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", source_region=\"sin1\", response_status=\"success\"}), 0) > bool 2)[$__range:$__interval]))",
+              "legendFormat": "{{provider}}",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "% of time at tip",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (≤2 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 3
+                  },
+                  {
+                    "color": "orange",
+                    "value": 10
+                  },
+                  {
+                    "color": "red",
+                    "value": 20
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 19,
+            "x": 0,
+            "y": 30
+          },
+          "id": 1012,
+          "options": {
+            "alignValue": "left",
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.0.0-23605486576",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", source_region=\"sin1\", response_status=\"success\"})) - max by (provider) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", source_region=\"sin1\", response_status=\"success\"})",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Block lag timeline",
+          "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "getLatestBlockhash success rate — the method used for block lag tracking.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "super-light-blue",
+                "mode": "continuous-YlBl"
+              },
+              "decimals": 2,
+              "mappings": [
+                {
+                  "options": {
+                    "from": 0.99991,
+                    "result": {
+                      "index": 0,
+                      "text": "100.0%"
+                    },
+                    "to": 1
+                  },
+                  "type": "range"
+                }
+              ],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 5,
+            "x": 19,
+            "y": 30
+          },
+          "id": 1013,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "13.0.0-23605486576",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sin1\", api_method=\"getLatestBlockhash\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sin1\", api_method=\"getLatestBlockhash\"}[$__range])) by (provider)",
+              "instant": true,
+              "range": false,
+              "legendFormat": "{{provider}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Success rate",
+          "type": "stat"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
       "id": 7,
       "panels": [
         {
@@ -768,7 +1065,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 24
+            "y": 41
           },
           "id": 3,
           "options": {
@@ -851,7 +1148,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 24
+            "y": 41
           },
           "id": 33,
           "options": {
@@ -977,7 +1274,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 32
+            "y": 49
           },
           "id": 20,
           "options": {
@@ -1060,7 +1357,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 32
+            "y": 49
           },
           "id": 34,
           "options": {
@@ -1186,7 +1483,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 40
+            "y": 57
           },
           "id": 52,
           "options": {
@@ -1269,7 +1566,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 40
+            "y": 57
           },
           "id": 53,
           "options": {
@@ -1395,7 +1692,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 48
+            "y": 65
           },
           "id": 21,
           "options": {
@@ -1478,7 +1775,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 48
+            "y": 65
           },
           "id": 60,
           "options": {
@@ -1604,7 +1901,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 56
+            "y": 73
           },
           "id": 63,
           "options": {
@@ -1687,7 +1984,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 56
+            "y": 73
           },
           "id": 64,
           "options": {
@@ -1813,7 +2110,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 64
+            "y": 81
           },
           "id": 50,
           "options": {
@@ -1849,7 +2146,7 @@
               "refId": "C"
             }
           ],
-          "title": "getBlock \u231b",
+          "title": "getBlock ⌛",
           "type": "timeseries"
         },
         {
@@ -1896,7 +2193,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 64
+            "y": 81
           },
           "id": 51,
           "options": {
@@ -1949,7 +2246,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 43
       },
       "id": 23,
       "panels": [
@@ -2034,7 +2331,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 21
+            "y": 38
           },
           "id": 24,
           "options": {
@@ -2178,7 +2475,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 21
+            "y": 38
           },
           "id": 25,
           "options": {
@@ -2322,7 +2619,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 287
+            "y": 304
           },
           "id": 26,
           "options": {
@@ -2466,7 +2763,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 287
+            "y": 304
           },
           "id": 54,
           "options": {
@@ -2610,7 +2907,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 292
+            "y": 309
           },
           "id": 65,
           "options": {
@@ -2754,7 +3051,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 292
+            "y": 309
           },
           "id": 55,
           "options": {
@@ -2828,7 +3125,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 44
       },
       "id": 999,
       "panels": [
@@ -2913,7 +3210,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 21
+            "y": 38
           },
           "id": 1000,
           "options": {
@@ -3057,7 +3354,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 21
+            "y": 38
           },
           "id": 1001,
           "options": {
@@ -3201,7 +3498,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 287
+            "y": 304
           },
           "id": 1002,
           "options": {
@@ -3345,7 +3642,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 287
+            "y": 304
           },
           "id": 1003,
           "options": {
@@ -3489,7 +3786,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 292
+            "y": 309
           },
           "id": 1004,
           "options": {
@@ -3633,7 +3930,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 292
+            "y": 309
           },
           "id": 1005,
           "options": {
@@ -3707,7 +4004,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 28
+        "y": 45
       },
       "id": 43,
       "panels": [
@@ -3792,7 +4089,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 22
+            "y": 39
           },
           "id": 44,
           "options": {
@@ -3936,7 +4233,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 22
+            "y": 39
           },
           "id": 45,
           "options": {
@@ -4080,7 +4377,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 273
+            "y": 290
           },
           "id": 58,
           "options": {
@@ -4224,7 +4521,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 273
+            "y": 290
           },
           "id": 46,
           "options": {
@@ -4368,7 +4665,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 278
+            "y": 295
           },
           "id": 66,
           "options": {
@@ -4512,7 +4809,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 278
+            "y": 295
           },
           "id": 56,
           "options": {
@@ -4586,7 +4883,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 29
+        "y": 46
       },
       "id": 32,
       "panels": [
@@ -4671,7 +4968,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 23
+            "y": 40
           },
           "id": 47,
           "options": {
@@ -4815,7 +5112,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 23
+            "y": 40
           },
           "id": 49,
           "options": {
@@ -4959,7 +5256,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 259
+            "y": 276
           },
           "id": 59,
           "options": {
@@ -5103,7 +5400,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 259
+            "y": 276
           },
           "id": 48,
           "options": {
@@ -5247,7 +5544,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 264
+            "y": 281
           },
           "id": 67,
           "options": {
@@ -5391,7 +5688,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 264
+            "y": 281
           },
           "id": 57,
           "options": {

--- a/dashboards/dashboards/compare-dashboard-solana-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-solana-us-west.json
@@ -89,7 +89,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "#### Description\n\nThis dashboard provides real-time and historical performance analytics for RPC nodes across major providers.\n\n* Click region buttons to view metrics from different locations\n* Adjust time range for historical analysis\n* Hover over info icons for detailed metric descriptions\n\n&nbsp;\n\n#### Data collection\n\nResponse times are measured by our Python service on [Vercel serverless functions](https://github.com/chainstacklabs/compare-dashboard-functions), sending requests every 1-3 minutes from three regions.\n\nResponse times exceeding 55 seconds are considered failures and excluded from charts.\n\nAll requests use latest blocks except \"archive\" methods (\u231b), which query historical blocks (1-2 days ago).\n\n\u2139\ufe0f If not specified, the first paid RPC provider plan (named Growth as a rule) is used for monitoring.\n\n&nbsp;\n\n#### How we rank providers\n\nWe evaluate RPC providers based on their **speed** (response time) and **reliability** (success rate) across three regions.\n\n* The **lower** the score, the **better** the provider\n* Even small success rate drops (99% vs 97%) significantly impact the final score\n* Performance is measured equally across all regions\n\n```plaintext\nScore = 1 / ((1/ResponseTime) \u00d7 (SuccessRate\u00b3))\n```",
+        "content": "#### Description\n\nThis dashboard provides real-time and historical performance analytics for RPC nodes across major providers.\n\n* Click region buttons to view metrics from different locations\n* Adjust time range for historical analysis\n* Hover over info icons for detailed metric descriptions\n\n&nbsp;\n\n#### Data collection\n\nResponse times are measured by our Python service on [Vercel serverless functions](https://github.com/chainstacklabs/compare-dashboard-functions), sending requests every 1-3 minutes from three regions.\n\nResponse times exceeding 55 seconds are considered failures and excluded from charts.\n\nAll requests use latest blocks except \"archive\" methods (⌛), which query historical blocks (1-2 days ago).\n\nℹ️ If not specified, the first paid RPC provider plan (named Growth as a rule) is used for monitoring.\n\n&nbsp;\n\n#### How we rank providers\n\nWe evaluate RPC providers based on their **speed** (response time) and **reliability** (success rate) across three regions.\n\n* The **lower** the score, the **better** the provider\n* Even small success rate drops (99% vs 97%) significantly impact the final score\n* Performance is measured equally across all regions\n\n```plaintext\nScore = 1 / ((1/ResponseTime) × (SuccessRate³))\n```",
         "mode": "markdown"
       },
       "pluginVersion": "12.4.0-19938312174",
@@ -97,7 +97,7 @@
       "type": "text"
     },
     {
-      "description": "We evaluate RPC providers based on their speed (response time) and reliability (success rate) across three regions.\n\nScore = 1 / ((1/ResponseTime) \u00d7 (SuccessRate\u00b3))",
+      "description": "We evaluate RPC providers based on their speed (response time) and reliability (success rate) across three regions.\n\nScore = 1 / ((1/ResponseTime) × (SuccessRate³))",
       "gridPos": {
         "h": 1,
         "w": 5,
@@ -688,6 +688,303 @@
         "x": 0,
         "y": 25
       },
+      "id": 1014,
+      "title": "Block lag",
+      "type": "row",
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Measures slot number from getLatestBlockhash. The tip is the highest slot seen across all providers at each measurement. Lag = tip − provider slot. Lag ≤ 2 slots is treated as at-tip to filter measurement jitter (3-min sampling vs ~0.4s slot time).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "blue",
+                "mode": "thresholds"
+              },
+              "decimals": 1,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 80
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 90
+                  },
+                  {
+                    "color": "green",
+                    "value": 99
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 26
+          },
+          "id": 1015,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "13.0.0-23605486576",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "100 * (1 - avg_over_time((clamp_min(scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", source_region=\"sfo1\", response_status=\"success\"})) - max by (provider) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", source_region=\"sfo1\", response_status=\"success\"}), 0) > bool 2)[$__range:$__interval]))",
+              "legendFormat": "{{provider}}",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "% of time at tip",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (≤2 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 3
+                  },
+                  {
+                    "color": "orange",
+                    "value": 10
+                  },
+                  {
+                    "color": "red",
+                    "value": 20
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 19,
+            "x": 0,
+            "y": 30
+          },
+          "id": 1016,
+          "options": {
+            "alignValue": "left",
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.0.0-23605486576",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", source_region=\"sfo1\", response_status=\"success\"})) - max by (provider) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", source_region=\"sfo1\", response_status=\"success\"})",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Block lag timeline",
+          "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "getLatestBlockhash success rate — the method used for block lag tracking.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "super-light-blue",
+                "mode": "continuous-YlBl"
+              },
+              "decimals": 2,
+              "mappings": [
+                {
+                  "options": {
+                    "from": 0.99991,
+                    "result": {
+                      "index": 0,
+                      "text": "100.0%"
+                    },
+                    "to": 1
+                  },
+                  "type": "range"
+                }
+              ],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 5,
+            "x": 19,
+            "y": 30
+          },
+          "id": 1017,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "13.0.0-23605486576",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sfo1\", api_method=\"getLatestBlockhash\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sfo1\", api_method=\"getLatestBlockhash\"}[$__range])) by (provider)",
+              "instant": true,
+              "range": false,
+              "legendFormat": "{{provider}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Success rate",
+          "type": "stat"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
       "id": 7,
       "panels": [
         {
@@ -769,7 +1066,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 24
+            "y": 41
           },
           "id": 3,
           "options": {
@@ -852,7 +1149,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 24
+            "y": 41
           },
           "id": 33,
           "options": {
@@ -978,7 +1275,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 200
+            "y": 217
           },
           "id": 20,
           "options": {
@@ -1061,7 +1358,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 200
+            "y": 217
           },
           "id": 34,
           "options": {
@@ -1187,7 +1484,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 208
+            "y": 225
           },
           "id": 52,
           "options": {
@@ -1270,7 +1567,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 208
+            "y": 225
           },
           "id": 53,
           "options": {
@@ -1396,7 +1693,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 216
+            "y": 233
           },
           "id": 21,
           "options": {
@@ -1479,7 +1776,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 216
+            "y": 233
           },
           "id": 60,
           "options": {
@@ -1605,7 +1902,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 224
+            "y": 241
           },
           "id": 63,
           "options": {
@@ -1688,7 +1985,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 224
+            "y": 241
           },
           "id": 64,
           "options": {
@@ -1814,7 +2111,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 232
+            "y": 249
           },
           "id": 50,
           "options": {
@@ -1850,7 +2147,7 @@
               "refId": "C"
             }
           ],
-          "title": "getBlock \u231b",
+          "title": "getBlock ⌛",
           "type": "timeseries"
         },
         {
@@ -1897,7 +2194,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 232
+            "y": 249
           },
           "id": 51,
           "options": {
@@ -1950,7 +2247,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 43
       },
       "id": 23,
       "panels": [
@@ -2035,7 +2332,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 21
+            "y": 38
           },
           "id": 24,
           "options": {
@@ -2179,7 +2476,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 21
+            "y": 38
           },
           "id": 25,
           "options": {
@@ -2323,7 +2620,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 347
+            "y": 364
           },
           "id": 26,
           "options": {
@@ -2467,7 +2764,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 347
+            "y": 364
           },
           "id": 54,
           "options": {
@@ -2611,7 +2908,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 352
+            "y": 369
           },
           "id": 65,
           "options": {
@@ -2755,7 +3052,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 352
+            "y": 369
           },
           "id": 55,
           "options": {
@@ -2829,7 +3126,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 27
+        "y": 44
       },
       "id": 999,
       "panels": [
@@ -2915,7 +3212,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 26
+            "y": 43
           },
           "id": 1000,
           "options": {
@@ -3060,7 +3357,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 26
+            "y": 43
           },
           "id": 1001,
           "options": {
@@ -3205,7 +3502,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 31
+            "y": 48
           },
           "id": 1002,
           "options": {
@@ -3350,7 +3647,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 31
+            "y": 48
           },
           "id": 1003,
           "options": {
@@ -3495,7 +3792,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 36
+            "y": 53
           },
           "id": 1004,
           "options": {
@@ -3640,7 +3937,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 36
+            "y": 53
           },
           "id": 1005,
           "options": {
@@ -3714,7 +4011,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 28
+        "y": 45
       },
       "id": 43,
       "panels": [
@@ -3799,7 +4096,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 22
+            "y": 39
           },
           "id": 44,
           "options": {
@@ -3943,7 +4240,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 22
+            "y": 39
           },
           "id": 45,
           "options": {
@@ -4087,7 +4384,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 333
+            "y": 350
           },
           "id": 58,
           "options": {
@@ -4231,7 +4528,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 333
+            "y": 350
           },
           "id": 46,
           "options": {
@@ -4375,7 +4672,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 338
+            "y": 355
           },
           "id": 66,
           "options": {
@@ -4519,7 +4816,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 338
+            "y": 355
           },
           "id": 56,
           "options": {
@@ -4593,7 +4890,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 29
+        "y": 46
       },
       "id": 32,
       "panels": [
@@ -4678,7 +4975,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 23
+            "y": 40
           },
           "id": 47,
           "options": {
@@ -4822,7 +5119,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 23
+            "y": 40
           },
           "id": 49,
           "options": {
@@ -4966,7 +5263,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 319
+            "y": 336
           },
           "id": 59,
           "options": {
@@ -5110,7 +5407,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 319
+            "y": 336
           },
           "id": 48,
           "options": {
@@ -5254,7 +5551,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 324
+            "y": 341
           },
           "id": 67,
           "options": {
@@ -5398,7 +5695,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 324
+            "y": 341
           },
           "id": 57,
           "options": {

--- a/dashboards/dashboards/compare-dashboard-solana.json
+++ b/dashboards/dashboards/compare-dashboard-solana.json
@@ -81,7 +81,7 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "#### Description\n\nThis dashboard provides real-time and historical performance analytics for RPC nodes across major providers.\n\n* Click region buttons to view metrics from different locations\n* Adjust time range for historical analysis\n* Hover over info icons for detailed metric descriptions\n\n&nbsp;\n\n#### Data collection\n\nResponse times are measured by our Python service on [Vercel serverless functions](https://github.com/chainstacklabs/compare-dashboard-functions), sending requests every 1-3 minutes from three regions.\n\nResponse times exceeding 55 seconds are considered failures and excluded from charts.\n\nAll requests use latest blocks except \"archive\" methods (\u231b), which query historical blocks (1-2 days ago).\n\n\u2139\ufe0f If not specified, the first paid RPC provider plan (named Growth as a rule) is used for monitoring.\n\n&nbsp;\n\n#### How we rank providers\n\nWe evaluate RPC providers based on their **speed** (response time) and **reliability** (success rate) across three regions.\n\n* The **lower** the score, the **better** the provider\n* Even small success rate drops (99% vs 97%) significantly impact the final score\n* Performance is measured equally across all regions\n\n```plaintext\nScore = 1 / ((1/ResponseTime) \u00d7 (SuccessRate\u00b3))\n```",
+        "content": "#### Description\n\nThis dashboard provides real-time and historical performance analytics for RPC nodes across major providers.\n\n* Click region buttons to view metrics from different locations\n* Adjust time range for historical analysis\n* Hover over info icons for detailed metric descriptions\n\n&nbsp;\n\n#### Data collection\n\nResponse times are measured by our Python service on [Vercel serverless functions](https://github.com/chainstacklabs/compare-dashboard-functions), sending requests every 1-3 minutes from three regions.\n\nResponse times exceeding 55 seconds are considered failures and excluded from charts.\n\nAll requests use latest blocks except \"archive\" methods (⌛), which query historical blocks (1-2 days ago).\n\nℹ️ If not specified, the first paid RPC provider plan (named Growth as a rule) is used for monitoring.\n\n&nbsp;\n\n#### How we rank providers\n\nWe evaluate RPC providers based on their **speed** (response time) and **reliability** (success rate) across three regions.\n\n* The **lower** the score, the **better** the provider\n* Even small success rate drops (99% vs 97%) significantly impact the final score\n* Performance is measured equally across all regions\n\n```plaintext\nScore = 1 / ((1/ResponseTime) × (SuccessRate³))\n```",
         "mode": "markdown"
       },
       "pluginVersion": "13.0.0-23605486576",
@@ -91,7 +91,7 @@
       "type": "text"
     },
     {
-      "description": "We evaluate RPC providers based on their speed (response time) and reliability (success rate) across three regions.\n\nScore = 1 / ((1/ResponseTime) \u00d7 (SuccessRate\u00b3))",
+      "description": "We evaluate RPC providers based on their speed (response time) and reliability (success rate) across three regions.\n\nScore = 1 / ((1/ResponseTime) × (SuccessRate³))",
       "gridPos": {
         "h": 1,
         "w": 14,
@@ -1426,6 +1426,619 @@
         "x": 0,
         "y": 35
       },
+      "id": 113,
+      "title": "Block lag",
+      "type": "row",
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Measures slot number from getLatestBlockhash. The tip is the highest slot seen across all providers at each measurement. Lag = tip − provider slot. Lag ≤ 2 slots is treated as at-tip to filter measurement jitter (3-min sampling vs ~0.4s slot time).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "blue",
+                "mode": "thresholds"
+              },
+              "decimals": 1,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "orange",
+                    "value": 80
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 90
+                  },
+                  {
+                    "color": "green",
+                    "value": 99
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Alchemy-Growth - fra1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Alchemy-Growth - EU"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Alchemy-Growth - sin1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Alchemy-Growth - SG"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Alchemy-Growth - sfo1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Alchemy-Growth - US"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack - fra1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth - EU"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack - sin1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth - SG"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack - sfo1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth - US"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Helius-Developer - fra1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Helius-Developer - EU"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Helius-Developer - sin1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Helius-Developer - SG"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Helius-Developer - sfo1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Helius-Developer - US"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Quicknode-Growth - fra1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Quicknode-Growth - EU"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Quicknode-Growth - sin1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Quicknode-Growth - SG"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Quicknode-Growth - sfo1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Quicknode-Growth - US"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 36
+          },
+          "id": 114,
+          "options": {
+            "colorMode": "value",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "lastNotNull"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "13.0.0-23605486576",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "100 * (1 - avg_over_time((clamp_min(scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", response_status=\"success\"})) - max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", response_status=\"success\"}), 0) > bool 2)[$__range:$__interval]))",
+              "legendFormat": "{{provider}} - {{source_region}}",
+              "instant": true,
+              "refId": "A"
+            }
+          ],
+          "title": "% of time at tip",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Each row is a provider-region. Color shows lag severity over time: green = at tip (≤2 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 3
+                  },
+                  {
+                    "color": "orange",
+                    "value": 10
+                  },
+                  {
+                    "color": "red",
+                    "value": 20
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Alchemy-Growth - fra1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Alchemy-Growth - EU"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Alchemy-Growth - sin1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Alchemy-Growth - SG"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Alchemy-Growth - sfo1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Alchemy-Growth - US"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack - fra1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth - EU"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack - sin1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth - SG"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack - sfo1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth - US"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Helius-Developer - fra1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Helius-Developer - EU"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Helius-Developer - sin1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Helius-Developer - SG"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Helius-Developer - sfo1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Helius-Developer - US"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Quicknode-Growth - fra1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Quicknode-Growth - EU"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Quicknode-Growth - sin1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Quicknode-Growth - SG"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Quicknode-Growth - sfo1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Quicknode-Growth - US"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 19,
+            "x": 0,
+            "y": 40
+          },
+          "id": 115,
+          "options": {
+            "alignValue": "left",
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.0.0-23605486576",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", response_status=\"success\"})) - max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", response_status=\"success\"})",
+              "legendFormat": "{{provider}} - {{source_region}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Block lag timeline",
+          "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "getLatestBlockhash success rate — the method used for block lag tracking. Low success rate means the provider's block lag data is incomplete.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "super-light-blue",
+                "mode": "continuous-YlBl"
+              },
+              "custom": {
+                "align": "left",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "wrapHeaderText": false
+              },
+              "decimals": 2,
+              "mappings": [
+                {
+                  "options": {
+                    "from": 0.99991,
+                    "result": {
+                      "index": 0,
+                      "text": "100.0%"
+                    },
+                    "to": 1
+                  },
+                  "type": "range"
+                }
+              ],
+              "max": 1,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  }
+                ]
+              },
+              "unit": "percentunit"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "1"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 70
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 10,
+            "w": 5,
+            "x": 19,
+            "y": 40
+          },
+          "id": 116,
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": false
+          },
+          "pluginVersion": "13.0.0-23605486576",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", api_method=\"getLatestBlockhash\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", api_method=\"getLatestBlockhash\"}[$__range])) by (provider, source_region)",
+              "instant": true,
+              "range": false,
+              "legendFormat": "{{provider}} - {{source_region}}",
+              "refId": "A"
+            }
+          ],
+          "title": "Success rate",
+          "transformations": [
+            {
+              "id": "joinByField",
+              "options": {
+                "byField": "Time",
+                "mode": "outer"
+              }
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "includeByName": {},
+                "indexByName": {
+                  "Time": 0,
+                  "Alchemy-Growth - fra1": 1,
+                  "Alchemy-Growth - sin1": 2,
+                  "Alchemy-Growth - sfo1": 3,
+                  "Chainstack - fra1": 4,
+                  "Chainstack - sin1": 5,
+                  "Chainstack - sfo1": 6,
+                  "Helius-Developer - fra1": 7,
+                  "Helius-Developer - sin1": 8,
+                  "Helius-Developer - sfo1": 9,
+                  "Quicknode-Growth - fra1": 10,
+                  "Quicknode-Growth - sin1": 11,
+                  "Quicknode-Growth - sfo1": 12
+                },
+                "renameByName": {
+                  "Alchemy-Growth - fra1": "Alchemy-Growth - EU",
+                  "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
+                  "Alchemy-Growth - sfo1": "Alchemy-Growth - US",
+                  "Chainstack - fra1": "Chainstack-Growth - EU",
+                  "Chainstack - sin1": "Chainstack-Growth - SG",
+                  "Chainstack - sfo1": "Chainstack-Growth - US",
+                  "Helius-Developer - fra1": "Helius-Developer - EU",
+                  "Helius-Developer - sin1": "Helius-Developer - SG",
+                  "Helius-Developer - sfo1": "Helius-Developer - US",
+                  "Quicknode-Growth - fra1": "Quicknode-Growth - EU",
+                  "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
+                  "Quicknode-Growth - sfo1": "Quicknode-Growth - US"
+                }
+              }
+            },
+            {
+              "id": "transpose",
+              "options": {}
+            }
+          ],
+          "type": "table"
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 58
+      },
       "id": 111,
       "panels": [
         {
@@ -1508,7 +2121,7 @@
             "h": 14,
             "w": 19,
             "x": 0,
-            "y": 36
+            "y": 59
           },
           "id": 3,
           "options": {
@@ -1669,7 +2282,7 @@
             "h": 14,
             "w": 5,
             "x": 19,
-            "y": 36
+            "y": 59
           },
           "id": 83,
           "options": {
@@ -1837,7 +2450,7 @@
             "h": 14,
             "w": 19,
             "x": 0,
-            "y": 75
+            "y": 98
           },
           "id": 85,
           "options": {
@@ -1998,7 +2611,7 @@
             "h": 14,
             "w": 5,
             "x": 19,
-            "y": 75
+            "y": 98
           },
           "id": 89,
           "options": {
@@ -2166,7 +2779,7 @@
             "h": 14,
             "w": 19,
             "x": 0,
-            "y": 89
+            "y": 112
           },
           "id": 86,
           "options": {
@@ -2327,7 +2940,7 @@
             "h": 14,
             "w": 5,
             "x": 19,
-            "y": 89
+            "y": 112
           },
           "id": 90,
           "options": {
@@ -2495,7 +3108,7 @@
             "h": 14,
             "w": 19,
             "x": 0,
-            "y": 103
+            "y": 126
           },
           "id": 87,
           "options": {
@@ -2658,7 +3271,7 @@
             "h": 14,
             "w": 5,
             "x": 19,
-            "y": 103
+            "y": 126
           },
           "id": 91,
           "options": {
@@ -2826,7 +3439,7 @@
             "h": 14,
             "w": 19,
             "x": 0,
-            "y": 117
+            "y": 140
           },
           "id": 94,
           "options": {
@@ -2987,7 +3600,7 @@
             "h": 14,
             "w": 5,
             "x": 19,
-            "y": 117
+            "y": 140
           },
           "id": 96,
           "options": {
@@ -3155,7 +3768,7 @@
             "h": 14,
             "w": 19,
             "x": 0,
-            "y": 131
+            "y": 154
           },
           "id": 88,
           "options": {
@@ -3191,7 +3804,7 @@
               "refId": "C"
             }
           ],
-          "title": "getBlock \u231b",
+          "title": "getBlock ⌛",
           "transformations": [
             {
               "id": "joinByField",
@@ -3316,7 +3929,7 @@
             "h": 14,
             "w": 5,
             "x": 19,
-            "y": 131
+            "y": 154
           },
           "id": 92,
           "options": {
@@ -3414,7 +4027,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 36
+        "y": 59
       },
       "id": 112,
       "panels": [
@@ -3532,7 +4145,7 @@
             "h": 8,
             "w": 20,
             "x": 0,
-            "y": 37
+            "y": 60
           },
           "id": 101,
           "options": {
@@ -3650,7 +4263,7 @@
             "h": 8,
             "w": 4,
             "x": 20,
-            "y": 37
+            "y": 60
           },
           "id": 102,
           "options": {
@@ -3698,7 +4311,7 @@
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 45
+            "y": 68
           },
           "id": 103,
           "options": {
@@ -3768,7 +4381,7 @@
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 46
+            "y": 69
           },
           "id": 104,
           "options": {
@@ -3979,7 +4592,7 @@
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 46
+            "y": 69
           },
           "id": 105,
           "options": {
@@ -4190,7 +4803,7 @@
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 46
+            "y": 69
           },
           "id": 109,
           "options": {
@@ -4400,7 +5013,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 46
+            "y": 69
           },
           "id": 107,
           "options": {
@@ -4610,7 +5223,7 @@
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 54
+            "y": 77
           },
           "id": 110,
           "options": {
@@ -4823,7 +5436,7 @@
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 54
+            "y": 77
           },
           "id": 108,
           "options": {


### PR DESCRIPTION
## Summary
- Add "Block lag" collapsible row to all 4 Solana dashboards (global, EU, Singapore, US West) with three panels: % of time at tip, block lag timeline, and success rate
- Lag computed from slot numbers captured by `getLatestBlockhash` — same pattern as TON (#63) adapted for Solana's 4 providers × 3 regions
- Global dashboard uses table visualization for success rate (with provider-region breakdown); regional dashboards use stat panels

## Test plan
- [x] Verify block lag panels render correctly on each Solana dashboard in Grafana
- [x] Confirm slot data populates for all providers (Chainstack, Alchemy-Growth, Helius-Developer, Quicknode-Growth)
- [x] Check thresholds display correct colors (green ≤2, yellow 3-10, orange 10-20, red >20)
- [x] Verify success rate panel shows getLatestBlockhash success per provider
- [x] Confirm existing panels (Historical data, Transaction landing, comparison rows) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)