### PR TITLE
fix(dashboards): fix block lag queries and unify panel styles across Solana/TON dashboards

### DIFF
--- a/dashboards/dashboards/compare-dashboard-solana-eu.json
+++ b/dashboards/dashboards/compare-dashboard-solana-eu.json
@@ -688,99 +688,7 @@
         "y": 25
       },
       "id": 1006,
-      "title": "Block lag",
-      "type": "row",
       "panels": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
-          "description": "Measures slot number from getLatestBlockhash. The tip is the highest slot seen across all providers at each measurement. Lag = tip − provider slot. Lag ≤ 2 slots is treated as at-tip to filter measurement jitter (3-min sampling vs ~0.4s slot time).",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "blue",
-                "mode": "thresholds"
-              },
-              "decimals": 1,
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 80
-                  },
-                  {
-                    "color": "yellow",
-                    "value": 90
-                  },
-                  {
-                    "color": "green",
-                    "value": 99
-                  }
-                ]
-              },
-              "unit": "percent"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 24,
-            "x": 0,
-            "y": 26
-          },
-          "id": 1007,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto",
-            "wideLayout": true
-          },
-          "pluginVersion": "13.0.0-23605486576",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "grafanacloud-prom"
-              },
-              "editorMode": "code",
-              "expr": "100 * (1 - avg_over_time((clamp_min(scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", source_region=\"fra1\", response_status=\"success\"})) - max by (provider) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", source_region=\"fra1\", response_status=\"success\"}), 0) > bool 2)[$__range:$__interval]))",
-              "legendFormat": "{{provider}}",
-              "instant": true,
-              "refId": "A"
-            }
-          ],
-          "title": "% of time at tip",
-          "type": "stat"
-        },
         {
           "datasource": {
             "type": "prometheus",
@@ -793,6 +701,7 @@
                 "mode": "thresholds"
               },
               "custom": {
+                "axisPlacement": "auto",
                 "fillOpacity": 80,
                 "hideFrom": {
                   "legend": false,
@@ -809,7 +718,7 @@
                 "steps": [
                   {
                     "color": "green",
-                    "value": null
+                    "value": 0
                   },
                   {
                     "color": "yellow",
@@ -842,14 +751,18 @@
             ]
           },
           "gridPos": {
-            "h": 10,
-            "w": 19,
+            "h": 14,
+            "w": 18,
             "x": 0,
             "y": 30
           },
           "id": 1008,
           "options": {
             "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "displayMode": "list",
               "placement": "bottom",
@@ -859,6 +772,7 @@
             "rowHeight": 0.8,
             "showValue": "never",
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
@@ -885,76 +799,153 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "getLatestBlockhash success rate — the method used for block lag tracking.",
+          "description": "",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "decimals": 2,
-              "mappings": [
-                {
-                  "options": {
-                    "from": 0.99991,
-                    "result": {
-                      "index": 0,
-                      "text": "100.0%"
-                    },
-                    "to": 1
-                  },
-                  "type": "range"
-                }
-              ],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "Chainstack": {
+                            "text": "Chainstack-Growth",
+                            "index": 0
+                          },
+                          "dRPC": {
+                            "text": "dRPC-Growth",
+                            "index": 1
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 108
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "% at Tip"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percent"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": 0
+                        },
+                        {
+                          "color": "orange",
+                          "value": 80
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 90
+                        },
+                        {
+                          "color": "green",
+                          "value": 99
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 85
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "SR"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 68
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 10,
-            "w": 5,
-            "x": 19,
+            "h": 14,
+            "w": 6,
+            "x": 18,
             "y": 30
           },
           "id": 1009,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "% at Tip"
+              }
+            ]
           },
           "pluginVersion": "13.0.0-23605486576",
           "targets": [
@@ -964,17 +955,67 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"fra1\", api_method=\"getLatestBlockhash\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"fra1\", api_method=\"getLatestBlockhash\"}[$__range])) by (provider)",
+              "exemplar": false,
+              "expr": "100 * (1 - avg_over_time((clamp_min(scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", source_region=\"fra1\", response_status=\"success\"})) - max by (provider) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", source_region=\"fra1\", response_status=\"success\"}), 0) > bool 2)[$__range:$__interval]))",
+              "format": "table",
               "instant": true,
-              "range": false,
-              "legendFormat": "{{provider}}",
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"fra1\", response_status=\"success\"} >= 0)[$__range:$__interval])) by (provider)\n/\nsum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"fra1\"} >= 0)[$__range:$__interval])) by (provider)",
+              "format": "table",
+              "instant": true,
+              "refId": "B"
             }
           ],
-          "title": "Success rate",
-          "type": "stat"
+          "title": "Block lag summary",
+          "transformations": [
+            {
+              "id": "merge",
+              "options": {}
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "provider": 0,
+                  "Value #A": 1,
+                  "Value #B": 2
+                },
+                "renameByName": {
+                  "provider": "Provider",
+                  "Value #A": "% at Tip",
+                  "Value #B": "SR"
+                }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": true,
+                    "field": "% at Tip"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "table"
         }
-      ]
+      ],
+      "title": "Block lag",
+      "type": "row"
     },
     {
       "collapsed": true,
@@ -1026,6 +1067,7 @@
                   "type": "log"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -1035,12 +1077,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -1062,16 +1104,19 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 41
           },
           "id": 3,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1112,84 +1157,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 41
           },
           "id": 33,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "11.6.0-82840",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
+              "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"fra1\", api_method=\"simulateTransaction\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"fra1\", api_method=\"simulateTransaction\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1231,6 +1323,7 @@
                   "type": "log"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -1240,16 +1333,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -1271,16 +1360,19 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 74
           },
           "id": 20,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1321,84 +1413,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 74
           },
           "id": 34,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "11.6.0-82840",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
+              "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"fra1\", api_method=\"getBalance\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"fra1\", api_method=\"getBalance\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1440,6 +1579,7 @@
                   "type": "log"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -1449,16 +1589,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -1480,16 +1616,19 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 82
           },
           "id": 52,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1530,84 +1669,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 82
           },
           "id": 53,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "11.6.0-82840",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
+              "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"fra1\", api_method=\"getTransaction\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"fra1\", api_method=\"getTransaction\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1649,6 +1835,7 @@
                   "type": "log"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -1658,16 +1845,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -1689,16 +1872,19 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 90
           },
           "id": 21,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1739,84 +1925,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 90
           },
           "id": 60,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "11.6.0-82840",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
+              "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"fra1\", api_method=\"getLatestBlockhash\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"fra1\", api_method=\"getLatestBlockhash\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1858,6 +2091,7 @@
                   "type": "log"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -1867,16 +2101,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -1898,16 +2128,19 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 98
           },
           "id": 63,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1948,84 +2181,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 98
           },
           "id": 64,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "11.6.0-82840",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
+              "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"fra1\", api_method=\"getProgramAccounts\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"fra1\", api_method=\"getProgramAccounts\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -2067,6 +2347,7 @@
                   "type": "log"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2076,16 +2357,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -2107,16 +2384,19 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 106
           },
           "id": 50,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -2157,84 +2437,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 106
           },
           "id": 51,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "11.6.0-82840",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
+              "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"fra1\", api_method=\"getBlock\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"fra1\", api_method=\"getBlock\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         }
       ],
       "title": "Historical data",
@@ -2259,6 +2586,7 @@
           "fieldConfig": {
             "defaults": {
               "color": {
+                "fixedColor": "super-light-blue",
                 "mode": "palette-classic"
               },
               "custom": {
@@ -2283,12 +2611,13 @@
                   "fill": "solid"
                 },
                 "lineWidth": 1,
-                "pointSize": 5,
+                "pointSize": 2,
                 "scaleDistribution": {
                   "log": 2,
                   "type": "log"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2298,15 +2627,16 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   }
                 ]
-              }
+              },
+              "unit": "s"
             },
             "overrides": [
               {
@@ -2360,16 +2690,24 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 42
           },
           "id": 70,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
-              "calcs": [],
-              "displayMode": "list",
+              "calcs": [
+                "min",
+                "p95",
+                "max"
+              ],
+              "displayMode": "table",
               "placement": "right",
               "showLegend": true,
               "sortBy": "95th %",
@@ -3624,7 +3962,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3650,6 +3990,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3667,7 +4008,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -3769,7 +4111,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3795,6 +4139,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3804,6 +4149,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -3811,7 +4157,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -3913,7 +4260,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3939,6 +4288,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3948,6 +4298,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -3955,7 +4306,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -3984,7 +4336,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 499
+            "y": 44
           },
           "id": 26,
           "options": {
@@ -4057,7 +4409,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -4083,6 +4437,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -4092,6 +4447,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -4099,7 +4455,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -4128,7 +4485,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 499
+            "y": 44
           },
           "id": 54,
           "options": {
@@ -4201,7 +4558,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -4227,6 +4586,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -4236,6 +4596,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -4243,7 +4604,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -4272,7 +4634,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 504
+            "y": 49
           },
           "id": 65,
           "options": {
@@ -4345,7 +4707,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -4371,6 +4735,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -4380,6 +4745,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -4387,7 +4753,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -4416,7 +4783,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 504
+            "y": 49
           },
           "id": 55,
           "options": {
@@ -4503,7 +4870,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -4529,6 +4898,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -4546,7 +4916,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -4648,7 +5019,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -4674,6 +5047,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -4683,6 +5057,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -4690,7 +5065,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -4792,7 +5168,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -4818,6 +5196,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -4827,6 +5206,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -4834,7 +5214,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -4863,7 +5244,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 499
+            "y": 44
           },
           "id": 1002,
           "options": {
@@ -4936,7 +5317,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -4962,6 +5345,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -4971,6 +5355,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -4978,7 +5363,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -5007,7 +5393,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 499
+            "y": 44
           },
           "id": 1003,
           "options": {
@@ -5080,7 +5466,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -5106,6 +5494,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -5115,6 +5504,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -5122,7 +5512,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -5151,7 +5542,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 504
+            "y": 49
           },
           "id": 1004,
           "options": {
@@ -5224,7 +5615,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -5250,6 +5643,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -5259,6 +5653,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -5266,7 +5661,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -5295,7 +5691,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 504
+            "y": 49
           },
           "id": 1005,
           "options": {
@@ -5382,7 +5778,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -5408,6 +5806,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -5425,7 +5824,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -5527,7 +5927,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -5553,6 +5955,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -5562,6 +5965,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -5569,7 +5973,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -5671,7 +6076,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -5697,6 +6104,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -5706,6 +6114,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -5713,7 +6122,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -5742,7 +6152,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 485
+            "y": 45
           },
           "id": 58,
           "options": {
@@ -5815,7 +6225,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -5841,6 +6253,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -5850,6 +6263,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -5857,7 +6271,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -5886,7 +6301,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 485
+            "y": 45
           },
           "id": 46,
           "options": {
@@ -5959,7 +6374,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -5985,6 +6402,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -5994,6 +6412,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -6001,7 +6420,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -6030,7 +6450,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 490
+            "y": 50
           },
           "id": 66,
           "options": {
@@ -6103,7 +6523,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -6129,6 +6551,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -6138,6 +6561,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -6145,7 +6569,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -6174,7 +6599,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 490
+            "y": 50
           },
           "id": 56,
           "options": {
@@ -6261,7 +6686,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -6287,6 +6714,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -6304,7 +6732,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -6406,7 +6835,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -6432,6 +6863,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -6441,6 +6873,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -6448,7 +6881,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -6550,7 +6984,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -6576,6 +7012,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -6585,6 +7022,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -6592,7 +7030,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -6621,7 +7060,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 471
+            "y": 392
           },
           "id": 59,
           "options": {
@@ -6694,7 +7133,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -6720,6 +7161,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -6729,6 +7171,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -6736,7 +7179,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -6765,7 +7209,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 471
+            "y": 392
           },
           "id": 48,
           "options": {
@@ -6838,7 +7282,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -6864,6 +7310,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -6873,6 +7320,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -6880,7 +7328,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -6909,7 +7358,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 476
+            "y": 397
           },
           "id": 67,
           "options": {
@@ -6982,7 +7431,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -7008,6 +7459,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -7017,6 +7469,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -7024,7 +7477,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -7053,7 +7507,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 476
+            "y": 397
           },
           "id": 57,
           "options": {
@@ -7153,6 +7607,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Solana (EU)",
   "uid": "be82wni0bhukgd",
-  "version": 87,
+  "version": 95,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-solana-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-solana-singapore.json
@@ -688,99 +688,7 @@
         "y": 25
       },
       "id": 1010,
-      "title": "Block lag",
-      "type": "row",
       "panels": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
-          "description": "Measures slot number from getLatestBlockhash. The tip is the highest slot seen across all providers at each measurement. Lag = tip − provider slot. Lag ≤ 2 slots is treated as at-tip to filter measurement jitter (3-min sampling vs ~0.4s slot time).",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "blue",
-                "mode": "thresholds"
-              },
-              "decimals": 1,
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 80
-                  },
-                  {
-                    "color": "yellow",
-                    "value": 90
-                  },
-                  {
-                    "color": "green",
-                    "value": 99
-                  }
-                ]
-              },
-              "unit": "percent"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 24,
-            "x": 0,
-            "y": 26
-          },
-          "id": 1011,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto",
-            "wideLayout": true
-          },
-          "pluginVersion": "13.0.0-23605486576",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "grafanacloud-prom"
-              },
-              "editorMode": "code",
-              "expr": "100 * (1 - avg_over_time((clamp_min(scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", source_region=\"sin1\", response_status=\"success\"})) - max by (provider) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", source_region=\"sin1\", response_status=\"success\"}), 0) > bool 2)[$__range:$__interval]))",
-              "legendFormat": "{{provider}}",
-              "instant": true,
-              "refId": "A"
-            }
-          ],
-          "title": "% of time at tip",
-          "type": "stat"
-        },
         {
           "datasource": {
             "type": "prometheus",
@@ -793,6 +701,7 @@
                 "mode": "thresholds"
               },
               "custom": {
+                "axisPlacement": "auto",
                 "fillOpacity": 80,
                 "hideFrom": {
                   "legend": false,
@@ -809,7 +718,7 @@
                 "steps": [
                   {
                     "color": "green",
-                    "value": null
+                    "value": 0
                   },
                   {
                     "color": "yellow",
@@ -842,14 +751,18 @@
             ]
           },
           "gridPos": {
-            "h": 10,
-            "w": 19,
+            "h": 14,
+            "w": 18,
             "x": 0,
             "y": 30
           },
           "id": 1012,
           "options": {
             "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "displayMode": "list",
               "placement": "bottom",
@@ -859,6 +772,7 @@
             "rowHeight": 0.8,
             "showValue": "never",
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
@@ -885,76 +799,153 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "getLatestBlockhash success rate — the method used for block lag tracking.",
+          "description": "",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "decimals": 2,
-              "mappings": [
-                {
-                  "options": {
-                    "from": 0.99991,
-                    "result": {
-                      "index": 0,
-                      "text": "100.0%"
-                    },
-                    "to": 1
-                  },
-                  "type": "range"
-                }
-              ],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "Chainstack": {
+                            "text": "Chainstack-Growth",
+                            "index": 0
+                          },
+                          "dRPC": {
+                            "text": "dRPC-Growth",
+                            "index": 1
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 108
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "% at Tip"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percent"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": 0
+                        },
+                        {
+                          "color": "orange",
+                          "value": 80
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 90
+                        },
+                        {
+                          "color": "green",
+                          "value": 99
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 85
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "SR"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 68
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 10,
-            "w": 5,
-            "x": 19,
+            "h": 14,
+            "w": 6,
+            "x": 18,
             "y": 30
           },
           "id": 1013,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "% at Tip"
+              }
+            ]
           },
           "pluginVersion": "13.0.0-23605486576",
           "targets": [
@@ -964,17 +955,67 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sin1\", api_method=\"getLatestBlockhash\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sin1\", api_method=\"getLatestBlockhash\"}[$__range])) by (provider)",
+              "exemplar": false,
+              "expr": "100 * (1 - avg_over_time((clamp_min(scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", source_region=\"sin1\", response_status=\"success\"})) - max by (provider) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", source_region=\"sin1\", response_status=\"success\"}), 0) > bool 2)[$__range:$__interval]))",
+              "format": "table",
               "instant": true,
-              "range": false,
-              "legendFormat": "{{provider}}",
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sin1\", response_status=\"success\"} >= 0)[$__range:$__interval])) by (provider)\n/\nsum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sin1\"} >= 0)[$__range:$__interval])) by (provider)",
+              "format": "table",
+              "instant": true,
+              "refId": "B"
             }
           ],
-          "title": "Success rate",
-          "type": "stat"
+          "title": "Block lag summary",
+          "transformations": [
+            {
+              "id": "merge",
+              "options": {}
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "provider": 0,
+                  "Value #A": 1,
+                  "Value #B": 2
+                },
+                "renameByName": {
+                  "provider": "Provider",
+                  "Value #A": "% at Tip",
+                  "Value #B": "SR"
+                }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": true,
+                    "field": "% at Tip"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "table"
         }
-      ]
+      ],
+      "title": "Block lag",
+      "type": "row"
     },
     {
       "collapsed": true,
@@ -1026,6 +1067,7 @@
                   "type": "log"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -1035,12 +1077,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -1062,16 +1104,19 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 41
           },
           "id": 3,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1112,84 +1157,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 41
           },
           "id": 33,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.0.0-85518.patch7-85777",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
+              "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sin1\", api_method=\"simulateTransaction\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sin1\", api_method=\"simulateTransaction\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1231,6 +1323,7 @@
                   "type": "log"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -1240,16 +1333,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -1271,16 +1360,19 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 49
           },
           "id": 20,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1321,84 +1413,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 49
           },
           "id": 34,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.0.0-85518.patch7-85777",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
+              "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sin1\", api_method=\"getBalance\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sin1\", api_method=\"getBalance\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1440,6 +1579,7 @@
                   "type": "log"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -1449,16 +1589,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -1480,16 +1616,19 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 57
           },
           "id": 52,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1530,84 +1669,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 57
           },
           "id": 53,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.0.0-85518.patch7-85777",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
+              "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sin1\", api_method=\"getTransaction\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sin1\", api_method=\"getTransaction\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1649,6 +1835,7 @@
                   "type": "log"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -1658,16 +1845,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -1689,16 +1872,19 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 65
           },
           "id": 21,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1739,84 +1925,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 65
           },
           "id": 60,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.0.0-85518.patch7-85777",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
+              "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sin1\", api_method=\"getLatestBlockhash\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sin1\", api_method=\"getLatestBlockhash\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1858,6 +2091,7 @@
                   "type": "log"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -1867,16 +2101,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -1898,16 +2128,19 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 73
           },
           "id": 63,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1948,84 +2181,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 73
           },
           "id": 64,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.0.0-85518.patch7-85777",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
+              "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sin1\", api_method=\"getProgramAccounts\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sin1\", api_method=\"getProgramAccounts\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -2067,6 +2347,7 @@
                   "type": "log"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2076,16 +2357,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -2107,16 +2384,19 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 81
           },
           "id": 50,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -2157,84 +2437,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 81
           },
           "id": 51,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.0.0-85518.patch7-85777",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
+              "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sin1\", api_method=\"getBlock\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sin1\", api_method=\"getBlock\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         }
       ],
       "title": "Historical data",
@@ -2259,7 +2586,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -2285,6 +2614,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2302,7 +2632,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -2404,7 +2735,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -2430,6 +2763,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2439,6 +2773,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -2446,7 +2781,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -2548,7 +2884,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -2574,6 +2912,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2583,6 +2922,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -2590,7 +2930,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -2619,7 +2960,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 304
+            "y": 43
           },
           "id": 26,
           "options": {
@@ -2692,7 +3033,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -2718,6 +3061,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2727,6 +3071,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -2734,7 +3079,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -2763,7 +3109,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 304
+            "y": 43
           },
           "id": 54,
           "options": {
@@ -2836,7 +3182,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -2862,6 +3210,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2871,6 +3220,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -2878,7 +3228,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -2907,7 +3258,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 309
+            "y": 48
           },
           "id": 65,
           "options": {
@@ -2980,7 +3331,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3006,6 +3359,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3015,6 +3369,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -3022,7 +3377,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -3051,7 +3407,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 309
+            "y": 48
           },
           "id": 55,
           "options": {
@@ -3138,7 +3494,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3164,6 +3522,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3181,7 +3540,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -3283,7 +3643,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3309,6 +3671,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3318,6 +3681,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -3325,7 +3689,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -3427,7 +3792,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3453,6 +3820,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3462,6 +3830,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -3469,7 +3838,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -3498,7 +3868,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 304
+            "y": 43
           },
           "id": 1002,
           "options": {
@@ -3571,7 +3941,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3597,6 +3969,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3606,6 +3979,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -3613,7 +3987,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -3642,7 +4017,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 304
+            "y": 43
           },
           "id": 1003,
           "options": {
@@ -3715,7 +4090,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3741,6 +4118,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3750,6 +4128,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -3757,7 +4136,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -3786,7 +4166,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 309
+            "y": 48
           },
           "id": 1004,
           "options": {
@@ -3859,7 +4239,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3885,6 +4267,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3894,6 +4277,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -3901,7 +4285,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -3930,7 +4315,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 309
+            "y": 48
           },
           "id": 1005,
           "options": {
@@ -4017,7 +4402,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -4043,6 +4430,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -4060,7 +4448,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -4162,7 +4551,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -4188,6 +4579,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -4197,6 +4589,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -4204,7 +4597,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -4306,7 +4700,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -4332,6 +4728,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -4341,6 +4738,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -4348,7 +4746,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -4377,7 +4776,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 290
+            "y": 44
           },
           "id": 58,
           "options": {
@@ -4450,7 +4849,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -4476,6 +4877,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -4485,6 +4887,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -4492,7 +4895,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -4521,7 +4925,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 290
+            "y": 44
           },
           "id": 46,
           "options": {
@@ -4594,7 +4998,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -4620,6 +5026,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -4629,6 +5036,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -4636,7 +5044,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -4665,7 +5074,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 295
+            "y": 49
           },
           "id": 66,
           "options": {
@@ -4738,7 +5147,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -4764,6 +5175,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -4773,6 +5185,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -4780,7 +5193,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -4809,7 +5223,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 295
+            "y": 49
           },
           "id": 56,
           "options": {
@@ -4896,7 +5310,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -4922,6 +5338,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -4939,7 +5356,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -5041,7 +5459,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -5067,6 +5487,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -5076,6 +5497,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -5083,7 +5505,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -5185,7 +5608,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -5211,6 +5636,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -5220,6 +5646,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -5227,7 +5654,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -5256,7 +5684,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 276
+            "y": 45
           },
           "id": 59,
           "options": {
@@ -5329,7 +5757,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -5355,6 +5785,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -5364,6 +5795,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -5371,7 +5803,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -5400,7 +5833,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 276
+            "y": 45
           },
           "id": 48,
           "options": {
@@ -5473,7 +5906,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -5499,6 +5934,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -5508,6 +5944,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -5515,7 +5952,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -5544,7 +5982,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 281
+            "y": 50
           },
           "id": 67,
           "options": {
@@ -5617,7 +6055,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -5643,6 +6083,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -5652,6 +6093,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -5659,7 +6101,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -5688,7 +6131,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 281
+            "y": 50
           },
           "id": 57,
           "options": {
@@ -5788,6 +6231,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Solana (Singapore)",
   "uid": "ae82yw1vzdfr4d",
-  "version": 66,
+  "version": 74,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-solana-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-solana-us-west.json
@@ -689,99 +689,7 @@
         "y": 25
       },
       "id": 1014,
-      "title": "Block lag",
-      "type": "row",
       "panels": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
-          "description": "Measures slot number from getLatestBlockhash. The tip is the highest slot seen across all providers at each measurement. Lag = tip − provider slot. Lag ≤ 2 slots is treated as at-tip to filter measurement jitter (3-min sampling vs ~0.4s slot time).",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "blue",
-                "mode": "thresholds"
-              },
-              "decimals": 1,
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 80
-                  },
-                  {
-                    "color": "yellow",
-                    "value": 90
-                  },
-                  {
-                    "color": "green",
-                    "value": 99
-                  }
-                ]
-              },
-              "unit": "percent"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 24,
-            "x": 0,
-            "y": 26
-          },
-          "id": 1015,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto",
-            "wideLayout": true
-          },
-          "pluginVersion": "13.0.0-23605486576",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "grafanacloud-prom"
-              },
-              "editorMode": "code",
-              "expr": "100 * (1 - avg_over_time((clamp_min(scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", source_region=\"sfo1\", response_status=\"success\"})) - max by (provider) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", source_region=\"sfo1\", response_status=\"success\"}), 0) > bool 2)[$__range:$__interval]))",
-              "legendFormat": "{{provider}}",
-              "instant": true,
-              "refId": "A"
-            }
-          ],
-          "title": "% of time at tip",
-          "type": "stat"
-        },
         {
           "datasource": {
             "type": "prometheus",
@@ -794,6 +702,7 @@
                 "mode": "thresholds"
               },
               "custom": {
+                "axisPlacement": "auto",
                 "fillOpacity": 80,
                 "hideFrom": {
                   "legend": false,
@@ -810,7 +719,7 @@
                 "steps": [
                   {
                     "color": "green",
-                    "value": null
+                    "value": 0
                   },
                   {
                     "color": "yellow",
@@ -843,14 +752,18 @@
             ]
           },
           "gridPos": {
-            "h": 10,
-            "w": 19,
+            "h": 14,
+            "w": 18,
             "x": 0,
             "y": 30
           },
           "id": 1016,
           "options": {
             "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "displayMode": "list",
               "placement": "bottom",
@@ -860,6 +773,7 @@
             "rowHeight": 0.8,
             "showValue": "never",
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
@@ -886,76 +800,153 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "getLatestBlockhash success rate — the method used for block lag tracking.",
+          "description": "",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "decimals": 2,
-              "mappings": [
-                {
-                  "options": {
-                    "from": 0.99991,
-                    "result": {
-                      "index": 0,
-                      "text": "100.0%"
-                    },
-                    "to": 1
-                  },
-                  "type": "range"
-                }
-              ],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "Chainstack": {
+                            "text": "Chainstack-Growth",
+                            "index": 0
+                          },
+                          "dRPC": {
+                            "text": "dRPC-Growth",
+                            "index": 1
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 108
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "% at Tip"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percent"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": 0
+                        },
+                        {
+                          "color": "orange",
+                          "value": 80
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 90
+                        },
+                        {
+                          "color": "green",
+                          "value": 99
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 85
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "SR"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 68
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 10,
-            "w": 5,
-            "x": 19,
+            "h": 14,
+            "w": 6,
+            "x": 18,
             "y": 30
           },
           "id": 1017,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "% at Tip"
+              }
+            ]
           },
           "pluginVersion": "13.0.0-23605486576",
           "targets": [
@@ -965,17 +956,67 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sfo1\", api_method=\"getLatestBlockhash\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sfo1\", api_method=\"getLatestBlockhash\"}[$__range])) by (provider)",
+              "exemplar": false,
+              "expr": "100 * (1 - avg_over_time((clamp_min(scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", source_region=\"sfo1\", response_status=\"success\"})) - max by (provider) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", source_region=\"sfo1\", response_status=\"success\"}), 0) > bool 2)[$__range:$__interval]))",
+              "format": "table",
               "instant": true,
-              "range": false,
-              "legendFormat": "{{provider}}",
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sfo1\", response_status=\"success\"} >= 0)[$__range:$__interval])) by (provider)\n/\nsum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sfo1\"} >= 0)[$__range:$__interval])) by (provider)",
+              "format": "table",
+              "instant": true,
+              "refId": "B"
             }
           ],
-          "title": "Success rate",
-          "type": "stat"
+          "title": "Block lag summary",
+          "transformations": [
+            {
+              "id": "merge",
+              "options": {}
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "provider": 0,
+                  "Value #A": 1,
+                  "Value #B": 2
+                },
+                "renameByName": {
+                  "provider": "Provider",
+                  "Value #A": "% at Tip",
+                  "Value #B": "SR"
+                }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": true,
+                    "field": "% at Tip"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "table"
         }
-      ]
+      ],
+      "title": "Block lag",
+      "type": "row"
     },
     {
       "collapsed": true,
@@ -1027,6 +1068,7 @@
                   "type": "log"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -1036,12 +1078,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -1063,16 +1105,19 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 41
           },
           "id": 3,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1113,84 +1158,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 41
           },
           "id": 33,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "11.6.0-82840",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
+              "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sfo1\", api_method=\"simulateTransaction\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sfo1\", api_method=\"simulateTransaction\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1232,6 +1324,7 @@
                   "type": "log"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -1241,16 +1334,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -1272,16 +1361,19 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 217
           },
           "id": 20,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1322,84 +1414,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 217
           },
           "id": 34,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "11.6.0-82840",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
+              "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sfo1\", api_method=\"getBalance\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sfo1\", api_method=\"getBalance\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1441,6 +1580,7 @@
                   "type": "log"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -1450,16 +1590,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -1481,16 +1617,19 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 225
           },
           "id": 52,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1531,84 +1670,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 225
           },
           "id": 53,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "11.6.0-82840",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
+              "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sfo1\", api_method=\"getTransaction\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sfo1\", api_method=\"getTransaction\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1650,6 +1836,7 @@
                   "type": "log"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -1659,16 +1846,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -1690,16 +1873,19 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 233
           },
           "id": 21,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1740,84 +1926,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 233
           },
           "id": 60,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "11.6.0-82840",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
+              "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sfo1\", api_method=\"getLatestBlockhash\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sfo1\", api_method=\"getLatestBlockhash\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1859,6 +2092,7 @@
                   "type": "log"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -1868,16 +2102,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -1899,16 +2129,19 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 241
           },
           "id": 63,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1949,84 +2182,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 241
           },
           "id": 64,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "11.6.0-82840",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
+              "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sfo1\", api_method=\"getProgramAccounts\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sfo1\", api_method=\"getProgramAccounts\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -2068,6 +2348,7 @@
                   "type": "log"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2077,16 +2358,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -2108,16 +2385,19 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 249
           },
           "id": 50,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -2158,84 +2438,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 249
           },
           "id": 51,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "11.6.0-82840",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
+              "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sfo1\", api_method=\"getBlock\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sfo1\", api_method=\"getBlock\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         }
       ],
       "title": "Historical data",
@@ -2260,7 +2587,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -2286,6 +2615,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2303,7 +2633,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -2405,7 +2736,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -2431,6 +2764,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2440,6 +2774,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -2447,7 +2782,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -2549,7 +2885,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -2575,6 +2913,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2584,6 +2923,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -2591,7 +2931,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -2620,7 +2961,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 364
+            "y": 43
           },
           "id": 26,
           "options": {
@@ -2693,7 +3034,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -2719,6 +3062,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2728,6 +3072,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -2735,7 +3080,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -2764,7 +3110,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 364
+            "y": 43
           },
           "id": 54,
           "options": {
@@ -2837,7 +3183,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -2863,6 +3211,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2872,6 +3221,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -2879,7 +3229,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -2908,7 +3259,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 369
+            "y": 48
           },
           "id": 65,
           "options": {
@@ -2981,7 +3332,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3007,6 +3360,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3016,6 +3370,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -3023,7 +3378,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -3052,7 +3408,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 369
+            "y": 48
           },
           "id": 55,
           "options": {
@@ -3139,7 +3495,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3165,6 +3523,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3285,7 +3644,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3311,6 +3672,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3320,6 +3682,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -3430,7 +3793,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3456,6 +3821,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3465,6 +3831,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -3575,7 +3942,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3601,6 +3970,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3610,6 +3980,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -3720,7 +4091,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3746,6 +4119,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3755,6 +4129,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -3865,7 +4240,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3891,6 +4268,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3900,6 +4278,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -4024,7 +4403,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -4050,6 +4431,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -4067,7 +4449,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -4169,7 +4552,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -4195,6 +4580,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -4204,6 +4590,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -4211,7 +4598,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -4313,7 +4701,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -4339,6 +4729,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -4348,6 +4739,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -4355,7 +4747,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -4384,7 +4777,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 350
+            "y": 44
           },
           "id": 58,
           "options": {
@@ -4457,7 +4850,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -4483,6 +4878,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -4492,6 +4888,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -4499,7 +4896,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -4528,7 +4926,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 350
+            "y": 44
           },
           "id": 46,
           "options": {
@@ -4601,7 +4999,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -4627,6 +5027,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -4636,6 +5037,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -4643,7 +5045,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -4672,7 +5075,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 355
+            "y": 49
           },
           "id": 66,
           "options": {
@@ -4745,7 +5148,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -4771,6 +5176,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -4780,6 +5186,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -4787,7 +5194,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -4816,7 +5224,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 355
+            "y": 49
           },
           "id": 56,
           "options": {
@@ -4903,7 +5311,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -4929,6 +5339,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -4946,7 +5357,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -5048,7 +5460,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -5074,6 +5488,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -5083,6 +5498,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -5090,7 +5506,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -5192,7 +5609,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -5218,6 +5637,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -5227,6 +5647,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -5234,7 +5655,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -5263,7 +5685,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 336
+            "y": 45
           },
           "id": 59,
           "options": {
@@ -5336,7 +5758,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -5362,6 +5786,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -5371,6 +5796,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -5378,7 +5804,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -5407,7 +5834,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 336
+            "y": 45
           },
           "id": 48,
           "options": {
@@ -5480,7 +5907,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -5506,6 +5935,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -5515,6 +5945,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -5522,7 +5953,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -5551,7 +5983,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 341
+            "y": 50
           },
           "id": 67,
           "options": {
@@ -5624,7 +6056,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -5650,6 +6084,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -5659,6 +6094,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -5666,7 +6102,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -5695,7 +6132,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 341
+            "y": 50
           },
           "id": 57,
           "options": {
@@ -5795,6 +6232,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Solana (US West)",
   "uid": "de82ypwiibsowe",
-  "version": 69,
+  "version": 77,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-solana.json
+++ b/dashboards/dashboards/compare-dashboard-solana.json
@@ -38,7 +38,7 @@
         "content": "<div style=\"display: inline-flex; align-items: center; margin: 5px; height: 70px;\">\n    <!-- Image Link -->\n    <a href=\"https://chainstack.com/\" target=\"_blank\" style=\"margin-right: 25px; display: inline-block;\">\n        <img src=\"https://chainstack.com/wp-content/themes/chainstack/img/press-kit-logo-white-text.svg\" alt=\"chainstack_logo\" style=\"max-width: 150px; height: auto; display: block;\">\n    </a>\n    \n    <!-- Text Links with Highlight on the First Link -->\n    <a href=\"https://chainstack.grafana.net/public-dashboards/65c0fcb02f994faf845d4ec095771bd0\" target=\"_self\" \n    style=\"text-decoration: none; color: #007bff; font-weight: bold; margin-right: 15px; padding: 5px 10px; border-radius: 5px;\">\n        Ethereum\n    </a>\n    <a href=\"https://chainstack.grafana.net/public-dashboards/b8f98de094e84c17becb38a1b318e2f2\" target=\"_self\" \n    style=\"text-decoration: none; color: #007bff; font-weight: bold; margin-right: 15px; padding: 5px 10px; border-radius: 5px;\">\n        Arbitrum\n    </a>\n    <a href=\"https://chainstack.grafana.net/public-dashboards/11861148d82247128307025fac628b6e\" target=\"_self\" \n    style=\"text-decoration: none; color: #007bff; font-weight: bold; margin-right: 15px; padding: 5px 10px; border-radius: 5px;\">\n        Base\n    </a>\n    <a href=\"https://chainstack.grafana.net/public-dashboards/059a680a502a4d8782e93fcc1f2f1be9\" target=\"_self\" \n    style=\"text-decoration: none; color: #007bff; font-weight: bold; margin-right: 15px; padding: 5px 10px; border-radius: 5px;\">\n        BNB\n    </a>\n    <a href=\"https://chainstack.grafana.net/public-dashboards/5f957bbcc3ae4c9d8d9669a299a24676\" target=\"_self\" \n    style=\"text-decoration: none; color: #007bff; font-weight: bold; margin-right: 15px; padding: 5px 10px; border-radius: 5px;\">\n        Hyperliquid\n    </a>\n    <a href=\"https://chainstack.grafana.net/public-dashboards/ae4e8ccc089b460f95d5d2f29dd0d022\" target=\"_self\" \n    style=\"text-decoration: none; color: #007bff; font-weight: bold; margin-right: 15px; padding: 5px 10px; border-radius: 5px;\">\n        Monad\n    </a>\n    <a href=\"https://chainstack.grafana.net/public-dashboards/254601572d9a4b7a90122e46248f82b0\" target=\"_self\" \n    style=\"text-decoration: none; color: #007bff; font-weight: bold; margin-right: 15px; padding: 5px 10px; border-radius: 5px; \n       background-color: #e0f7fa; border: 1px solid #007bff;\">\n        Solana\n    </a>\n    <a href=\"https://chainstack.grafana.net/public-dashboards/deeaf524ea264f42a12718f675511b13\" target=\"_self\" \n       style=\"text-decoration: none; color: #007bff; font-weight: bold; margin-right: 15px; padding: 5px 10px; border-radius: 5px;\">\n        TON\n    </a>\n</div>\n\n",
         "mode": "html"
       },
-      "pluginVersion": "13.0.0-23605486576",
+      "pluginVersion": "13.1.0-24455754975",
       "targets": [],
       "title": "",
       "transparent": true,
@@ -61,7 +61,7 @@
         "content": "<div style=\"display: inline-flex; align-items: center; margin: 5px; height: 70px;\">\n    <a href=\"https://chainstack.grafana.net/public-dashboards/254601572d9a4b7a90122e46248f82b0\" target=\"_self\" \n       style=\"text-decoration: none; color: #6c757d; font-weight: bold; margin-right: 15px; padding: 5px 10px; border-radius: 5px; \n       background-color: #f8f9fa; border: 1px solid #dee2e6;\">\n        Global\n    </a>\n    <a href=\"https://chainstack.grafana.net/public-dashboards/ca292eb9006541389b119061260e6bc8\" target=\"_self\" \n       style=\"text-decoration: none; color: #6c757d; font-weight: bold; margin-right: 15px; padding: 5px 10px; border-radius: 5px;\">\n        US West\n    </a>\n    <a href=\"https://chainstack.grafana.net/public-dashboards/47f9dafa230148bf95aaa1d82f5f518b\" target=\"_self\" \n       style=\"text-decoration: none; color: #6c757d; font-weight: bold; margin-right: 15px; padding: 5px 10px; border-radius: 5px;\">\n        EU\n    </a>\n    <a href=\"https://chainstack.grafana.net/public-dashboards/93d0717a742149bcabb2038a722c9a8d\" target=\"_self\" \n       style=\"text-decoration: none; color: #6c757d; font-weight: bold; margin-right: 15px; padding: 5px 10px; border-radius: 5px;\">\n        Asia\n    </a>\n</div>",
         "mode": "html"
       },
-      "pluginVersion": "13.0.0-23605486576",
+      "pluginVersion": "13.1.0-24455754975",
       "targets": [],
       "title": "",
       "transparent": true,
@@ -81,17 +81,17 @@
           "showLineNumbers": false,
           "showMiniMap": false
         },
-        "content": "#### Description\n\nThis dashboard provides real-time and historical performance analytics for RPC nodes across major providers.\n\n* Click region buttons to view metrics from different locations\n* Adjust time range for historical analysis\n* Hover over info icons for detailed metric descriptions\n\n&nbsp;\n\n#### Data collection\n\nResponse times are measured by our Python service on [Vercel serverless functions](https://github.com/chainstacklabs/compare-dashboard-functions), sending requests every 1-3 minutes from three regions.\n\nResponse times exceeding 55 seconds are considered failures and excluded from charts.\n\nAll requests use latest blocks except \"archive\" methods (⌛), which query historical blocks (1-2 days ago).\n\nℹ️ If not specified, the first paid RPC provider plan (named Growth as a rule) is used for monitoring.\n\n&nbsp;\n\n#### How we rank providers\n\nWe evaluate RPC providers based on their **speed** (response time) and **reliability** (success rate) across three regions.\n\n* The **lower** the score, the **better** the provider\n* Even small success rate drops (99% vs 97%) significantly impact the final score\n* Performance is measured equally across all regions\n\n```plaintext\nScore = 1 / ((1/ResponseTime) × (SuccessRate³))\n```",
+        "content": "#### Description\n\nThis dashboard provides real-time and historical performance analytics for RPC nodes across major providers.\n\n* Click region buttons to view metrics from different locations\n* Adjust time range for historical analysis\n* Hover over info icons for detailed metric descriptions\n\n&nbsp;\n\n#### Data collection\n\nResponse times are measured by our Python service on [Vercel serverless functions](https://github.com/chainstacklabs/compare-dashboard-functions), sending requests every 1-3 minutes from three regions.\n\nResponse times exceeding 55 seconds are considered failures and excluded from charts.\n\nAll requests use latest blocks except \"archive\" methods (\u231b), which query historical blocks (1-2 days ago).\n\n\u2139\ufe0f If not specified, the first paid RPC provider plan (named Growth as a rule) is used for monitoring.\n\n&nbsp;\n\n#### How we rank providers\n\nWe evaluate RPC providers based on their **speed** (response time) and **reliability** (success rate) across three regions.\n\n* The **lower** the score, the **better** the provider\n* Even small success rate drops (99% vs 97%) significantly impact the final score\n* Performance is measured equally across all regions\n\n```plaintext\nScore = 1 / ((1/ResponseTime) \u00d7 (SuccessRate\u00b3))\n```",
         "mode": "markdown"
       },
-      "pluginVersion": "13.0.0-23605486576",
+      "pluginVersion": "13.1.0-24455754975",
       "targets": [],
       "title": "",
       "transparent": true,
       "type": "text"
     },
     {
-      "description": "We evaluate RPC providers based on their speed (response time) and reliability (success rate) across three regions.\n\nScore = 1 / ((1/ResponseTime) × (SuccessRate³))",
+      "description": "We evaluate RPC providers based on their speed (response time) and reliability (success rate) across three regions.\n\nScore = 1 / ((1/ResponseTime) \u00d7 (SuccessRate\u00b3))",
       "gridPos": {
         "h": 1,
         "w": 14,
@@ -108,7 +108,7 @@
         "content": "",
         "mode": "markdown"
       },
-      "pluginVersion": "13.0.0-23605486576",
+      "pluginVersion": "13.1.0-24455754975",
       "targets": [],
       "title": "Provider score (lower is better)",
       "transparent": true,
@@ -196,7 +196,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "13.0.0-23605486576",
+      "pluginVersion": "13.1.0-24455754975",
       "targets": [
         {
           "datasource": {
@@ -233,7 +233,7 @@
         "content": "",
         "mode": "markdown"
       },
-      "pluginVersion": "13.0.0-23605486576",
+      "pluginVersion": "13.1.0-24455754975",
       "targets": [],
       "title": "What is the p95 response time and overall success rate?",
       "transparent": true,
@@ -271,6 +271,7 @@
               "mode": "off"
             }
           },
+          "max": 2,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -368,7 +369,7 @@
         "xTickLabelRotation": 0,
         "xTickLabelSpacing": 100
       },
-      "pluginVersion": "13.0.0-23605486576",
+      "pluginVersion": "13.1.0-24455754975",
       "targets": [
         {
           "datasource": {
@@ -491,19 +492,83 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "1"
+              "options": "Provider"
             },
             "properties": [
               {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "Chainstack": {
+                        "index": 0,
+                        "text": "Chainstack-Growth"
+                      },
+                      "dRPC": {
+                        "index": 1,
+                        "text": "dRPC-Growth"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              },
+              {
                 "id": "custom.width",
                 "value": 120
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Region"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "fra1": {
+                        "index": 0,
+                        "text": "EU"
+                      },
+                      "sfo1": {
+                        "index": 2,
+                        "text": "US West"
+                      },
+                      "sin1": {
+                        "index": 1,
+                        "text": "SG"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
               },
+              {
+                "id": "custom.width",
+                "value": 80
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SR"
+            },
+            "properties": [
               {
                 "id": "custom.cellOptions",
                 "value": {
                   "mode": "basic",
                   "type": "gauge"
                 }
+              },
+              {
+                "id": "custom.width",
+                "value": 120
               }
             ]
           }
@@ -520,7 +585,7 @@
         "cellHeight": "sm",
         "showHeader": false
       },
-      "pluginVersion": "13.0.0-23605486576",
+      "pluginVersion": "13.1.0-24455754975",
       "targets": [
         {
           "datasource": {
@@ -531,13 +596,11 @@
           "editorMode": "code",
           "exemplar": false,
           "expr": "sum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", response_status=\"success\"} >= 0)[$__range:$__interval])) by (provider, source_region)\r\n/\r\nsum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\"} >= 0)[$__range:$__interval])) by (provider, source_region)",
-          "format": "time_series",
+          "format": "table",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": true,
           "interval": "",
-          "legendFormat": "{{provider}} - {{source_region}}",
-          "range": false,
           "refId": "A",
           "useBackend": false
         }
@@ -545,59 +608,22 @@
       "title": "Success rate",
       "transformations": [
         {
-          "id": "joinByField",
-          "options": {
-            "byField": "Time",
-            "mode": "outer"
-          }
-        },
-        {
           "id": "organize",
           "options": {
             "excludeByName": {
               "Time": true
             },
-            "includeByName": {},
             "indexByName": {
-              "Alchemy-Growth - fra1": 1,
-              "Alchemy-Growth - sfo1": 3,
-              "Alchemy-Growth - sin1": 2,
-              "Chainstack - fra1": 4,
-              "Chainstack - sfo1": 6,
-              "Chainstack - sin1": 5,
-              "Helius-Developer - fra1": 7,
-              "Helius-Developer - sfo1": 9,
-              "Helius-Developer - sin1": 8,
-              "Quicknode-Growth - fra1": 10,
-              "Quicknode-Growth - sfo1": 12,
-              "Quicknode-Growth - sin1": 11,
-              "Time": 0,
-              "dRPC - fra1": 13,
-              "dRPC - sfo1": 15,
-              "dRPC - sin1": 14
+              "Value": 2,
+              "provider": 0,
+              "source_region": 1
             },
             "renameByName": {
-              "Alchemy-Growth - fra1": "Alchemy-Growth - EU",
-              "Alchemy-Growth - sfo1": "Alchemy-Growth - US West",
-              "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
-              "Chainstack - fra1": "Chainstack-Growth - EU",
-              "Chainstack - sfo1": "Chainstack-Growth - US West",
-              "Chainstack - sin1": "Chainstack-Growth - SG",
-              "Helius-Developer - fra1": "Helius-Developer - EU",
-              "Helius-Developer - sfo1": "Helius-Developer - US West",
-              "Helius-Developer - sin1": "Helius-Developer - SG",
-              "Quicknode-Growth - fra1": "Quicknode-Growth - EU",
-              "Quicknode-Growth - sfo1": "Quicknode-Growth - US West",
-              "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
-              "dRPC - fra1": "dRPC-Growth - EU",
-              "dRPC - sfo1": "dRPC-Growth - US West",
-              "dRPC - sin1": "dRPC-Growth - SG"
+              "Value": "SR",
+              "provider": "Provider",
+              "source_region": "Region"
             }
           }
-        },
-        {
-          "id": "transpose",
-          "options": {}
         }
       ],
       "type": "table"
@@ -634,6 +660,7 @@
               "mode": "off"
             }
           },
+          "max": 2,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -731,7 +758,7 @@
         "xTickLabelRotation": 0,
         "xTickLabelSpacing": 100
       },
-      "pluginVersion": "13.0.0-23605486576",
+      "pluginVersion": "13.1.0-24455754975",
       "targets": [
         {
           "datasource": {
@@ -817,7 +844,7 @@
         "content": "",
         "mode": "markdown"
       },
-      "pluginVersion": "13.0.0-23605486576",
+      "pluginVersion": "13.1.0-24455754975",
       "targets": [],
       "title": "What is the p95 response time in each region?",
       "transparent": true,
@@ -940,7 +967,7 @@
         "xTickLabelRotation": 0,
         "xTickLabelSpacing": 100
       },
-      "pluginVersion": "13.0.0-23605486576",
+      "pluginVersion": "13.1.0-24455754975",
       "targets": [
         {
           "datasource": {
@@ -1153,7 +1180,7 @@
         "xTickLabelRotation": 0,
         "xTickLabelSpacing": 100
       },
-      "pluginVersion": "13.0.0-23605486576",
+      "pluginVersion": "13.1.0-24455754975",
       "targets": [
         {
           "datasource": {
@@ -1281,6 +1308,7 @@
               "mode": "off"
             }
           },
+          "max": 2,
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -1322,7 +1350,7 @@
         "xTickLabelRotation": 0,
         "xTickLabelSpacing": 100
       },
-      "pluginVersion": "13.0.0-23605486576",
+      "pluginVersion": "13.1.0-24455754975",
       "targets": [
         {
           "datasource": {
@@ -1426,244 +1454,21 @@
         "x": 0,
         "y": 35
       },
-      "id": 113,
-      "title": "Block lag",
-      "type": "row",
+      "id": 117,
       "panels": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Measures slot number from getLatestBlockhash. The tip is the highest slot seen across all providers at each measurement. Lag = tip − provider slot. Lag ≤ 2 slots is treated as at-tip to filter measurement jitter (3-min sampling vs ~0.4s slot time).",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "blue",
-                "mode": "thresholds"
-              },
-              "decimals": 1,
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 80
-                  },
-                  {
-                    "color": "yellow",
-                    "value": 90
-                  },
-                  {
-                    "color": "green",
-                    "value": 99
-                  }
-                ]
-              },
-              "unit": "percent"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Alchemy-Growth - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Alchemy-Growth - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Alchemy-Growth - sin1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Alchemy-Growth - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Alchemy-Growth - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Alchemy-Growth - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack - sin1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Helius-Developer - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Helius-Developer - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Helius-Developer - sin1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Helius-Developer - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Helius-Developer - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Helius-Developer - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Quicknode-Growth - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Quicknode-Growth - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Quicknode-Growth - sin1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Quicknode-Growth - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Quicknode-Growth - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Quicknode-Growth - US"
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 24,
-            "x": 0,
-            "y": 36
-          },
-          "id": 114,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto",
-            "wideLayout": true
-          },
-          "pluginVersion": "13.0.0-23605486576",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "grafanacloud-prom"
-              },
-              "editorMode": "code",
-              "expr": "100 * (1 - avg_over_time((clamp_min(scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", response_status=\"success\"})) - max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", response_status=\"success\"}), 0) > bool 2)[$__range:$__interval]))",
-              "legendFormat": "{{provider}} - {{source_region}}",
-              "instant": true,
-              "refId": "A"
-            }
-          ],
-          "title": "% of time at tip",
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
-          "description": "Each row is a provider-region. Color shows lag severity over time: green = at tip (≤2 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip.",
+          "description": "Each row is a provider-region. Lag is relative to the best provider in the same region. Color shows severity: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20).",
           "fieldConfig": {
             "defaults": {
               "color": {
                 "mode": "thresholds"
               },
               "custom": {
+                "axisPlacement": "auto",
                 "fillOpacity": 80,
                 "hideFrom": {
                   "legend": false,
@@ -1680,7 +1485,7 @@
                 "steps": [
                   {
                     "color": "green",
-                    "value": null
+                    "value": 0
                   },
                   {
                     "color": "yellow",
@@ -1841,18 +1646,58 @@
                     "value": "Quicknode-Growth - US"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC - fra1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth - EU"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC - sin1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth - SG"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC - sfo1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth - US"
+                  }
+                ]
               }
             ]
           },
           "gridPos": {
-            "h": 10,
-            "w": 19,
+            "h": 14,
+            "w": 18,
             "x": 0,
-            "y": 40
+            "y": 36
           },
           "id": 115,
           "options": {
             "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "displayMode": "list",
               "placement": "bottom",
@@ -1862,11 +1707,12 @@
             "rowHeight": 0.8,
             "showValue": "never",
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "13.0.0-23605486576",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1874,7 +1720,7 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", response_status=\"success\"})) - max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", response_status=\"success\"})",
+              "expr": "-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", response_status=\"success\"}))",
               "legendFormat": "{{provider}} - {{source_region}}",
               "range": true,
               "refId": "A"
@@ -1888,15 +1734,11 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "getLatestBlockhash success rate — the method used for block lag tracking. Low success rate means the provider's block lag data is incomplete.",
+          "description": "Block lag tracking summary. % at Tip = percentage of time slot lag \u2264 2 (tip is best provider in same region). Success Rate = getLatestBlockhash reliability.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
-              },
               "custom": {
-                "align": "left",
+                "align": "auto",
                 "cellOptions": {
                   "type": "auto"
                 },
@@ -1904,62 +1746,177 @@
                   "reducers": []
                 },
                 "inspect": false,
-                "wrapHeaderText": false
+                "minWidth": 110
               },
-              "decimals": 2,
-              "mappings": [
-                {
-                  "options": {
-                    "from": 0.99991,
-                    "result": {
-                      "index": 0,
-                      "text": "100.0%"
-                    },
-                    "to": 1
-                  },
-                  "type": "range"
-                }
-              ],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "1"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
                     "id": "custom.width",
-                    "value": 70
+                    "value": 108
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Region"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "fra1": {
+                            "index": 0,
+                            "text": "EU"
+                          },
+                          "sfo1": {
+                            "index": 2,
+                            "text": "US"
+                          },
+                          "sin1": {
+                            "index": 1,
+                            "text": "SG"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 60
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "% at Tip"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percent"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": 0
+                        },
+                        {
+                          "color": "orange",
+                          "value": 80
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 90
+                        },
+                        {
+                          "color": "green",
+                          "value": 99
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 85
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "SR"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 68
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 10,
-            "w": 5,
-            "x": 19,
-            "y": 40
+            "h": 14,
+            "w": 6,
+            "x": 18,
+            "y": 36
           },
           "id": 116,
           "options": {
             "cellHeight": "sm",
-            "showHeader": false
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "% at Tip"
+              }
+            ]
           },
-          "pluginVersion": "13.0.0-23605486576",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1968,21 +1925,29 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", api_method=\"getLatestBlockhash\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", api_method=\"getLatestBlockhash\"}[$__range])) by (provider, source_region)",
+              "expr": "100 * (1 - avg_over_time((clamp_min(-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", response_status=\"success\"})), 0) > bool 2)[$__range:$__interval]))",
+              "format": "table",
               "instant": true,
-              "range": false,
-              "legendFormat": "{{provider}} - {{source_region}}",
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", response_status=\"success\"} >= 0)[$__range:$__interval])) by (provider, source_region)\n/\nsum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\"} >= 0)[$__range:$__interval])) by (provider, source_region)",
+              "format": "table",
+              "instant": true,
+              "refId": "B"
             }
           ],
-          "title": "Success rate",
+          "title": "Block lag summary",
           "transformations": [
             {
-              "id": "joinByField",
-              "options": {
-                "byField": "Time",
-                "mode": "outer"
-              }
+              "id": "merge",
+              "options": {}
             },
             {
               "id": "organize",
@@ -1990,46 +1955,38 @@
                 "excludeByName": {
                   "Time": true
                 },
-                "includeByName": {},
                 "indexByName": {
-                  "Time": 0,
-                  "Alchemy-Growth - fra1": 1,
-                  "Alchemy-Growth - sin1": 2,
-                  "Alchemy-Growth - sfo1": 3,
-                  "Chainstack - fra1": 4,
-                  "Chainstack - sin1": 5,
-                  "Chainstack - sfo1": 6,
-                  "Helius-Developer - fra1": 7,
-                  "Helius-Developer - sin1": 8,
-                  "Helius-Developer - sfo1": 9,
-                  "Quicknode-Growth - fra1": 10,
-                  "Quicknode-Growth - sin1": 11,
-                  "Quicknode-Growth - sfo1": 12
+                  "Value #A": 2,
+                  "Value #B": 3,
+                  "provider": 0,
+                  "source_region": 1
                 },
                 "renameByName": {
-                  "Alchemy-Growth - fra1": "Alchemy-Growth - EU",
-                  "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
-                  "Alchemy-Growth - sfo1": "Alchemy-Growth - US",
-                  "Chainstack - fra1": "Chainstack-Growth - EU",
-                  "Chainstack - sin1": "Chainstack-Growth - SG",
-                  "Chainstack - sfo1": "Chainstack-Growth - US",
-                  "Helius-Developer - fra1": "Helius-Developer - EU",
-                  "Helius-Developer - sin1": "Helius-Developer - SG",
-                  "Helius-Developer - sfo1": "Helius-Developer - US",
-                  "Quicknode-Growth - fra1": "Quicknode-Growth - EU",
-                  "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
-                  "Quicknode-Growth - sfo1": "Quicknode-Growth - US"
+                  "Value #A": "% at Tip",
+                  "Value #B": "SR",
+                  "provider": "Provider",
+                  "source_region": "Region"
                 }
               }
             },
             {
-              "id": "transpose",
-              "options": {}
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": true,
+                    "field": "% at Tip"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
         }
-      ]
+      ],
+      "title": "Block lag",
+      "type": "row"
     },
     {
       "collapsed": true,
@@ -2037,9 +1994,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 58
+        "y": 36
       },
-      "id": 111,
+      "id": 118,
       "panels": [
         {
           "datasource": {
@@ -2118,16 +2075,19 @@
             ]
           },
           "gridPos": {
-            "h": 14,
-            "w": 19,
+            "h": 12,
+            "w": 18,
             "x": 0,
-            "y": 59
+            "y": 37
           },
           "id": 3,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -2143,7 +2103,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -2221,12 +2181,8 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
-              },
               "custom": {
-                "align": "left",
+                "align": "auto",
                 "cellOptions": {
                   "type": "auto"
                 },
@@ -2234,138 +2190,155 @@
                   "reducers": []
                 },
                 "inspect": false,
-                "wrapHeaderText": false
+                "minWidth": 110
               },
-              "decimals": 0,
-              "mappings": [
-                {
-                  "options": {
-                    "from": 0.99991,
-                    "result": {
-                      "index": 0,
-                      "text": "100.0%"
-                    },
-                    "to": 1
-                  },
-                  "type": "range"
-                }
-              ],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "1"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
                     "id": "custom.width",
-                    "value": 70
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Region"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "fra1": {
+                            "index": 0,
+                            "text": "EU"
+                          },
+                          "sfo1": {
+                            "index": 2,
+                            "text": "US"
+                          },
+                          "sin1": {
+                            "index": 1,
+                            "text": "SG"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 72
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 14,
-            "w": 5,
-            "x": 19,
-            "y": 59
+            "h": 12,
+            "w": 6,
+            "x": 18,
+            "y": 37
           },
           "id": 83,
           "options": {
             "cellHeight": "sm",
-            "showHeader": false
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", api_method=\"simulateTransaction\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", api_method=\"simulateTransaction\"}[$__range])) by (provider, source_region)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
+              "format": "table",
               "instant": true,
-              "interval": "",
-              "legendFormat": "{{provider}} - {{source_region}}",
-              "range": false,
-              "refId": "A",
-              "useBackend": false
+              "refId": "A"
             }
           ],
           "title": "Success rate",
           "transformations": [
-            {
-              "id": "joinByField",
-              "options": {
-                "byField": "Time",
-                "mode": "outer"
-              }
-            },
             {
               "id": "organize",
               "options": {
                 "excludeByName": {
                   "Time": true
                 },
-                "includeByName": {},
                 "indexByName": {
-                  "Alchemy-Growth - fra1": 1,
-                  "Alchemy-Growth - sfo1": 3,
-                  "Alchemy-Growth - sin1": 2,
-                  "Chainstack - fra1": 4,
-                  "Chainstack - sfo1": 6,
-                  "Chainstack - sin1": 5,
-                  "Helius-Developer - fra1": 10,
-                  "Helius-Developer - sfo1": 12,
-                  "Helius-Developer - sin1": 11,
-                  "Quicknode-Growth - fra1": 7,
-                  "Quicknode-Growth - sfo1": 9,
-                  "Quicknode-Growth - sin1": 8,
-                  "Time": 0,
-                  "dRPC - fra1": 13,
-                  "dRPC - sfo1": 15,
-                  "dRPC - sin1": 14
+                  "Value": 2,
+                  "provider": 0,
+                  "source_region": 1
                 },
                 "renameByName": {
-                  "Alchemy-Growth - fra1": "Alchemy-Growth - EU",
-                  "Alchemy-Growth - sfo1": "Alchemy-Growth - US West",
-                  "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
-                  "Chainstack - fra1": "Chainstack-Growth - EU",
-                  "Chainstack - sfo1": "Chainstack-Growth - US West",
-                  "Chainstack - sin1": "Chainstack-Growth - SG",
-                  "Helius-Developer - fra1": "Helius-Developer - EU",
-                  "Helius-Developer - sfo1": "Helius-Developer - US West",
-                  "Helius-Developer - sin1": "Helius-Developer - SG",
-                  "Quicknode-Growth - fra1": "Quicknode-Growth - EU",
-                  "Quicknode-Growth - sfo1": "Quicknode-Growth - US West",
-                  "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
-                  "dRPC - fra1": "dRPC-Growth - EU",
-                  "dRPC - sfo1": "dRPC-Growth - US West",
-                  "dRPC - sin1": "dRPC-Growth - SG"
+                  "Value": "Success Rate",
+                  "provider": "Provider",
+                  "source_region": "Region"
                 }
               }
-            },
-            {
-              "id": "transpose",
-              "options": {}
             }
           ],
           "type": "table"
@@ -2447,16 +2420,19 @@
             ]
           },
           "gridPos": {
-            "h": 14,
-            "w": 19,
+            "h": 12,
+            "w": 18,
             "x": 0,
-            "y": 98
+            "y": 49
           },
           "id": 85,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -2472,7 +2448,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -2550,12 +2526,8 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
-              },
               "custom": {
-                "align": "left",
+                "align": "auto",
                 "cellOptions": {
                   "type": "auto"
                 },
@@ -2563,138 +2535,155 @@
                   "reducers": []
                 },
                 "inspect": false,
-                "wrapHeaderText": false
+                "minWidth": 110
               },
-              "decimals": 2,
-              "mappings": [
-                {
-                  "options": {
-                    "from": 0.99991,
-                    "result": {
-                      "index": 0,
-                      "text": "100.0%"
-                    },
-                    "to": 1
-                  },
-                  "type": "range"
-                }
-              ],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "1"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
                     "id": "custom.width",
-                    "value": 70
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Region"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "fra1": {
+                            "index": 0,
+                            "text": "EU"
+                          },
+                          "sfo1": {
+                            "index": 2,
+                            "text": "US"
+                          },
+                          "sin1": {
+                            "index": 1,
+                            "text": "SG"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 72
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 14,
-            "w": 5,
-            "x": 19,
-            "y": 98
+            "h": 12,
+            "w": 6,
+            "x": 18,
+            "y": 49
           },
           "id": 89,
           "options": {
             "cellHeight": "sm",
-            "showHeader": false
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", api_method=\"getBalance\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", api_method=\"getBalance\"}[$__range])) by (provider, source_region)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
+              "format": "table",
               "instant": true,
-              "interval": "",
-              "legendFormat": "{{provider}} - {{source_region}}",
-              "range": false,
-              "refId": "A",
-              "useBackend": false
+              "refId": "A"
             }
           ],
           "title": "Success rate",
           "transformations": [
-            {
-              "id": "joinByField",
-              "options": {
-                "byField": "Time",
-                "mode": "outer"
-              }
-            },
             {
               "id": "organize",
               "options": {
                 "excludeByName": {
                   "Time": true
                 },
-                "includeByName": {},
                 "indexByName": {
-                  "Alchemy-Growth - fra1": 1,
-                  "Alchemy-Growth - sfo1": 3,
-                  "Alchemy-Growth - sin1": 2,
-                  "Chainstack - fra1": 4,
-                  "Chainstack - sfo1": 6,
-                  "Chainstack - sin1": 5,
-                  "Helius-Developer - fra1": 10,
-                  "Helius-Developer - sfo1": 12,
-                  "Helius-Developer - sin1": 11,
-                  "Quicknode-Growth - fra1": 7,
-                  "Quicknode-Growth - sfo1": 9,
-                  "Quicknode-Growth - sin1": 8,
-                  "Time": 0,
-                  "dRPC - fra1": 13,
-                  "dRPC - sfo1": 15,
-                  "dRPC - sin1": 14
+                  "Value": 2,
+                  "provider": 0,
+                  "source_region": 1
                 },
                 "renameByName": {
-                  "Alchemy-Growth - fra1": "Alchemy-Growth - EU",
-                  "Alchemy-Growth - sfo1": "Alchemy-Growth - US West",
-                  "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
-                  "Chainstack - fra1": "Chainstack-Growth - EU",
-                  "Chainstack - sfo1": "Chainstack-Growth - US West",
-                  "Chainstack - sin1": "Chainstack-Growth - SG",
-                  "Helius-Developer - fra1": "Helius-Developer - EU",
-                  "Helius-Developer - sfo1": "Helius-Developer - US West",
-                  "Helius-Developer - sin1": "Helius-Developer - SG",
-                  "Quicknode-Growth - fra1": "Quicknode-Growth - EU",
-                  "Quicknode-Growth - sfo1": "Quicknode-Growth - US West",
-                  "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
-                  "dRPC - fra1": "dRPC-Growth - EU",
-                  "dRPC - sfo1": "dRPC-Growth - US West",
-                  "dRPC - sin1": "dRPC-Growth - SG"
+                  "Value": "Success Rate",
+                  "provider": "Provider",
+                  "source_region": "Region"
                 }
               }
-            },
-            {
-              "id": "transpose",
-              "options": {}
             }
           ],
           "type": "table"
@@ -2776,16 +2765,19 @@
             ]
           },
           "gridPos": {
-            "h": 14,
-            "w": 19,
+            "h": 12,
+            "w": 18,
             "x": 0,
-            "y": 112
+            "y": 61
           },
           "id": 86,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -2801,7 +2793,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -2879,12 +2871,8 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
-              },
               "custom": {
-                "align": "left",
+                "align": "auto",
                 "cellOptions": {
                   "type": "auto"
                 },
@@ -2892,138 +2880,155 @@
                   "reducers": []
                 },
                 "inspect": false,
-                "wrapHeaderText": false
+                "minWidth": 110
               },
-              "decimals": 2,
-              "mappings": [
-                {
-                  "options": {
-                    "from": 0.99991,
-                    "result": {
-                      "index": 0,
-                      "text": "100.0%"
-                    },
-                    "to": 1
-                  },
-                  "type": "range"
-                }
-              ],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "1"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
                     "id": "custom.width",
-                    "value": 70
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Region"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "fra1": {
+                            "index": 0,
+                            "text": "EU"
+                          },
+                          "sfo1": {
+                            "index": 2,
+                            "text": "US"
+                          },
+                          "sin1": {
+                            "index": 1,
+                            "text": "SG"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 72
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 14,
-            "w": 5,
-            "x": 19,
-            "y": 112
+            "h": 12,
+            "w": 6,
+            "x": 18,
+            "y": 61
           },
           "id": 90,
           "options": {
             "cellHeight": "sm",
-            "showHeader": false
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", api_method=\"getTransaction\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", api_method=\"getTransaction\"}[$__range])) by (provider, source_region)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
+              "format": "table",
               "instant": true,
-              "interval": "",
-              "legendFormat": "{{provider}} - {{source_region}}",
-              "range": false,
-              "refId": "A",
-              "useBackend": false
+              "refId": "A"
             }
           ],
           "title": "Success rate",
           "transformations": [
-            {
-              "id": "joinByField",
-              "options": {
-                "byField": "Time",
-                "mode": "outer"
-              }
-            },
             {
               "id": "organize",
               "options": {
                 "excludeByName": {
                   "Time": true
                 },
-                "includeByName": {},
                 "indexByName": {
-                  "Alchemy-Growth - fra1": 1,
-                  "Alchemy-Growth - sfo1": 3,
-                  "Alchemy-Growth - sin1": 2,
-                  "Chainstack - fra1": 4,
-                  "Chainstack - sfo1": 6,
-                  "Chainstack - sin1": 5,
-                  "Helius-Developer - fra1": 10,
-                  "Helius-Developer - sfo1": 12,
-                  "Helius-Developer - sin1": 11,
-                  "Quicknode-Growth - fra1": 7,
-                  "Quicknode-Growth - sfo1": 9,
-                  "Quicknode-Growth - sin1": 8,
-                  "Time": 0,
-                  "dRPC - fra1": 13,
-                  "dRPC - sfo1": 15,
-                  "dRPC - sin1": 14
+                  "Value": 2,
+                  "provider": 0,
+                  "source_region": 1
                 },
                 "renameByName": {
-                  "Alchemy-Growth - fra1": "Alchemy-Growth - EU",
-                  "Alchemy-Growth - sfo1": "Alchemy-Growth - US West",
-                  "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
-                  "Chainstack - fra1": "Chainstack-Growth - EU",
-                  "Chainstack - sfo1": "Chainstack-Growth - US West",
-                  "Chainstack - sin1": "Chainstack-Growth - SG",
-                  "Helius-Developer - fra1": "Helius-Developer - EU",
-                  "Helius-Developer - sfo1": "Helius-Developer - US West",
-                  "Helius-Developer - sin1": "Helius-Developer - SG",
-                  "Quicknode-Growth - fra1": "Quicknode-Growth - EU",
-                  "Quicknode-Growth - sfo1": "Quicknode-Growth - US West",
-                  "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
-                  "dRPC - fra1": "dRPC-Growth - EU",
-                  "dRPC - sfo1": "dRPC-Growth - US West",
-                  "dRPC - sin1": "dRPC-Growth - SG"
+                  "Value": "Success Rate",
+                  "provider": "Provider",
+                  "source_region": "Region"
                 }
               }
-            },
-            {
-              "id": "transpose",
-              "options": {}
             }
           ],
           "type": "table"
@@ -3105,16 +3110,19 @@
             ]
           },
           "gridPos": {
-            "h": 14,
-            "w": 19,
+            "h": 12,
+            "w": 18,
             "x": 0,
-            "y": 126
+            "y": 73
           },
           "id": 87,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -3130,7 +3138,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -3210,12 +3218,8 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
-              },
               "custom": {
-                "align": "left",
+                "align": "auto",
                 "cellOptions": {
                   "type": "auto"
                 },
@@ -3223,138 +3227,155 @@
                   "reducers": []
                 },
                 "inspect": false,
-                "wrapHeaderText": false
+                "minWidth": 110
               },
-              "decimals": 1,
-              "mappings": [
-                {
-                  "options": {
-                    "from": 0.99991,
-                    "result": {
-                      "index": 0,
-                      "text": "100.0%"
-                    },
-                    "to": 1
-                  },
-                  "type": "range"
-                }
-              ],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "1"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
                     "id": "custom.width",
-                    "value": 70
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Region"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "fra1": {
+                            "index": 0,
+                            "text": "EU"
+                          },
+                          "sfo1": {
+                            "index": 2,
+                            "text": "US"
+                          },
+                          "sin1": {
+                            "index": 1,
+                            "text": "SG"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 72
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 14,
-            "w": 5,
-            "x": 19,
-            "y": 126
+            "h": 12,
+            "w": 6,
+            "x": 18,
+            "y": 73
           },
           "id": 91,
           "options": {
             "cellHeight": "sm",
-            "showHeader": false
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", api_method=\"getLatestBlockhash\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", api_method=\"getLatestBlockhash\"}[$__range])) by (provider, source_region)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
+              "format": "table",
               "instant": true,
-              "interval": "",
-              "legendFormat": "{{provider}} - {{source_region}}",
-              "range": false,
-              "refId": "A",
-              "useBackend": false
+              "refId": "A"
             }
           ],
           "title": "Success rate",
           "transformations": [
-            {
-              "id": "joinByField",
-              "options": {
-                "byField": "Time",
-                "mode": "outer"
-              }
-            },
             {
               "id": "organize",
               "options": {
                 "excludeByName": {
                   "Time": true
                 },
-                "includeByName": {},
                 "indexByName": {
-                  "Alchemy-Growth - fra1": 1,
-                  "Alchemy-Growth - sfo1": 3,
-                  "Alchemy-Growth - sin1": 2,
-                  "Chainstack - fra1": 4,
-                  "Chainstack - sfo1": 6,
-                  "Chainstack - sin1": 5,
-                  "Helius-Developer - fra1": 10,
-                  "Helius-Developer - sfo1": 12,
-                  "Helius-Developer - sin1": 11,
-                  "Quicknode-Growth - fra1": 7,
-                  "Quicknode-Growth - sfo1": 9,
-                  "Quicknode-Growth - sin1": 8,
-                  "Time": 0,
-                  "dRPC - fra1": 13,
-                  "dRPC - sfo1": 15,
-                  "dRPC - sin1": 14
+                  "Value": 2,
+                  "provider": 0,
+                  "source_region": 1
                 },
                 "renameByName": {
-                  "Alchemy-Growth - fra1": "Alchemy-Growth - EU",
-                  "Alchemy-Growth - sfo1": "Alchemy-Growth - US West",
-                  "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
-                  "Chainstack - fra1": "Chainstack-Growth - EU",
-                  "Chainstack - sfo1": "Chainstack-Growth - US West",
-                  "Chainstack - sin1": "Chainstack-Growth - SG",
-                  "Helius-Developer - fra1": "Helius-Developer - EU",
-                  "Helius-Developer - sfo1": "Helius-Developer - US West",
-                  "Helius-Developer - sin1": "Helius-Developer - SG",
-                  "Quicknode-Growth - fra1": "Quicknode-Growth - EU",
-                  "Quicknode-Growth - sfo1": "Quicknode-Growth - US West",
-                  "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
-                  "dRPC - fra1": "dRPC-Growth - EU",
-                  "dRPC - sfo1": "dRPC-Growth - US West",
-                  "dRPC - sin1": "dRPC-Growth - SG"
+                  "Value": "Success Rate",
+                  "provider": "Provider",
+                  "source_region": "Region"
                 }
               }
-            },
-            {
-              "id": "transpose",
-              "options": {}
             }
           ],
           "type": "table"
@@ -3436,16 +3457,19 @@
             ]
           },
           "gridPos": {
-            "h": 14,
-            "w": 19,
+            "h": 12,
+            "w": 18,
             "x": 0,
-            "y": 140
+            "y": 85
           },
           "id": 94,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -3461,7 +3485,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -3539,12 +3563,8 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
-              },
               "custom": {
-                "align": "left",
+                "align": "auto",
                 "cellOptions": {
                   "type": "auto"
                 },
@@ -3552,138 +3572,155 @@
                   "reducers": []
                 },
                 "inspect": false,
-                "wrapHeaderText": false
+                "minWidth": 110
               },
-              "decimals": 2,
-              "mappings": [
-                {
-                  "options": {
-                    "from": 0.99991,
-                    "result": {
-                      "index": 0,
-                      "text": "100.0%"
-                    },
-                    "to": 1
-                  },
-                  "type": "range"
-                }
-              ],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "1"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
                     "id": "custom.width",
-                    "value": 70
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Region"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "fra1": {
+                            "index": 0,
+                            "text": "EU"
+                          },
+                          "sfo1": {
+                            "index": 2,
+                            "text": "US"
+                          },
+                          "sin1": {
+                            "index": 1,
+                            "text": "SG"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 72
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 14,
-            "w": 5,
-            "x": 19,
-            "y": 140
+            "h": 12,
+            "w": 6,
+            "x": 18,
+            "y": 85
           },
           "id": 96,
           "options": {
             "cellHeight": "sm",
-            "showHeader": false
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", api_method=\"getProgramAccounts\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", api_method=\"getProgramAccounts\"}[$__range])) by (provider, source_region)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
+              "format": "table",
               "instant": true,
-              "interval": "",
-              "legendFormat": "{{provider}} - {{source_region}}",
-              "range": false,
-              "refId": "A",
-              "useBackend": false
+              "refId": "A"
             }
           ],
           "title": "Success rate",
           "transformations": [
-            {
-              "id": "joinByField",
-              "options": {
-                "byField": "Time",
-                "mode": "outer"
-              }
-            },
             {
               "id": "organize",
               "options": {
                 "excludeByName": {
                   "Time": true
                 },
-                "includeByName": {},
                 "indexByName": {
-                  "Alchemy-Growth - fra1": 1,
-                  "Alchemy-Growth - sfo1": 3,
-                  "Alchemy-Growth - sin1": 2,
-                  "Chainstack - fra1": 4,
-                  "Chainstack - sfo1": 6,
-                  "Chainstack - sin1": 5,
-                  "Helius-Developer - fra1": 10,
-                  "Helius-Developer - sfo1": 12,
-                  "Helius-Developer - sin1": 11,
-                  "Quicknode-Growth - fra1": 7,
-                  "Quicknode-Growth - sfo1": 9,
-                  "Quicknode-Growth - sin1": 8,
-                  "Time": 0,
-                  "dRPC - fra1": 13,
-                  "dRPC - sfo1": 15,
-                  "dRPC - sin1": 14
+                  "Value": 2,
+                  "provider": 0,
+                  "source_region": 1
                 },
                 "renameByName": {
-                  "Alchemy-Growth - fra1": "Alchemy-Growth - EU",
-                  "Alchemy-Growth - sfo1": "Alchemy-Growth - US West",
-                  "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
-                  "Chainstack - fra1": "Chainstack-Growth - EU",
-                  "Chainstack - sfo1": "Chainstack-Growth - US West",
-                  "Chainstack - sin1": "Chainstack-Growth - SG",
-                  "Helius-Developer - fra1": "Helius-Developer - EU",
-                  "Helius-Developer - sfo1": "Helius-Developer - US West",
-                  "Helius-Developer - sin1": "Helius-Developer - SG",
-                  "Quicknode-Growth - fra1": "Quicknode-Growth - EU",
-                  "Quicknode-Growth - sfo1": "Quicknode-Growth - US West",
-                  "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
-                  "dRPC - fra1": "dRPC-Growth - EU",
-                  "dRPC - sfo1": "dRPC-Growth - US West",
-                  "dRPC - sin1": "dRPC-Growth - SG"
+                  "Value": "Success Rate",
+                  "provider": "Provider",
+                  "source_region": "Region"
                 }
               }
-            },
-            {
-              "id": "transpose",
-              "options": {}
             }
           ],
           "type": "table"
@@ -3765,16 +3802,19 @@
             ]
           },
           "gridPos": {
-            "h": 14,
-            "w": 19,
+            "h": 12,
+            "w": 18,
             "x": 0,
-            "y": 154
+            "y": 97
           },
           "id": 88,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -3790,7 +3830,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -3804,7 +3844,7 @@
               "refId": "C"
             }
           ],
-          "title": "getBlock ⌛",
+          "title": "getBlock \u231b",
           "transformations": [
             {
               "id": "joinByField",
@@ -3868,12 +3908,8 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
-              },
               "custom": {
-                "align": "left",
+                "align": "auto",
                 "cellOptions": {
                   "type": "auto"
                 },
@@ -3881,138 +3917,155 @@
                   "reducers": []
                 },
                 "inspect": false,
-                "wrapHeaderText": false
+                "minWidth": 110
               },
-              "decimals": 2,
-              "mappings": [
-                {
-                  "options": {
-                    "from": 0.99991,
-                    "result": {
-                      "index": 0,
-                      "text": "100.0%"
-                    },
-                    "to": 1
-                  },
-                  "type": "range"
-                }
-              ],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "1"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
                     "id": "custom.width",
-                    "value": 70
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Region"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "fra1": {
+                            "index": 0,
+                            "text": "EU"
+                          },
+                          "sfo1": {
+                            "index": 2,
+                            "text": "US"
+                          },
+                          "sin1": {
+                            "index": 1,
+                            "text": "SG"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 72
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 14,
-            "w": 5,
-            "x": 19,
-            "y": 154
+            "h": 12,
+            "w": 6,
+            "x": 18,
+            "y": 97
           },
           "id": 92,
           "options": {
             "cellHeight": "sm",
-            "showHeader": false
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", api_method=\"getBlock\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", api_method=\"getBlock\"}[$__range])) by (provider, source_region)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
+              "format": "table",
               "instant": true,
-              "interval": "",
-              "legendFormat": "{{provider}} - {{source_region}}",
-              "range": false,
-              "refId": "A",
-              "useBackend": false
+              "refId": "A"
             }
           ],
           "title": "Success rate",
           "transformations": [
-            {
-              "id": "joinByField",
-              "options": {
-                "byField": "Time",
-                "mode": "outer"
-              }
-            },
             {
               "id": "organize",
               "options": {
                 "excludeByName": {
                   "Time": true
                 },
-                "includeByName": {},
                 "indexByName": {
-                  "Alchemy-Growth - fra1": 1,
-                  "Alchemy-Growth - sfo1": 3,
-                  "Alchemy-Growth - sin1": 2,
-                  "Chainstack - fra1": 4,
-                  "Chainstack - sfo1": 6,
-                  "Chainstack - sin1": 5,
-                  "Helius-Developer - fra1": 10,
-                  "Helius-Developer - sfo1": 12,
-                  "Helius-Developer - sin1": 11,
-                  "Quicknode-Growth - fra1": 7,
-                  "Quicknode-Growth - sfo1": 9,
-                  "Quicknode-Growth - sin1": 8,
-                  "Time": 0,
-                  "dRPC - fra1": 13,
-                  "dRPC - sfo1": 15,
-                  "dRPC - sin1": 14
+                  "Value": 2,
+                  "provider": 0,
+                  "source_region": 1
                 },
                 "renameByName": {
-                  "Alchemy-Growth - fra1": "Alchemy-Growth - EU",
-                  "Alchemy-Growth - sfo1": "Alchemy-Growth - US West",
-                  "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
-                  "Chainstack - fra1": "Chainstack-Growth - EU",
-                  "Chainstack - sfo1": "Chainstack-Growth - US West",
-                  "Chainstack - sin1": "Chainstack-Growth - SG",
-                  "Helius-Developer - fra1": "Helius-Developer - EU",
-                  "Helius-Developer - sfo1": "Helius-Developer - US West",
-                  "Helius-Developer - sin1": "Helius-Developer - SG",
-                  "Quicknode-Growth - fra1": "Quicknode-Growth - EU",
-                  "Quicknode-Growth - sfo1": "Quicknode-Growth - US West",
-                  "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
-                  "dRPC - fra1": "dRPC-Growth - EU",
-                  "dRPC - sfo1": "dRPC-Growth - US West",
-                  "dRPC - sin1": "dRPC-Growth - SG"
+                  "Value": "Success Rate",
+                  "provider": "Provider",
+                  "source_region": "Region"
                 }
               }
-            },
-            {
-              "id": "transpose",
-              "options": {}
             }
           ],
           "type": "table"
@@ -4027,9 +4080,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 59
+        "y": 37
       },
-      "id": 112,
+      "id": 119,
       "panels": [
         {
           "datasource": {
@@ -4040,6 +4093,7 @@
           "fieldConfig": {
             "defaults": {
               "color": {
+                "fixedColor": "super-light-blue",
                 "mode": "palette-classic"
               },
               "custom": {
@@ -4064,7 +4118,7 @@
                   "fill": "solid"
                 },
                 "lineWidth": 1,
-                "pointSize": 5,
+                "pointSize": 2,
                 "scaleDistribution": {
                   "log": 2,
                   "type": "log"
@@ -4088,7 +4142,8 @@
                     "value": 0
                   }
                 ]
-              }
+              },
+              "unit": "s"
             },
             "overrides": [
               {
@@ -4142,18 +4197,27 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
-            "y": 60
+            "y": 38
           },
           "id": 101,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
-              "calcs": [],
-              "displayMode": "list",
+              "calcs": [
+                "p95",
+                "max"
+              ],
+              "displayMode": "table",
               "placement": "right",
-              "showLegend": true
+              "showLegend": true,
+              "sortBy": "95th %",
+              "sortDesc": false
             },
             "tooltip": {
               "hideZeros": false,
@@ -4161,7 +4225,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -4191,99 +4255,105 @@
           "description": "The success rate of transaction landing, calculated by dividing successful confirmations by total attempts over the selected time range. Data grouped by provider and displayed as a percentage.\n\nChainstack-Default means a default Solana RPC endpoint (not bloXroute) under Growth plan.\n\nChainstack-Warp means a Solana Trader Node (bloXroute) under Growth plan.\n\nHelius-Default means a default Solana RPC endpoint (staked) under Developer plan.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Default"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Default"
+                          },
+                          "Chainstack_tx": {
+                            "index": 1,
+                            "text": "Chainstack-Warp"
+                          },
+                          "Helius-Developer": {
+                            "index": 2,
+                            "text": "Helius-Default"
+                          },
+                          "dRPC": {
+                            "index": 3,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack_tx"
+                  "options": "Success Rate"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Warp"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Helius-Developer"
-                },
-                "properties": [
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
                   {
-                    "id": "displayName",
-                    "value": "Helius-Default"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "dRPC"
-                },
-                "properties": [
+                    "id": "decimals",
+                    "value": 2
+                  },
                   {
-                    "id": "displayName",
-                    "value": "dRPC-Growth"
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
-            "y": 60
+            "h": 12,
+            "w": 6,
+            "x": 18,
+            "y": 38
           },
           "id": 102,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -4293,25 +4363,42 @@
               "disableTextWrap": false,
               "editorMode": "code",
               "expr": "sum(count_over_time(transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", metric_type=\"slot_latency\", api_method=\"sendTransaction\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", metric_type=\"slot_latency\", api_method=\"sendTransaction\"}[$__range])) by (provider)",
+              "format": "table",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
-              "instant": false,
+              "instant": true,
               "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
               "refId": "A",
               "useBackend": false
             }
           ],
           "title": "Landing rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "gridPos": {
             "h": 1,
             "w": 24,
             "x": 0,
-            "y": 68
+            "y": 50
           },
           "id": 103,
           "options": {
@@ -4323,7 +4410,7 @@
             "content": "",
             "mode": "markdown"
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [],
           "title": "Slot distribution",
           "transparent": true,
@@ -4381,7 +4468,7 @@
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 69
+            "y": 51
           },
           "id": 104,
           "options": {
@@ -4409,7 +4496,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -4592,7 +4679,7 @@
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 69
+            "y": 51
           },
           "id": 105,
           "options": {
@@ -4620,7 +4707,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -4803,7 +4890,7 @@
             "h": 8,
             "w": 6,
             "x": 12,
-            "y": 69
+            "y": 51
           },
           "id": 109,
           "options": {
@@ -4831,7 +4918,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -5013,7 +5100,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 69
+            "y": 51
           },
           "id": 107,
           "options": {
@@ -5041,7 +5128,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -5223,7 +5310,7 @@
             "h": 8,
             "w": 6,
             "x": 0,
-            "y": 77
+            "y": 59
           },
           "id": 110,
           "options": {
@@ -5251,7 +5338,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -5436,7 +5523,7 @@
             "h": 8,
             "w": 6,
             "x": 6,
-            "y": 77
+            "y": 59
           },
           "id": 108,
           "options": {
@@ -5464,7 +5551,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -5644,6 +5731,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Solana",
   "uid": "fe3mtxna6483ke-solana-global",
-  "version": 77,
+  "version": 111,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-ton-eu.json
+++ b/dashboards/dashboards/compare-dashboard-ton-eu.json
@@ -657,111 +657,7 @@
         "y": 25
       },
       "id": 1008,
-      "title": "Block lag",
-      "type": "row",
       "panels": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
-          "description": "Measures masterchain block sequence number (seqno) from getMasterchainInfo. The tip is the highest seqno seen across all providers at each measurement. Lag = tip − provider seqno. Lag ≤ 2 blocks is treated as at-tip to filter measurement jitter (3-min sampling vs ~0.4s block time).",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "blue",
-                "mode": "thresholds"
-              },
-              "decimals": 1,
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 80
-                  },
-                  {
-                    "color": "yellow",
-                    "value": 90
-                  },
-                  {
-                    "color": "green",
-                    "value": 99
-                  }
-                ]
-              },
-              "unit": "percent"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "dRPC"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "dRPC-Growth"
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 24,
-            "x": 0,
-            "y": 26
-          },
-          "id": 1005,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto",
-            "wideLayout": true
-          },
-          "pluginVersion": "13.0.0-23605486576",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "grafanacloud-prom"
-              },
-              "editorMode": "code",
-              "expr": "100 * (1 - avg_over_time((clamp_min(scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", source_region=\"fra1\", response_status=\"success\"})) - max by (provider) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", source_region=\"fra1\", response_status=\"success\"}), 0) > bool 2)[$__range:$__interval]))",
-              "legendFormat": "{{provider}}",
-              "instant": true,
-              "refId": "A"
-            }
-          ],
-          "title": "% of time at tip",
-          "type": "stat"
-        },
         {
           "datasource": {
             "type": "prometheus",
@@ -774,6 +670,7 @@
                 "mode": "thresholds"
               },
               "custom": {
+                "axisPlacement": "auto",
                 "fillOpacity": 80,
                 "hideFrom": {
                   "legend": false,
@@ -790,7 +687,7 @@
                 "steps": [
                   {
                     "color": "green",
-                    "value": null
+                    "value": 0
                   },
                   {
                     "color": "yellow",
@@ -835,14 +732,18 @@
             ]
           },
           "gridPos": {
-            "h": 10,
-            "w": 19,
+            "h": 14,
+            "w": 18,
             "x": 0,
             "y": 30
           },
           "id": 1006,
           "options": {
             "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "displayMode": "list",
               "placement": "bottom",
@@ -852,6 +753,7 @@
             "rowHeight": 0.8,
             "showValue": "never",
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
@@ -878,88 +780,153 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "getMasterchainInfo success rate — the method used for block lag tracking.",
+          "description": "",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "decimals": 2,
-              "mappings": [
-                {
-                  "options": {
-                    "from": 0.99991,
-                    "result": {
-                      "index": 0,
-                      "text": "100.0%"
-                    },
-                    "to": 1
-                  },
-                  "type": "range"
-                }
-              ],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "Chainstack": {
+                            "text": "Chainstack-Growth",
+                            "index": 0
+                          },
+                          "dRPC": {
+                            "text": "dRPC-Growth",
+                            "index": 1
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 108
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "dRPC"
+                  "options": "% at Tip"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "dRPC-Growth"
+                    "id": "unit",
+                    "value": "percent"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": 0
+                        },
+                        {
+                          "color": "orange",
+                          "value": 80
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 90
+                        },
+                        {
+                          "color": "green",
+                          "value": 99
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 85
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "SR"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 68
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 10,
-            "w": 5,
-            "x": 19,
+            "h": 14,
+            "w": 6,
+            "x": 18,
             "y": 30
           },
           "id": 1007,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "% at Tip"
+              }
+            ]
           },
           "pluginVersion": "13.0.0-23605486576",
           "targets": [
@@ -969,17 +936,67 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"fra1\", api_method=\"getMasterchainInfo\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"fra1\", api_method=\"getMasterchainInfo\"}[$__range])) by (provider)",
+              "exemplar": false,
+              "expr": "100 * (1 - avg_over_time((clamp_min(scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", source_region=\"fra1\", response_status=\"success\"})) - max by (provider) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", source_region=\"fra1\", response_status=\"success\"}), 0) > bool 2)[$__range:$__interval]))",
+              "format": "table",
               "instant": true,
-              "range": false,
-              "legendFormat": "{{provider}}",
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"fra1\", response_status=\"success\"} >= 0)[$__range:$__interval])) by (provider)\n/\nsum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"fra1\"} >= 0)[$__range:$__interval])) by (provider)",
+              "format": "table",
+              "instant": true,
+              "refId": "B"
             }
           ],
-          "title": "Success rate",
-          "type": "stat"
+          "title": "Block lag summary",
+          "transformations": [
+            {
+              "id": "merge",
+              "options": {}
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "provider": 0,
+                  "Value #A": 1,
+                  "Value #B": 2
+                },
+                "renameByName": {
+                  "provider": "Provider",
+                  "Value #A": "% at Tip",
+                  "Value #B": "SR"
+                }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": true,
+                    "field": "% at Tip"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "table"
         }
-      ]
+      ],
+      "title": "Block lag",
+      "type": "row"
     },
     {
       "collapsed": true,
@@ -1031,6 +1048,7 @@
                   "type": "log"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -1040,12 +1058,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -1067,16 +1085,19 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 41
           },
           "id": 3,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1117,84 +1138,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 41
           },
           "id": 33,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "11.6.0-82840",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
+              "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"fra1\", api_method=\"runGetMethod\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"fra1\", api_method=\"runGetMethod\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1236,6 +1304,7 @@
                   "type": "log"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -1245,16 +1314,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -1276,16 +1341,19 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 49
           },
           "id": 20,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1326,84 +1394,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 49
           },
           "id": 34,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "11.6.0-82840",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
+              "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"fra1\", api_method=\"getAddressBalance\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"fra1\", api_method=\"getAddressBalance\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1445,6 +1560,7 @@
                   "type": "log"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -1454,16 +1570,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -1485,16 +1597,19 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 57
           },
           "id": 47,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1535,84 +1650,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 57
           },
           "id": 48,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "11.6.0-82840",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
+              "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"fra1\", api_method=\"getAddressBalance\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"fra1\", api_method=\"getAddressBalance\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1654,6 +1816,7 @@
                   "type": "log"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -1663,16 +1826,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -1694,16 +1853,19 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 65
           },
           "id": 21,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1744,84 +1906,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 65
           },
           "id": 35,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "11.6.0-82840",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
+              "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"fra1\", api_method=\"getBlockHeader\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"fra1\", api_method=\"getBlockHeader\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1863,6 +2072,7 @@
                   "type": "log"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -1872,16 +2082,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -1903,16 +2109,19 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 73
           },
           "id": 49,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1953,84 +2162,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 73
           },
           "id": 50,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "11.6.0-82840",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
+              "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"fra1\", api_method=\"getBlockTransactions\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"fra1\", api_method=\"getBlockTransactions\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         }
       ],
       "title": "Historical data",
@@ -2055,7 +2311,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -2081,6 +2339,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2098,7 +2357,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -2200,7 +2460,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -2226,6 +2488,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2235,6 +2498,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -2242,7 +2506,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -2344,7 +2609,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -2370,6 +2637,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2379,6 +2647,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -2386,7 +2655,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -2415,7 +2685,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 213
+            "y": 43
           },
           "id": 26,
           "options": {
@@ -2488,7 +2758,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -2514,6 +2786,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2523,6 +2796,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -2530,7 +2804,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -2559,7 +2834,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 213
+            "y": 43
           },
           "id": 51,
           "options": {
@@ -2632,7 +2907,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -2658,6 +2935,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2667,6 +2945,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -2674,7 +2953,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -2703,7 +2983,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 218
+            "y": 48
           },
           "id": 52,
           "options": {
@@ -2790,7 +3070,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -2816,6 +3098,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2833,7 +3116,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -2935,7 +3219,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -2961,6 +3247,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2970,6 +3257,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -2977,7 +3265,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -3079,7 +3368,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3105,6 +3396,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3114,6 +3406,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -3121,7 +3414,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -3150,7 +3444,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 213
+            "y": 43
           },
           "id": 1002,
           "options": {
@@ -3223,7 +3517,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3249,6 +3545,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3258,6 +3555,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -3265,7 +3563,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -3294,7 +3593,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 213
+            "y": 43
           },
           "id": 1003,
           "options": {
@@ -3367,7 +3666,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3393,6 +3694,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3402,6 +3704,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -3409,7 +3712,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -3438,7 +3742,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 218
+            "y": 48
           },
           "id": 1004,
           "options": {
@@ -3525,7 +3829,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3551,6 +3857,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3568,7 +3875,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -3670,7 +3978,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3696,6 +4006,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3705,6 +4016,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -3712,7 +4024,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -3814,7 +4127,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3840,6 +4155,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3849,6 +4165,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -3856,7 +4173,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -3885,7 +4203,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 199
+            "y": 44
           },
           "id": 57,
           "options": {
@@ -3958,7 +4276,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3984,6 +4304,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3993,6 +4314,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -4000,7 +4322,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -4029,7 +4352,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 199
+            "y": 44
           },
           "id": 60,
           "options": {
@@ -4102,7 +4425,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -4128,6 +4453,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -4137,6 +4463,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -4144,7 +4471,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -4173,7 +4501,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 204
+            "y": 49
           },
           "id": 58,
           "options": {
@@ -4273,6 +4601,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: TON (EU)",
   "uid": "be82wni0bhukgd-ton-germ",
-  "version": 73,
+  "version": 82,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-ton-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-ton-singapore.json
@@ -657,111 +657,7 @@
         "y": 25
       },
       "id": 72,
-      "title": "Block lag",
-      "type": "row",
       "panels": [
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
-          "description": "Measures masterchain block sequence number (seqno) from getMasterchainInfo. The tip is the highest seqno seen across all providers at each measurement. Lag = tip − provider seqno. Lag ≤ 2 blocks is treated as at-tip to filter measurement jitter (3-min sampling vs ~0.4s block time).",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "blue",
-                "mode": "thresholds"
-              },
-              "decimals": 1,
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 80
-                  },
-                  {
-                    "color": "yellow",
-                    "value": 90
-                  },
-                  {
-                    "color": "green",
-                    "value": 99
-                  }
-                ]
-              },
-              "unit": "percent"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "dRPC"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "dRPC-Growth"
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 24,
-            "x": 0,
-            "y": 26
-          },
-          "id": 69,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto",
-            "wideLayout": true
-          },
-          "pluginVersion": "13.0.0-23605486576",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "grafanacloud-prom"
-              },
-              "editorMode": "code",
-              "expr": "100 * (1 - avg_over_time((clamp_min(scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", source_region=\"sin1\", response_status=\"success\"})) - max by (provider) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", source_region=\"sin1\", response_status=\"success\"}), 0) > bool 2)[$__range:$__interval]))",
-              "legendFormat": "{{provider}}",
-              "instant": true,
-              "refId": "A"
-            }
-          ],
-          "title": "% of time at tip",
-          "type": "stat"
-        },
         {
           "datasource": {
             "type": "prometheus",
@@ -774,6 +670,7 @@
                 "mode": "thresholds"
               },
               "custom": {
+                "axisPlacement": "auto",
                 "fillOpacity": 80,
                 "hideFrom": {
                   "legend": false,
@@ -790,7 +687,7 @@
                 "steps": [
                   {
                     "color": "green",
-                    "value": null
+                    "value": 0
                   },
                   {
                     "color": "yellow",
@@ -835,14 +732,18 @@
             ]
           },
           "gridPos": {
-            "h": 10,
-            "w": 19,
+            "h": 14,
+            "w": 18,
             "x": 0,
             "y": 30
           },
           "id": 70,
           "options": {
             "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "displayMode": "list",
               "placement": "bottom",
@@ -852,6 +753,7 @@
             "rowHeight": 0.8,
             "showValue": "never",
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
@@ -878,88 +780,153 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "getMasterchainInfo success rate — the method used for block lag tracking.",
+          "description": "",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "decimals": 2,
-              "mappings": [
-                {
-                  "options": {
-                    "from": 0.99991,
-                    "result": {
-                      "index": 0,
-                      "text": "100.0%"
-                    },
-                    "to": 1
-                  },
-                  "type": "range"
-                }
-              ],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "Chainstack": {
+                            "text": "Chainstack-Growth",
+                            "index": 0
+                          },
+                          "dRPC": {
+                            "text": "dRPC-Growth",
+                            "index": 1
+                          }
+                        }
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 108
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "dRPC"
+                  "options": "% at Tip"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "dRPC-Growth"
+                    "id": "unit",
+                    "value": "percent"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": 0
+                        },
+                        {
+                          "color": "orange",
+                          "value": 80
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 90
+                        },
+                        {
+                          "color": "green",
+                          "value": 99
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 85
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "SR"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 68
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 10,
-            "w": 5,
-            "x": 19,
+            "h": 14,
+            "w": 6,
+            "x": 18,
             "y": 30
           },
           "id": 71,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "% at Tip"
+              }
+            ]
           },
           "pluginVersion": "13.0.0-23605486576",
           "targets": [
@@ -969,17 +936,67 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"sin1\", api_method=\"getMasterchainInfo\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"sin1\", api_method=\"getMasterchainInfo\"}[$__range])) by (provider)",
+              "exemplar": false,
+              "expr": "100 * (1 - avg_over_time((clamp_min(scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", source_region=\"sin1\", response_status=\"success\"})) - max by (provider) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", source_region=\"sin1\", response_status=\"success\"}), 0) > bool 2)[$__range:$__interval]))",
+              "format": "table",
               "instant": true,
-              "range": false,
-              "legendFormat": "{{provider}}",
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"sin1\", response_status=\"success\"} >= 0)[$__range:$__interval])) by (provider)\n/\nsum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"sin1\"} >= 0)[$__range:$__interval])) by (provider)",
+              "format": "table",
+              "instant": true,
+              "refId": "B"
             }
           ],
-          "title": "Success rate",
-          "type": "stat"
+          "title": "Block lag summary",
+          "transformations": [
+            {
+              "id": "merge",
+              "options": {}
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "provider": 0,
+                  "Value #A": 1,
+                  "Value #B": 2
+                },
+                "renameByName": {
+                  "provider": "Provider",
+                  "Value #A": "% at Tip",
+                  "Value #B": "SR"
+                }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": true,
+                    "field": "% at Tip"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "table"
         }
-      ]
+      ],
+      "title": "Block lag",
+      "type": "row"
     },
     {
       "collapsed": true,
@@ -1031,6 +1048,7 @@
                   "type": "log"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -1040,12 +1058,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -1067,16 +1085,19 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 41
           },
           "id": 3,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1117,84 +1138,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 41
           },
           "id": 33,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "11.6.0-82840",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
+              "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"sin1\", api_method=\"runGetMethod\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"sin1\", api_method=\"runGetMethod\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1236,6 +1304,7 @@
                   "type": "log"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -1245,16 +1314,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -1276,16 +1341,19 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 49
           },
           "id": 20,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1326,84 +1394,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 49
           },
           "id": 34,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "11.6.0-82840",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
+              "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"sin1\", api_method=\"getAddressBalance\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"sin1\", api_method=\"getAddressBalance\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1445,6 +1560,7 @@
                   "type": "log"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -1454,16 +1570,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -1485,16 +1597,19 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 57
           },
           "id": 47,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1535,84 +1650,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 57
           },
           "id": 48,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "11.6.0-82840",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
+              "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"sin1\", api_method=\"getAddressBalance\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"sin1\", api_method=\"getAddressBalance\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1654,6 +1816,7 @@
                   "type": "log"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -1663,16 +1826,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -1694,16 +1853,19 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 65
           },
           "id": 21,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1744,84 +1906,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 65
           },
           "id": 35,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "11.6.0-82840",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
+              "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"sin1\", api_method=\"getBlockHeader\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"sin1\", api_method=\"getBlockHeader\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1863,6 +2072,7 @@
                   "type": "log"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -1872,16 +2082,12 @@
                   "mode": "off"
                 }
               },
-              "mappings": [],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
-                  },
-                  {
-                    "color": "red",
-                    "value": 80
+                    "color": "green",
+                    "value": 0
                   }
                 ]
               },
@@ -1903,16 +2109,19 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 73
           },
           "id": 49,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1953,84 +2162,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 73
           },
           "id": 50,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "11.6.0-82840",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
+              "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"sin1\", api_method=\"getBlockTransactions\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"sin1\", api_method=\"getBlockTransactions\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         }
       ],
       "title": "Historical data",
@@ -2055,7 +2311,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -2081,6 +2339,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2098,7 +2357,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -2200,7 +2460,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -2226,6 +2488,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2235,6 +2498,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -2242,7 +2506,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -2344,7 +2609,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -2370,6 +2637,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2379,6 +2647,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -2386,7 +2655,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -2415,7 +2685,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 203
+            "y": 43
           },
           "id": 26,
           "options": {
@@ -2488,7 +2758,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -2514,6 +2786,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2523,6 +2796,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -2530,7 +2804,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -2559,7 +2834,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 203
+            "y": 43
           },
           "id": 51,
           "options": {
@@ -2632,7 +2907,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -2658,6 +2935,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2667,6 +2945,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -2674,7 +2953,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -2703,7 +2983,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 208
+            "y": 48
           },
           "id": 52,
           "options": {
@@ -2790,7 +3070,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -2816,6 +3098,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2833,7 +3116,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -2935,7 +3219,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -2961,6 +3247,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -2970,6 +3257,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -2977,7 +3265,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -3079,7 +3368,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3105,6 +3396,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3114,6 +3406,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -3121,7 +3414,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -3150,7 +3444,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 203
+            "y": 43
           },
           "id": 66,
           "options": {
@@ -3223,7 +3517,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3249,6 +3545,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3258,6 +3555,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -3265,7 +3563,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -3294,7 +3593,7 @@
             "h": 5,
             "w": 12,
             "x": 12,
-            "y": 203
+            "y": 43
           },
           "id": 67,
           "options": {
@@ -3367,7 +3666,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3393,6 +3694,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3402,6 +3704,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -3409,7 +3712,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -3438,7 +3742,7 @@
             "h": 5,
             "w": 12,
             "x": 0,
-            "y": 208
+            "y": 48
           },
           "id": 68,
           "options": {
@@ -3525,7 +3829,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3551,6 +3857,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3568,7 +3875,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -3670,7 +3978,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3696,6 +4006,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3705,6 +4016,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -3712,7 +4024,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -3814,7 +4127,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3840,6 +4155,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3849,6 +4165,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -3856,7 +4173,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -3958,7 +4276,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -3984,6 +4304,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -3993,6 +4314,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -4000,7 +4322,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -4102,7 +4425,9 @@
           "fieldConfig": {
             "defaults": {
               "color": {
-                "mode": "thresholds"
+                "fixedColor": "#61bbfb",
+                "mode": "thresholds",
+                "seriesBy": "last"
               },
               "custom": {
                 "axisBorderShow": false,
@@ -4128,6 +4453,7 @@
                   "type": "linear"
                 },
                 "showPoints": "auto",
+                "showValues": false,
                 "spanNulls": true,
                 "stacking": {
                   "group": "A",
@@ -4137,6 +4463,7 @@
                   "mode": "area"
                 }
               },
+              "fieldMinMax": false,
               "mappings": [],
               "max": 0.5,
               "min": -0.5,
@@ -4144,7 +4471,8 @@
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
                   },
                   {
                     "color": "text",
@@ -4273,6 +4601,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: TON (Singapore)",
   "uid": "be82wni0bhukgd-ton-sing",
-  "version": 68,
+  "version": 77,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-ton.json
+++ b/dashboards/dashboards/compare-dashboard-ton.json
@@ -38,7 +38,7 @@
         "content": "<div style=\"display: inline-flex; align-items: center; margin: 5px; height: 70px;\">\n    <!-- Image Link -->\n    <a href=\"https://chainstack.com/\" target=\"_blank\" style=\"margin-right: 25px; display: inline-block;\">\n        <img src=\"https://chainstack.com/wp-content/themes/chainstack/img/press-kit-logo-white-text.svg\" alt=\"chainstack_logo\" style=\"max-width: 150px; height: auto; display: block;\">\n    </a>\n    \n    <!-- Text Links with Highlight on the First Link -->\n    <a href=\"https://chainstack.grafana.net/public-dashboards/65c0fcb02f994faf845d4ec095771bd0\" target=\"_self\" \n    style=\"text-decoration: none; color: #007bff; font-weight: bold; margin-right: 15px; padding: 5px 10px; border-radius: 5px;\">\n        Ethereum\n    </a>\n    <a href=\"https://chainstack.grafana.net/public-dashboards/b8f98de094e84c17becb38a1b318e2f2\" target=\"_self\" \n    style=\"text-decoration: none; color: #007bff; font-weight: bold; margin-right: 15px; padding: 5px 10px; border-radius: 5px;\">\n        Arbitrum\n    </a>\n    <a href=\"https://chainstack.grafana.net/public-dashboards/11861148d82247128307025fac628b6e\" target=\"_self\" \n    style=\"text-decoration: none; color: #007bff; font-weight: bold; margin-right: 15px; padding: 5px 10px; border-radius: 5px;\">\n        Base\n    </a>\n    <a href=\"https://chainstack.grafana.net/public-dashboards/059a680a502a4d8782e93fcc1f2f1be9\" target=\"_self\" \n    style=\"text-decoration: none; color: #007bff; font-weight: bold; margin-right: 15px; padding: 5px 10px; border-radius: 5px;\">\n        BNB\n    </a>\n    <a href=\"https://chainstack.grafana.net/public-dashboards/5f957bbcc3ae4c9d8d9669a299a24676\" target=\"_self\" \n    style=\"text-decoration: none; color: #007bff; font-weight: bold; margin-right: 15px; padding: 5px 10px; border-radius: 5px;\">\n        Hyperliquid\n    </a>\n    <a href=\"https://chainstack.grafana.net/public-dashboards/ae4e8ccc089b460f95d5d2f29dd0d022\" target=\"_self\" \n    style=\"text-decoration: none; color: #007bff; font-weight: bold; margin-right: 15px; padding: 5px 10px; border-radius: 5px;\">\n        Monad\n    </a>\n    <a href=\"https://chainstack.grafana.net/public-dashboards/254601572d9a4b7a90122e46248f82b0\" target=\"_self\" \n       style=\"text-decoration: none; color: #007bff; font-weight: bold; margin-right: 15px; padding: 5px 10px; border-radius: 5px;\">\n        Solana\n    </a>\n    <a href=\"https://chainstack.grafana.net/public-dashboards/deeaf524ea264f42a12718f675511b13\" target=\"_self\" \n    style=\"text-decoration: none; color: #007bff; font-weight: bold; margin-right: 15px; padding: 5px 10px; border-radius: 5px; \n       background-color: #e0f7fa; border: 1px solid #007bff;\">\n        TON\n    </a>\n</div>\n\n",
         "mode": "html"
       },
-      "pluginVersion": "13.0.0-23605486576",
+      "pluginVersion": "13.1.0-24455754975",
       "targets": [],
       "title": "",
       "transparent": true,
@@ -61,7 +61,7 @@
         "content": "<div style=\"display: inline-flex; align-items: center; margin: 5px; height: 70px;\">\n    <a href=\"https://chainstack.grafana.net/public-dashboards/deeaf524ea264f42a12718f675511b13\" target=\"_self\" \n       style=\"text-decoration: none; color: #6c757d; font-weight: bold; margin-right: 15px; padding: 5px 10px; border-radius: 5px; \n       background-color: #f8f9fa; border: 1px solid #dee2e6;\">\n        Global\n    </a>\n    <a href=\"https://chainstack.grafana.net/public-dashboards/46a05852cab24c8d9b58774d29bf0e08\" target=\"_self\" \n       style=\"text-decoration: none; color: #6c757d; font-weight: bold; margin-right: 15px; padding: 5px 10px; border-radius: 5px;\">\n        EU\n    </a>\n    <a href=\"https://chainstack.grafana.net/public-dashboards/31da274a37b84ca2a7a2e7b7f90b4903\" target=\"_self\" \n       style=\"text-decoration: none; color: #6c757d; font-weight: bold; margin-right: 15px; padding: 5px 10px; border-radius: 5px;\">\n        Asia\n    </a>\n</div>",
         "mode": "html"
       },
-      "pluginVersion": "13.0.0-23605486576",
+      "pluginVersion": "13.1.0-24455754975",
       "targets": [],
       "title": "",
       "transparent": true,
@@ -84,7 +84,7 @@
         "content": "#### Description\n\nThis dashboard provides real-time and historical performance analytics for RPC nodes across major providers.\n\n* Click region buttons to view metrics from different locations\n* Adjust time range for historical analysis\n* Hover over info icons for detailed metric descriptions\n\n&nbsp;\n\n#### Data collection\n\nResponse times are measured by our Python service on [Vercel serverless functions](https://github.com/chainstacklabs/compare-dashboard-functions), sending requests every 1-3 minutes from three regions.\n\nResponse times exceeding 55 seconds are considered failures and excluded from charts.\n\nAll requests use latest blocks except \"archive\" methods (⌛), which query historical blocks (1-2 days ago).\n\nℹ️ If not specified, the first paid RPC provider plan (named Growth as a rule) is used for monitoring.\n\n&nbsp;\n\n#### How we rank providers\n\nWe evaluate RPC providers based on their **speed** (response time) and **reliability** (success rate) across three regions.\n\n* The **lower** the score, the **better** the provider\n* Even small success rate drops (99% vs 97%) significantly impact the final score\n* Performance is measured equally across all regions\n\n```plaintext\nScore = 1 / ((1/ResponseTime) × (SuccessRate³))\n```",
         "mode": "markdown"
       },
-      "pluginVersion": "13.0.0-23605486576",
+      "pluginVersion": "13.1.0-24455754975",
       "targets": [],
       "title": "",
       "transparent": true,
@@ -108,7 +108,7 @@
         "content": "",
         "mode": "markdown"
       },
-      "pluginVersion": "13.0.0-23605486576",
+      "pluginVersion": "13.1.0-24455754975",
       "targets": [],
       "title": "Provider score (lower is better)",
       "transparent": true,
@@ -196,7 +196,7 @@
         "textMode": "auto",
         "wideLayout": true
       },
-      "pluginVersion": "13.0.0-23605486576",
+      "pluginVersion": "13.1.0-24455754975",
       "targets": [
         {
           "datasource": {
@@ -233,7 +233,7 @@
         "content": "",
         "mode": "markdown"
       },
-      "pluginVersion": "13.0.0-23605486576",
+      "pluginVersion": "13.1.0-24455754975",
       "targets": [],
       "title": "What is the p95 response time and overall success rate?",
       "transparent": true,
@@ -368,7 +368,7 @@
         "xTickLabelRotation": 0,
         "xTickLabelSpacing": 100
       },
-      "pluginVersion": "13.0.0-23605486576",
+      "pluginVersion": "13.1.0-24455754975",
       "targets": [
         {
           "datasource": {
@@ -493,19 +493,83 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "1"
+              "options": "Provider"
             },
             "properties": [
               {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "Chainstack": {
+                        "text": "Chainstack-Growth",
+                        "index": 0
+                      },
+                      "dRPC": {
+                        "text": "dRPC-Growth",
+                        "index": 1
+                      }
+                    }
+                  }
+                ]
+              },
+              {
                 "id": "custom.width",
                 "value": 120
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Region"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "fra1": {
+                        "text": "EU",
+                        "index": 0
+                      },
+                      "sin1": {
+                        "text": "SG",
+                        "index": 1
+                      },
+                      "sfo1": {
+                        "text": "US West",
+                        "index": 2
+                      }
+                    }
+                  }
+                ]
               },
+              {
+                "id": "custom.width",
+                "value": 80
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SR"
+            },
+            "properties": [
               {
                 "id": "custom.cellOptions",
                 "value": {
                   "mode": "basic",
                   "type": "gauge"
                 }
+              },
+              {
+                "id": "custom.width",
+                "value": 120
               }
             ]
           }
@@ -522,7 +586,7 @@
         "cellHeight": "sm",
         "showHeader": false
       },
-      "pluginVersion": "13.0.0-23605486576",
+      "pluginVersion": "13.1.0-24455754975",
       "targets": [
         {
           "datasource": {
@@ -537,65 +601,30 @@
           "includeNullMetadata": true,
           "instant": true,
           "interval": "",
-          "legendFormat": "{{provider}} - {{source_region}}",
-          "range": false,
           "refId": "A",
-          "useBackend": false
+          "useBackend": false,
+          "format": "table"
         }
       ],
       "title": "Success rate",
       "transformations": [
-        {
-          "id": "joinByField",
-          "options": {
-            "byField": "Time",
-            "mode": "outer"
-          }
-        },
         {
           "id": "organize",
           "options": {
             "excludeByName": {
               "Time": true
             },
-            "includeByName": {},
             "indexByName": {
-              "Chainstack - fra1": 1,
-              "Chainstack - sfo1": 3,
-              "Chainstack - sin1": 2,
-              "Quicknode-Growth - fra1": 4,
-              "Quicknode-Growth - sfo1": 6,
-              "Quicknode-Growth - sin1": 5,
-              "Time": 0,
-              "TonCenter-WithAPIKey - fra1": 7,
-              "TonCenter-WithAPIKey - sfo1": 9,
-              "TonCenter-WithAPIKey - sin1": 8,
-              "dRPC - fra1": 10,
-              "dRPC - sfo1": 12,
-              "dRPC - sin1": 11
+              "provider": 0,
+              "source_region": 1,
+              "Value": 2
             },
             "renameByName": {
-              "Alchemy-Growth - fra1": "Alchemy-Growth - EU",
-              "Alchemy-Growth - sfo1": "Alchemy-Growth - US West",
-              "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
-              "Chainstack - fra1": "Chainstack-Growth - EU",
-              "Chainstack - sfo1": "Chainstack-Growth - US West",
-              "Chainstack - sin1": "Chainstack-Growth - SG",
-              "Quicknode-Growth - fra1": "Quicknode-Growth - EU",
-              "Quicknode-Growth - sfo1": "Quicknode-Growth - US West",
-              "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
-              "TonCenter-WithAPIKey - fra1": "TonCenter-WithAPIKey - EU",
-              "TonCenter-WithAPIKey - sfo1": "TonCenter-WithAPIKey - US West",
-              "TonCenter-WithAPIKey - sin1": "TonCenter-WithAPIKey - SG",
-              "dRPC - fra1": "dRPC-Growth - EU",
-              "dRPC - sfo1": "dRPC-Growth - US West",
-              "dRPC - sin1": "dRPC-Growth - SG"
+              "provider": "Provider",
+              "source_region": "Region",
+              "Value": "SR"
             }
           }
-        },
-        {
-          "id": "transpose",
-          "options": {}
         }
       ],
       "type": "table"
@@ -729,7 +758,7 @@
         "xTickLabelRotation": 0,
         "xTickLabelSpacing": 100
       },
-      "pluginVersion": "13.0.0-23605486576",
+      "pluginVersion": "13.1.0-24455754975",
       "targets": [
         {
           "datasource": {
@@ -814,7 +843,7 @@
         "content": "",
         "mode": "markdown"
       },
-      "pluginVersion": "13.0.0-23605486576",
+      "pluginVersion": "13.1.0-24455754975",
       "targets": [],
       "title": "What is the p95 response time in each region?",
       "transparent": true,
@@ -937,7 +966,7 @@
         "xTickLabelRotation": 0,
         "xTickLabelSpacing": 100
       },
-      "pluginVersion": "13.0.0-23605486576",
+      "pluginVersion": "13.1.0-24455754975",
       "targets": [
         {
           "datasource": {
@@ -1100,7 +1129,7 @@
         "xTickLabelRotation": 0,
         "xTickLabelSpacing": 100
       },
-      "pluginVersion": "13.0.0-23605486576",
+      "pluginVersion": "13.1.0-24455754975",
       "targets": [
         {
           "datasource": {
@@ -1201,196 +1230,21 @@
         "x": 0,
         "y": 34
       },
-      "id": 100,
-      "title": "Block lag",
-      "type": "row",
+      "id": 112,
       "panels": [
         {
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Measures masterchain block sequence number (seqno) from getMasterchainInfo. The tip is the highest seqno seen across all providers at each measurement. Lag = tip − provider seqno. Lag ≤ 2 blocks is treated as at-tip to filter measurement jitter (3-min sampling vs ~0.4s block time).",
-          "fieldConfig": {
-            "defaults": {
-              "color": {
-                "fixedColor": "blue",
-                "mode": "thresholds"
-              },
-              "decimals": 1,
-              "thresholds": {
-                "mode": "absolute",
-                "steps": [
-                  {
-                    "color": "red",
-                    "value": null
-                  },
-                  {
-                    "color": "orange",
-                    "value": 80
-                  },
-                  {
-                    "color": "yellow",
-                    "value": 90
-                  },
-                  {
-                    "color": "green",
-                    "value": 99
-                  }
-                ]
-              },
-              "unit": "percent"
-            },
-            "overrides": [
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack - sin1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Quicknode-Growth - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Quicknode-Growth - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Quicknode-Growth - sin1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Quicknode-Growth - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "TonCenter-WithAPIKey - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "TonCenter-WithAPIKey - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "TonCenter-WithAPIKey - sin1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "TonCenter-WithAPIKey - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "dRPC - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "dRPC-Growth - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "dRPC - sin1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "dRPC-Growth - SG"
-                  }
-                ]
-              }
-            ]
-          },
-          "gridPos": {
-            "h": 4,
-            "w": 24,
-            "x": 0,
-            "y": 35
-          },
-          "id": 103,
-          "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "auto",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "textMode": "auto",
-            "wideLayout": true
-          },
-          "pluginVersion": "13.0.0-23605486576",
-          "targets": [
-            {
-              "datasource": {
-                "type": "prometheus",
-                "uid": "grafanacloud-prom"
-              },
-              "editorMode": "code",
-              "expr": "100 * (1 - avg_over_time((clamp_min(scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", response_status=\"success\"})) - max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", response_status=\"success\"}), 0) > bool 2)[$__range:$__interval]))",
-              "legendFormat": "{{provider}} - {{source_region}}",
-              "instant": true,
-              "refId": "A"
-            }
-          ],
-          "title": "% of time at tip",
-          "type": "stat"
-        },
-        {
-          "datasource": {
-            "type": "prometheus",
-            "uid": "grafanacloud-prom"
-          },
-          "description": "Each row is a provider-region. Color shows lag severity over time: green = at tip (≤2 blocks), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Masterchain seqno lag. 0 = at the tip.",
+          "description": "Each row is a provider-region. Lag is relative to the best provider in the same region. Color shows severity: green = at tip (≤2 blocks), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20).",
           "fieldConfig": {
             "defaults": {
               "color": {
                 "mode": "thresholds"
               },
               "custom": {
+                "axisPlacement": "auto",
                 "fillOpacity": 80,
                 "hideFrom": {
                   "legend": false,
@@ -1407,7 +1261,7 @@
                 "steps": [
                   {
                     "color": "green",
-                    "value": null
+                    "value": 0
                   },
                   {
                     "color": "yellow",
@@ -1524,14 +1378,18 @@
             ]
           },
           "gridPos": {
-            "h": 10,
-            "w": 19,
+            "h": 14,
+            "w": 18,
             "x": 0,
-            "y": 39
+            "y": 35
           },
           "id": 111,
           "options": {
             "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "displayMode": "list",
               "placement": "bottom",
@@ -1541,11 +1399,12 @@
             "rowHeight": 0.8,
             "showValue": "never",
             "tooltip": {
+              "hideZeros": false,
               "mode": "single",
               "sort": "none"
             }
           },
-          "pluginVersion": "13.0.0-23605486576",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1553,7 +1412,7 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", response_status=\"success\"})) - max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", response_status=\"success\"})",
+              "expr": "-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", response_status=\"success\"}))",
               "legendFormat": "{{provider}} - {{source_region}}",
               "range": true,
               "refId": "A"
@@ -1567,15 +1426,11 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "getMasterchainInfo success rate — the method used for block lag tracking. Low success rate means the provider's block lag data is incomplete.",
+          "description": "Block lag tracking summary. % at Tip = percentage of time seqno lag ≤ 2 (tip is best provider in same region). Success Rate = getMasterchainInfo reliability.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
-              },
               "custom": {
-                "align": "left",
+                "align": "auto",
                 "cellOptions": {
                   "type": "auto"
                 },
@@ -1583,62 +1438,177 @@
                   "reducers": []
                 },
                 "inspect": false,
-                "wrapHeaderText": false
+                "minWidth": 110
               },
-              "decimals": 2,
-              "mappings": [
-                {
-                  "options": {
-                    "from": 0.99991,
-                    "result": {
-                      "index": 0,
-                      "text": "100.0%"
-                    },
-                    "to": 1
-                  },
-                  "type": "range"
-                }
-              ],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "1"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
                     "id": "custom.width",
-                    "value": 70
+                    "value": 108
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Region"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "fra1": {
+                            "index": 0,
+                            "text": "EU"
+                          },
+                          "sfo1": {
+                            "index": 2,
+                            "text": "US"
+                          },
+                          "sin1": {
+                            "index": 1,
+                            "text": "SG"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 60
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "% at Tip"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percent"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": 0
+                        },
+                        {
+                          "color": "orange",
+                          "value": 80
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 90
+                        },
+                        {
+                          "color": "green",
+                          "value": 99
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 85
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "SR"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 68
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 10,
-            "w": 5,
-            "x": 19,
-            "y": 39
+            "h": 14,
+            "w": 6,
+            "x": 18,
+            "y": 35
           },
           "id": 105,
           "options": {
             "cellHeight": "sm",
-            "showHeader": false
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "% at Tip"
+              }
+            ]
           },
-          "pluginVersion": "13.0.0-23605486576",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1647,21 +1617,29 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", api_method=\"getMasterchainInfo\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", api_method=\"getMasterchainInfo\"}[$__range])) by (provider, source_region)",
+              "expr": "100 * (1 - avg_over_time((clamp_min(-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", response_status=\"success\"})), 0) > bool 2)[$__range:$__interval]))",
+              "format": "table",
               "instant": true,
-              "range": false,
-              "legendFormat": "{{provider}} - {{source_region}}",
               "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", response_status=\"success\"} >= 0)[$__range:$__interval])) by (provider, source_region)\n/\nsum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\"} >= 0)[$__range:$__interval])) by (provider, source_region)",
+              "format": "table",
+              "instant": true,
+              "refId": "B"
             }
           ],
-          "title": "Success rate",
+          "title": "Block lag summary",
           "transformations": [
             {
-              "id": "joinByField",
-              "options": {
-                "byField": "Time",
-                "mode": "outer"
-              }
+              "id": "merge",
+              "options": {}
             },
             {
               "id": "organize",
@@ -1669,38 +1647,38 @@
                 "excludeByName": {
                   "Time": true
                 },
-                "includeByName": {},
                 "indexByName": {
-                  "Chainstack - fra1": 1,
-                  "Chainstack - sin1": 2,
-                  "Quicknode-Growth - fra1": 3,
-                  "Quicknode-Growth - sin1": 4,
-                  "TonCenter-WithAPIKey - fra1": 5,
-                  "TonCenter-WithAPIKey - sin1": 6,
-                  "dRPC - fra1": 7,
-                  "dRPC - sin1": 8,
-                  "Time": 0
+                  "Value #A": 2,
+                  "Value #B": 3,
+                  "provider": 0,
+                  "source_region": 1
                 },
                 "renameByName": {
-                  "Chainstack - fra1": "Chainstack-Growth - EU",
-                  "Chainstack - sin1": "Chainstack-Growth - SG",
-                  "Quicknode-Growth - fra1": "Quicknode-Growth - EU",
-                  "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
-                  "TonCenter-WithAPIKey - fra1": "TonCenter-WithAPIKey - EU",
-                  "TonCenter-WithAPIKey - sin1": "TonCenter-WithAPIKey - SG",
-                  "dRPC - fra1": "dRPC-Growth - EU",
-                  "dRPC - sin1": "dRPC-Growth - SG"
+                  "Value #A": "% at Tip",
+                  "Value #B": "SR",
+                  "provider": "Provider",
+                  "source_region": "Region"
                 }
               }
             },
             {
-              "id": "transpose",
-              "options": {}
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": true,
+                    "field": "% at Tip"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
         }
-      ]
+      ],
+      "title": "Block lag",
+      "type": "row"
     },
     {
       "collapsed": true,
@@ -1708,9 +1686,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 57
+        "y": 35
       },
-      "id": 87,
+      "id": 113,
       "panels": [
         {
           "datasource": {
@@ -1776,9 +1754,9 @@
           },
           "gridPos": {
             "h": 12,
-            "w": 19,
+            "w": 18,
             "x": 0,
-            "y": 58
+            "y": 36
           },
           "id": 3,
           "options": {
@@ -1788,7 +1766,6 @@
             },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1804,7 +1781,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "13.0.0-23605486576",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1879,12 +1856,8 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
-              },
               "custom": {
-                "align": "left",
+                "align": "auto",
                 "cellOptions": {
                   "type": "auto"
                 },
@@ -1892,45 +1865,104 @@
                   "reducers": []
                 },
                 "inspect": false,
-                "wrapHeaderText": false
+                "minWidth": 110
               },
-              "decimals": 2,
-              "mappings": [
-                {
-                  "options": {
-                    "from": 0.99991,
-                    "result": {
-                      "index": 0,
-                      "text": "100.0%"
-                    },
-                    "to": 1
-                  },
-                  "type": "range"
-                }
-              ],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "1"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
                     "id": "custom.width",
-                    "value": 70
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Region"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "fra1": {
+                            "index": 0,
+                            "text": "EU"
+                          },
+                          "sfo1": {
+                            "index": 2,
+                            "text": "US"
+                          },
+                          "sin1": {
+                            "index": 1,
+                            "text": "SG"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 72
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
@@ -1938,89 +1970,50 @@
           },
           "gridPos": {
             "h": 12,
-            "w": 5,
-            "x": 19,
-            "y": 58
+            "w": 6,
+            "x": 18,
+            "y": 36
           },
           "id": 83,
           "options": {
             "cellHeight": "sm",
-            "showHeader": false
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "13.0.0-23605486576",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", api_method=\"runGetMethod\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", api_method=\"runGetMethod\"}[$__range])) by (provider, source_region)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
+              "format": "table",
               "instant": true,
-              "interval": "",
-              "legendFormat": "{{provider}} - {{source_region}}",
-              "range": false,
-              "refId": "A",
-              "useBackend": false
+              "refId": "A"
             }
           ],
           "title": "Success rate",
           "transformations": [
-            {
-              "id": "joinByField",
-              "options": {
-                "byField": "Time",
-                "mode": "outer"
-              }
-            },
             {
               "id": "organize",
               "options": {
                 "excludeByName": {
                   "Time": true
                 },
-                "includeByName": {},
                 "indexByName": {
-                  "Chainstack - fra1": 1,
-                  "Chainstack - sfo1": 3,
-                  "Chainstack - sin1": 2,
-                  "Quicknode-Growth - fra1": 4,
-                  "Quicknode-Growth - sfo1": 6,
-                  "Quicknode-Growth - sin1": 5,
-                  "Time": 0,
-                  "TonCenter-WithAPIKey - fra1": 7,
-                  "TonCenter-WithAPIKey - sfo1": 9,
-                  "TonCenter-WithAPIKey - sin1": 8,
-                  "dRPC - fra1": 10,
-                  "dRPC - sfo1": 12,
-                  "dRPC - sin1": 11
+                  "Value": 2,
+                  "provider": 0,
+                  "source_region": 1
                 },
                 "renameByName": {
-                  "Alchemy-Growth - fra1": "Alchemy-Growth - EU",
-                  "Alchemy-Growth - sfo1": "Alchemy-Growth - US West",
-                  "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
-                  "Chainstack - fra1": "Chainstack-Growth - EU",
-                  "Chainstack - sfo1": "Chainstack-Growth - US West",
-                  "Chainstack - sin1": "Chainstack-Growth - SG",
-                  "Quicknode-Growth - fra1": "Quicknode-Growth - EU",
-                  "Quicknode-Growth - sfo1": "Quicknode-Growth - US West",
-                  "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
-                  "TonCenter-WithAPIKey - fra1": "TonCenter-WithAPIKey - EU",
-                  "TonCenter-WithAPIKey - sfo1": "TonCenter-WithAPIKey - US West",
-                  "TonCenter-WithAPIKey - sin1": "TonCenter-WithAPIKey - SG",
-                  "dRPC - fra1": "dRPC-Growth - EU",
-                  "dRPC - sfo1": "dRPC-Growth - US West",
-                  "dRPC - sin1": "dRPC-Growth - SG"
+                  "Value": "Success Rate",
+                  "provider": "Provider",
+                  "source_region": "Region"
                 }
               }
-            },
-            {
-              "id": "transpose",
-              "options": {}
             }
           ],
           "type": "table"
@@ -2089,9 +2082,9 @@
           },
           "gridPos": {
             "h": 12,
-            "w": 19,
+            "w": 18,
             "x": 0,
-            "y": 70
+            "y": 48
           },
           "id": 71,
           "options": {
@@ -2101,7 +2094,6 @@
             },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -2117,7 +2109,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "13.0.0-23605486576",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -2192,12 +2184,8 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
-              },
               "custom": {
-                "align": "left",
+                "align": "auto",
                 "cellOptions": {
                   "type": "auto"
                 },
@@ -2205,45 +2193,104 @@
                   "reducers": []
                 },
                 "inspect": false,
-                "wrapHeaderText": false
+                "minWidth": 110
               },
-              "decimals": 2,
-              "mappings": [
-                {
-                  "options": {
-                    "from": 0.99991,
-                    "result": {
-                      "index": 0,
-                      "text": "100.0%"
-                    },
-                    "to": 1
-                  },
-                  "type": "range"
-                }
-              ],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "1"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
                     "id": "custom.width",
-                    "value": 70
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Region"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "fra1": {
+                            "index": 0,
+                            "text": "EU"
+                          },
+                          "sfo1": {
+                            "index": 2,
+                            "text": "US"
+                          },
+                          "sin1": {
+                            "index": 1,
+                            "text": "SG"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 72
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
@@ -2251,89 +2298,50 @@
           },
           "gridPos": {
             "h": 12,
-            "w": 5,
-            "x": 19,
-            "y": 70
+            "w": 6,
+            "x": 18,
+            "y": 48
           },
           "id": 72,
           "options": {
             "cellHeight": "sm",
-            "showHeader": false
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "13.0.0-23605486576",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", api_method=\"getAddressBalance\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", api_method=\"getAddressBalance\"}[$__range])) by (provider, source_region)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
+              "format": "table",
               "instant": true,
-              "interval": "",
-              "legendFormat": "{{provider}} - {{source_region}}",
-              "range": false,
-              "refId": "A",
-              "useBackend": false
+              "refId": "A"
             }
           ],
           "title": "Success rate",
           "transformations": [
-            {
-              "id": "joinByField",
-              "options": {
-                "byField": "Time",
-                "mode": "outer"
-              }
-            },
             {
               "id": "organize",
               "options": {
                 "excludeByName": {
                   "Time": true
                 },
-                "includeByName": {},
                 "indexByName": {
-                  "Chainstack - fra1": 1,
-                  "Chainstack - sfo1": 3,
-                  "Chainstack - sin1": 2,
-                  "Quicknode-Growth - fra1": 4,
-                  "Quicknode-Growth - sfo1": 6,
-                  "Quicknode-Growth - sin1": 5,
-                  "Time": 0,
-                  "TonCenter-WithAPIKey - fra1": 7,
-                  "TonCenter-WithAPIKey - sfo1": 9,
-                  "TonCenter-WithAPIKey - sin1": 8,
-                  "dRPC - fra1": 10,
-                  "dRPC - sfo1": 12,
-                  "dRPC - sin1": 11
+                  "Value": 2,
+                  "provider": 0,
+                  "source_region": 1
                 },
                 "renameByName": {
-                  "Alchemy-Growth - fra1": "Alchemy-Growth - EU",
-                  "Alchemy-Growth - sfo1": "Alchemy-Growth - US West",
-                  "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
-                  "Chainstack - fra1": "Chainstack-Growth - EU",
-                  "Chainstack - sfo1": "Chainstack-Growth - US West",
-                  "Chainstack - sin1": "Chainstack-Growth - SG",
-                  "Quicknode-Growth - fra1": "Quicknode-Growth - EU",
-                  "Quicknode-Growth - sfo1": "Quicknode-Growth - US West",
-                  "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
-                  "TonCenter-WithAPIKey - fra1": "TonCenter-WithAPIKey - EU",
-                  "TonCenter-WithAPIKey - sfo1": "TonCenter-WithAPIKey - US West",
-                  "TonCenter-WithAPIKey - sin1": "TonCenter-WithAPIKey - SG",
-                  "dRPC - fra1": "dRPC-Growth - EU",
-                  "dRPC - sfo1": "dRPC-Growth - US West",
-                  "dRPC - sin1": "dRPC-Growth - SG"
+                  "Value": "Success Rate",
+                  "provider": "Provider",
+                  "source_region": "Region"
                 }
               }
-            },
-            {
-              "id": "transpose",
-              "options": {}
             }
           ],
           "type": "table"
@@ -2402,9 +2410,9 @@
           },
           "gridPos": {
             "h": 12,
-            "w": 19,
+            "w": 18,
             "x": 0,
-            "y": 82
+            "y": 60
           },
           "id": 73,
           "options": {
@@ -2414,7 +2422,6 @@
             },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -2430,7 +2437,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "13.0.0-23605486576",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -2505,12 +2512,8 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
-              },
               "custom": {
-                "align": "left",
+                "align": "auto",
                 "cellOptions": {
                   "type": "auto"
                 },
@@ -2518,45 +2521,104 @@
                   "reducers": []
                 },
                 "inspect": false,
-                "wrapHeaderText": false
+                "minWidth": 110
               },
-              "decimals": 2,
-              "mappings": [
-                {
-                  "options": {
-                    "from": 0.99991,
-                    "result": {
-                      "index": 0,
-                      "text": "100.0%"
-                    },
-                    "to": 1
-                  },
-                  "type": "range"
-                }
-              ],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "1"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
                     "id": "custom.width",
-                    "value": 70
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Region"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "fra1": {
+                            "index": 0,
+                            "text": "EU"
+                          },
+                          "sfo1": {
+                            "index": 2,
+                            "text": "US"
+                          },
+                          "sin1": {
+                            "index": 1,
+                            "text": "SG"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 72
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
@@ -2564,89 +2626,50 @@
           },
           "gridPos": {
             "h": 12,
-            "w": 5,
-            "x": 19,
-            "y": 82
+            "w": 6,
+            "x": 18,
+            "y": 60
           },
           "id": 74,
           "options": {
             "cellHeight": "sm",
-            "showHeader": false
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "13.0.0-23605486576",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", api_method=\"getWalletInformation\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", api_method=\"getWalletInformation\"}[$__range])) by (provider, source_region)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
+              "format": "table",
               "instant": true,
-              "interval": "",
-              "legendFormat": "{{provider}} - {{source_region}}",
-              "range": false,
-              "refId": "A",
-              "useBackend": false
+              "refId": "A"
             }
           ],
           "title": "Success rate",
           "transformations": [
-            {
-              "id": "joinByField",
-              "options": {
-                "byField": "Time",
-                "mode": "outer"
-              }
-            },
             {
               "id": "organize",
               "options": {
                 "excludeByName": {
                   "Time": true
                 },
-                "includeByName": {},
                 "indexByName": {
-                  "Chainstack - fra1": 1,
-                  "Chainstack - sfo1": 3,
-                  "Chainstack - sin1": 2,
-                  "Quicknode-Growth - fra1": 4,
-                  "Quicknode-Growth - sfo1": 6,
-                  "Quicknode-Growth - sin1": 5,
-                  "Time": 0,
-                  "TonCenter-WithAPIKey - fra1": 7,
-                  "TonCenter-WithAPIKey - sfo1": 9,
-                  "TonCenter-WithAPIKey - sin1": 8,
-                  "dRPC - fra1": 10,
-                  "dRPC - sfo1": 12,
-                  "dRPC - sin1": 11
+                  "Value": 2,
+                  "provider": 0,
+                  "source_region": 1
                 },
                 "renameByName": {
-                  "Alchemy-Growth - fra1": "Alchemy-Growth - EU",
-                  "Alchemy-Growth - sfo1": "Alchemy-Growth - US West",
-                  "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
-                  "Chainstack - fra1": "Chainstack-Growth - EU",
-                  "Chainstack - sfo1": "Chainstack-Growth - US West",
-                  "Chainstack - sin1": "Chainstack-Growth - SG",
-                  "Quicknode-Growth - fra1": "Quicknode-Growth - EU",
-                  "Quicknode-Growth - sfo1": "Quicknode-Growth - US West",
-                  "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
-                  "TonCenter-WithAPIKey - fra1": "TonCenter-WithAPIKey - EU",
-                  "TonCenter-WithAPIKey - sfo1": "TonCenter-WithAPIKey - US West",
-                  "TonCenter-WithAPIKey - sin1": "TonCenter-WithAPIKey - SG",
-                  "dRPC - fra1": "dRPC-Growth - EU",
-                  "dRPC - sfo1": "dRPC-Growth - US West",
-                  "dRPC - sin1": "dRPC-Growth - SG"
+                  "Value": "Success Rate",
+                  "provider": "Provider",
+                  "source_region": "Region"
                 }
               }
-            },
-            {
-              "id": "transpose",
-              "options": {}
             }
           ],
           "type": "table"
@@ -2715,9 +2738,9 @@
           },
           "gridPos": {
             "h": 12,
-            "w": 19,
+            "w": 18,
             "x": 0,
-            "y": 94
+            "y": 72
           },
           "id": 75,
           "options": {
@@ -2727,7 +2750,6 @@
             },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -2743,7 +2765,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "13.0.0-23605486576",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -2818,12 +2840,8 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
-              },
               "custom": {
-                "align": "left",
+                "align": "auto",
                 "cellOptions": {
                   "type": "auto"
                 },
@@ -2831,45 +2849,104 @@
                   "reducers": []
                 },
                 "inspect": false,
-                "wrapHeaderText": false
+                "minWidth": 110
               },
-              "decimals": 2,
-              "mappings": [
-                {
-                  "options": {
-                    "from": 0.99991,
-                    "result": {
-                      "index": 0,
-                      "text": "100.0%"
-                    },
-                    "to": 1
-                  },
-                  "type": "range"
-                }
-              ],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "1"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
                     "id": "custom.width",
-                    "value": 70
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Region"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "fra1": {
+                            "index": 0,
+                            "text": "EU"
+                          },
+                          "sfo1": {
+                            "index": 2,
+                            "text": "US"
+                          },
+                          "sin1": {
+                            "index": 1,
+                            "text": "SG"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 72
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
@@ -2877,89 +2954,50 @@
           },
           "gridPos": {
             "h": 12,
-            "w": 5,
-            "x": 19,
-            "y": 94
+            "w": 6,
+            "x": 18,
+            "y": 72
           },
           "id": 76,
           "options": {
             "cellHeight": "sm",
-            "showHeader": false
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "13.0.0-23605486576",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", api_method=\"getBlockTransactions\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", api_method=\"getBlockTransactions\"}[$__range])) by (provider, source_region)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
+              "format": "table",
               "instant": true,
-              "interval": "",
-              "legendFormat": "{{provider}} - {{source_region}}",
-              "range": false,
-              "refId": "A",
-              "useBackend": false
+              "refId": "A"
             }
           ],
           "title": "Success rate",
           "transformations": [
-            {
-              "id": "joinByField",
-              "options": {
-                "byField": "Time",
-                "mode": "outer"
-              }
-            },
             {
               "id": "organize",
               "options": {
                 "excludeByName": {
                   "Time": true
                 },
-                "includeByName": {},
                 "indexByName": {
-                  "Chainstack - fra1": 1,
-                  "Chainstack - sfo1": 3,
-                  "Chainstack - sin1": 2,
-                  "Quicknode-Growth - fra1": 4,
-                  "Quicknode-Growth - sfo1": 6,
-                  "Quicknode-Growth - sin1": 5,
-                  "Time": 0,
-                  "TonCenter-WithAPIKey - fra1": 7,
-                  "TonCenter-WithAPIKey - sfo1": 9,
-                  "TonCenter-WithAPIKey - sin1": 8,
-                  "dRPC - fra1": 10,
-                  "dRPC - sfo1": 12,
-                  "dRPC - sin1": 11
+                  "Value": 2,
+                  "provider": 0,
+                  "source_region": 1
                 },
                 "renameByName": {
-                  "Alchemy-Growth - fra1": "Alchemy-Growth - EU",
-                  "Alchemy-Growth - sfo1": "Alchemy-Growth - US West",
-                  "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
-                  "Chainstack - fra1": "Chainstack-Growth - EU",
-                  "Chainstack - sfo1": "Chainstack-Growth - US West",
-                  "Chainstack - sin1": "Chainstack-Growth - SG",
-                  "Quicknode-Growth - fra1": "Quicknode-Growth - EU",
-                  "Quicknode-Growth - sfo1": "Quicknode-Growth - US West",
-                  "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
-                  "TonCenter-WithAPIKey - fra1": "TonCenter-WithAPIKey - EU",
-                  "TonCenter-WithAPIKey - sfo1": "TonCenter-WithAPIKey - US West",
-                  "TonCenter-WithAPIKey - sin1": "TonCenter-WithAPIKey - SG",
-                  "dRPC - fra1": "dRPC-Growth - EU",
-                  "dRPC - sfo1": "dRPC-Growth - US West",
-                  "dRPC - sin1": "dRPC-Growth - SG"
+                  "Value": "Success Rate",
+                  "provider": "Provider",
+                  "source_region": "Region"
                 }
               }
-            },
-            {
-              "id": "transpose",
-              "options": {}
             }
           ],
           "type": "table"
@@ -3028,15 +3066,18 @@
           },
           "gridPos": {
             "h": 12,
-            "w": 19,
+            "w": 18,
             "x": 0,
-            "y": 106
+            "y": 84
           },
           "id": 77,
           "options": {
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -3052,7 +3093,7 @@
               "sort": "none"
             }
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -3127,12 +3168,8 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
-              },
               "custom": {
-                "align": "left",
+                "align": "auto",
                 "cellOptions": {
                   "type": "auto"
                 },
@@ -3140,45 +3177,104 @@
                   "reducers": []
                 },
                 "inspect": false,
-                "wrapHeaderText": false
+                "minWidth": 110
               },
-              "decimals": 2,
-              "mappings": [
-                {
-                  "options": {
-                    "from": 0.99991,
-                    "result": {
-                      "index": 0,
-                      "text": "100.0%"
-                    },
-                    "to": 1
-                  },
-                  "type": "range"
-                }
-              ],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "1"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
                     "id": "custom.width",
-                    "value": 70
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Region"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "fra1": {
+                            "index": 0,
+                            "text": "EU"
+                          },
+                          "sfo1": {
+                            "index": 2,
+                            "text": "US"
+                          },
+                          "sin1": {
+                            "index": 1,
+                            "text": "SG"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 72
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
@@ -3186,89 +3282,50 @@
           },
           "gridPos": {
             "h": 12,
-            "w": 5,
-            "x": 19,
-            "y": 106
+            "w": 6,
+            "x": 18,
+            "y": 84
           },
           "id": 78,
           "options": {
             "cellHeight": "sm",
-            "showHeader": false
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", api_method=\"getBlockHeader\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", api_method=\"getBlockHeader\"}[$__range])) by (provider, source_region)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
+              "format": "table",
               "instant": true,
-              "interval": "",
-              "legendFormat": "{{provider}} - {{source_region}}",
-              "range": false,
-              "refId": "A",
-              "useBackend": false
+              "refId": "A"
             }
           ],
           "title": "Success rate",
           "transformations": [
-            {
-              "id": "joinByField",
-              "options": {
-                "byField": "Time",
-                "mode": "outer"
-              }
-            },
             {
               "id": "organize",
               "options": {
                 "excludeByName": {
                   "Time": true
                 },
-                "includeByName": {},
                 "indexByName": {
-                  "Chainstack - fra1": 1,
-                  "Chainstack - sfo1": 3,
-                  "Chainstack - sin1": 2,
-                  "Quicknode-Growth - fra1": 4,
-                  "Quicknode-Growth - sfo1": 6,
-                  "Quicknode-Growth - sin1": 5,
-                  "Time": 0,
-                  "TonCenter-WithAPIKey - fra1": 7,
-                  "TonCenter-WithAPIKey - sfo1": 9,
-                  "TonCenter-WithAPIKey - sin1": 8,
-                  "dRPC - fra1": 10,
-                  "dRPC - sfo1": 12,
-                  "dRPC - sin1": 11
+                  "Value": 2,
+                  "provider": 0,
+                  "source_region": 1
                 },
                 "renameByName": {
-                  "Alchemy-Growth - fra1": "Alchemy-Growth - EU",
-                  "Alchemy-Growth - sfo1": "Alchemy-Growth - US West",
-                  "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
-                  "Chainstack - fra1": "Chainstack-Growth - EU",
-                  "Chainstack - sfo1": "Chainstack-Growth - US West",
-                  "Chainstack - sin1": "Chainstack-Growth - SG",
-                  "Quicknode-Growth - fra1": "Quicknode-Growth - EU",
-                  "Quicknode-Growth - sfo1": "Quicknode-Growth - US West",
-                  "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
-                  "TonCenter-WithAPIKey - fra1": "TonCenter-WithAPIKey - EU",
-                  "TonCenter-WithAPIKey - sfo1": "TonCenter-WithAPIKey - US West",
-                  "TonCenter-WithAPIKey - sin1": "TonCenter-WithAPIKey - SG",
-                  "dRPC - fra1": "dRPC-Growth - EU",
-                  "dRPC - sfo1": "dRPC-Growth - US West",
-                  "dRPC - sin1": "dRPC-Growth - SG"
+                  "Value": "Success Rate",
+                  "provider": "Provider",
+                  "source_region": "Region"
                 }
               }
-            },
-            {
-              "id": "transpose",
-              "options": {}
             }
           ],
           "type": "table"
@@ -3323,6 +3380,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: TON",
   "uid": "fe3mtxna6483ke-TON-global",
-  "version": 66,
+  "version": 104,
   "weekStart": "monday"
 }


### PR DESCRIPTION
## Summary
- Fix block lag PromQL queries on global dashboards — use per-region tip instead of cross-region `scalar(max(...))` to eliminate artificial lag from cron timing skew
- Unify panel styles across all 7 Solana/TON dashboards (2 global, 5 regional): overview SR, block lag summary, historical line charts, historical success rate tables, and comparison charts
- Convert regional block lag section to match global layout: timeline + combined summary table (Provider, % at Tip, SR)
- Restore "Chainstack vs. XXX" comparison sections to reference style (Monad): h=5 w=12 paired layout, linear scale, centered zero, area thresholds

## Test plan
- [x] Verify block lag panels show realistic per-region lag (no more "all regions red" on global dashboards)
- [x] Confirm unified column widths and formatting across all success rate tables
- [x] Check historical line charts use log scale with p95+max legend
- [x] Verify comparison charts render correctly with paired layout and difference visualization
- [x] Confirm all dashboards load without errors in Grafana

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Reorganized Block lag visualizations across dashboards to display timeline and summary table views for improved analysis clarity.

* **Style**
  * Updated dashboard panel layouts, thresholds, and display options for better visibility and readability across all regional dashboard variants.

* **Chores**
  * Incremented dashboard versions to reflect configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->