### PR TITLE
feat(dashboards): update Hyperliquid dashboards with block lag panels and unified panel styles

### DIFF
--- a/dashboards/dashboards/compare-dashboard-hyperliquid-eu.json
+++ b/dashboards/dashboards/compare-dashboard-hyperliquid-eu.json
@@ -842,7 +842,345 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 24
+        "y": 25
+      },
+      "id": 1100,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 3
+                  },
+                  {
+                    "color": "orange",
+                    "value": 10
+                  },
+                  {
+                    "color": "red",
+                    "value": 20
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 14,
+            "w": 18,
+            "x": 0,
+            "y": 30
+          },
+          "id": 1101,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.0.0-23605486576",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"Hyperliquid\", source_region=\"fra1\", response_status=\"success\"})) - max by (provider) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Hyperliquid\", source_region=\"fra1\", response_status=\"success\"})",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Block lag timeline",
+          "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 108
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "% at Tip"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percent"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": 0
+                        },
+                        {
+                          "color": "orange",
+                          "value": 80
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 90
+                        },
+                        {
+                          "color": "green",
+                          "value": 99
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 85
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "SR"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 68
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 14,
+            "w": 6,
+            "x": 18,
+            "y": 30
+          },
+          "id": 1102,
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "% at Tip"
+              }
+            ]
+          },
+          "pluginVersion": "13.0.0-23605486576",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "100 * (1 - avg_over_time((clamp_min(scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"Hyperliquid\", source_region=\"fra1\", response_status=\"success\"})) - max by (provider) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Hyperliquid\", source_region=\"fra1\", response_status=\"success\"}), 0) > bool 2)[$__range:1m]))",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"fra1\"}[$__range])) by (provider)",
+              "format": "table",
+              "instant": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Block lag summary",
+          "transformations": [
+            {
+              "id": "merge",
+              "options": {}
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value #A": 1,
+                  "Value #B": 2,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value #A": "% at Tip",
+                  "Value #B": "SR",
+                  "provider": "Provider"
+                }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": true,
+                    "field": "% at Tip"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "title": "Block lag",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 42
       },
       "id": 7,
       "panels": [
@@ -936,8 +1274,8 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 24
           },
@@ -945,7 +1283,6 @@
           "options": {
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -986,97 +1323,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "dRPC"
+                  "options": "Success Rate"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "dRPC-Growth"
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 24
           },
           "id": 33,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.2.0-17638611789.patch2",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"fra1\", api_method=\"eth_call\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"fra1\", api_method=\"eth_call\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "exemplar": false,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"fra1\", api_method=\"eth_call\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"fra1\", api_method=\"eth_call\"}[$__range])) by (provider)",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1172,8 +1543,8 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 32
           },
@@ -1181,7 +1552,6 @@
           "options": {
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1222,97 +1592,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "dRPC"
+                  "options": "Success Rate"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "dRPC-Growth"
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 32
           },
           "id": 35,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.2.0-17638611789.patch2",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"fra1\", api_method=\"eth_getBalance\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"fra1\", api_method=\"eth_getBalance\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "exemplar": false,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"fra1\", api_method=\"eth_getBalance\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"fra1\", api_method=\"eth_getBalance\"}[$__range])) by (provider)",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1408,8 +1812,8 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 40
           },
@@ -1417,7 +1821,6 @@
           "options": {
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1458,97 +1861,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "dRPC"
+                  "options": "Success Rate"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "dRPC-Growth"
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 40
           },
           "id": 97,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.2.0-17638611789.patch2",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"fra1\", api_method=\"eth_getLogs\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"fra1\", api_method=\"eth_getLogs\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "exemplar": false,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"fra1\", api_method=\"eth_getLogs\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"fra1\", api_method=\"eth_getLogs\"}[$__range])) by (provider)",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1640,8 +2077,8 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 48
           },
@@ -1649,7 +2086,6 @@
           "options": {
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1690,97 +2126,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "dRPC"
+                  "options": "Success Rate"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "dRPC-Growth"
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 48
           },
           "id": 44,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.2.0-17638611789.patch2",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"fra1\", api_method=\"eth_getTransactionReceipt\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"fra1\", api_method=\"eth_getTransactionReceipt\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "exemplar": false,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"fra1\", api_method=\"eth_getTransactionReceipt\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"fra1\", api_method=\"eth_getTransactionReceipt\"}[$__range])) by (provider)",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1876,8 +2346,8 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 56
           },
@@ -1885,7 +2355,6 @@
           "options": {
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1926,97 +2395,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "dRPC"
+                  "options": "Success Rate"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "dRPC-Growth"
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 56
           },
           "id": 34,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.2.0-17638611789.patch2",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"fra1\", api_method=\"eth_blockNumber\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"fra1\", api_method=\"eth_blockNumber\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "exemplar": false,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"fra1\", api_method=\"eth_blockNumber\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"fra1\", api_method=\"eth_blockNumber\"}[$__range])) by (provider)",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -2112,8 +2615,8 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 64
           },
@@ -2121,7 +2624,6 @@
           "options": {
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -2162,97 +2664,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "dRPC"
+                  "options": "Success Rate"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "dRPC-Growth"
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 64
           },
           "id": 101,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.2.0-17638611789.patch2",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"fra1\", api_method=\"clearinghouseState\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"fra1\", api_method=\"clearinghouseState\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "exemplar": false,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"fra1\", api_method=\"clearinghouseState\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"fra1\", api_method=\"clearinghouseState\"}[$__range])) by (provider)",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -2348,8 +2884,8 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 72
           },
@@ -2357,7 +2893,6 @@
           "options": {
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -2398,97 +2933,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "dRPC"
+                  "options": "Success Rate"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "dRPC-Growth"
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 72
           },
           "id": 103,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.2.0-17638611789.patch2",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"fra1\", api_method=\"openOrders\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"fra1\", api_method=\"openOrders\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "exemplar": false,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"fra1\", api_method=\"openOrders\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"fra1\", api_method=\"openOrders\"}[$__range])) by (provider)",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         }
       ],
       "title": "Historical data",
@@ -2500,7 +3069,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 43
       },
       "id": 23,
       "panels": [
@@ -3244,7 +3813,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 44
       },
       "id": 32,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-hyperliquid-japan.json
+++ b/dashboards/dashboards/compare-dashboard-hyperliquid-japan.json
@@ -862,7 +862,345 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 24
+        "y": 25
+      },
+      "id": 1100,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 3
+                  },
+                  {
+                    "color": "orange",
+                    "value": 10
+                  },
+                  {
+                    "color": "red",
+                    "value": 20
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 14,
+            "w": 18,
+            "x": 0,
+            "y": 30
+          },
+          "id": 1101,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.0.0-23605486576",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"Hyperliquid\", source_region=\"hnd1\", response_status=\"success\"})) - max by (provider) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Hyperliquid\", source_region=\"hnd1\", response_status=\"success\"})",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Block lag timeline",
+          "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 108
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "% at Tip"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percent"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": 0
+                        },
+                        {
+                          "color": "orange",
+                          "value": 80
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 90
+                        },
+                        {
+                          "color": "green",
+                          "value": 99
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 85
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "SR"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 68
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 14,
+            "w": 6,
+            "x": 18,
+            "y": 30
+          },
+          "id": 1102,
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "% at Tip"
+              }
+            ]
+          },
+          "pluginVersion": "13.0.0-23605486576",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "100 * (1 - avg_over_time((clamp_min(scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"Hyperliquid\", source_region=\"hnd1\", response_status=\"success\"})) - max by (provider) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Hyperliquid\", source_region=\"hnd1\", response_status=\"success\"}), 0) > bool 2)[$__range:1m]))",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"hnd1\", response_status=\"success\"}[$__range])) by (provider)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"hnd1\"}[$__range])) by (provider)",
+              "format": "table",
+              "instant": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Block lag summary",
+          "transformations": [
+            {
+              "id": "merge",
+              "options": {}
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value #A": 1,
+                  "Value #B": 2,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value #A": "% at Tip",
+                  "Value #B": "SR",
+                  "provider": "Provider"
+                }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": true,
+                    "field": "% at Tip"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "title": "Block lag",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 42
       },
       "id": 7,
       "panels": [
@@ -956,8 +1294,8 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 24
           },
@@ -965,7 +1303,6 @@
           "options": {
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1006,97 +1343,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "dRPC"
+                  "options": "Success Rate"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "dRPC-Growth"
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 24
           },
           "id": 33,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.2.0-17638611789.patch2",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"hnd1\", api_method=\"eth_call\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"hnd1\", api_method=\"eth_call\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "exemplar": false,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"hnd1\", api_method=\"eth_call\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"hnd1\", api_method=\"eth_call\"}[$__range])) by (provider)",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1192,8 +1563,8 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 32
           },
@@ -1201,7 +1572,6 @@
           "options": {
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1242,97 +1612,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "dRPC"
+                  "options": "Success Rate"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "dRPC-Growth"
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 32
           },
           "id": 35,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.2.0-17638611789.patch2",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"hnd1\", api_method=\"eth_getBalance\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"hnd1\", api_method=\"eth_getBalance\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "exemplar": false,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"hnd1\", api_method=\"eth_getBalance\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"hnd1\", api_method=\"eth_getBalance\"}[$__range])) by (provider)",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1428,8 +1832,8 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 40
           },
@@ -1437,7 +1841,6 @@
           "options": {
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1478,97 +1881,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "dRPC"
+                  "options": "Success Rate"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "dRPC-Growth"
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 40
           },
           "id": 63,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.2.0-17638611789.patch2",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"hnd1\", api_method=\"eth_getLogs\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"hnd1\", api_method=\"eth_getLogs\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "exemplar": false,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"hnd1\", api_method=\"eth_getLogs\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"hnd1\", api_method=\"eth_getLogs\"}[$__range])) by (provider)",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1660,8 +2097,8 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 48
           },
@@ -1669,7 +2106,6 @@
           "options": {
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1710,97 +2146,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "dRPC"
+                  "options": "Success Rate"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "dRPC-Growth"
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 48
           },
           "id": 44,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.2.0-17638611789.patch2",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"hnd1\", api_method=\"eth_getTransactionReceipt\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"hnd1\", api_method=\"eth_getTransactionReceipt\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "exemplar": false,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"hnd1\", api_method=\"eth_getTransactionReceipt\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"hnd1\", api_method=\"eth_getTransactionReceipt\"}[$__range])) by (provider)",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1896,8 +2366,8 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 56
           },
@@ -1905,7 +2375,6 @@
           "options": {
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1946,97 +2415,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "dRPC"
+                  "options": "Success Rate"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "dRPC-Growth"
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 56
           },
           "id": 34,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.2.0-17638611789.patch2",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"hnd1\", api_method=\"eth_blockNumber\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"hnd1\", api_method=\"eth_blockNumber\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "exemplar": false,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"hnd1\", api_method=\"eth_blockNumber\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"hnd1\", api_method=\"eth_blockNumber\"}[$__range])) by (provider)",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -2132,8 +2635,8 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 64
           },
@@ -2141,7 +2644,6 @@
           "options": {
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -2182,97 +2684,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "dRPC"
+                  "options": "Success Rate"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "dRPC-Growth"
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 64
           },
           "id": 67,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.2.0-17638611789.patch2",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"hnd1\", api_method=\"clearinghouseState\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"hnd1\", api_method=\"clearinghouseState\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "exemplar": false,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"hnd1\", api_method=\"clearinghouseState\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"hnd1\", api_method=\"clearinghouseState\"}[$__range])) by (provider)",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -2368,8 +2904,8 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 72
           },
@@ -2377,7 +2913,6 @@
           "options": {
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -2418,97 +2953,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "dRPC"
+                  "options": "Success Rate"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "dRPC-Growth"
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 72
           },
           "id": 69,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.2.0-17638611789.patch2",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"hnd1\", api_method=\"clearinghouseState\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"hnd1\", api_method=\"clearinghouseState\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "exemplar": false,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"hnd1\", api_method=\"openOrders\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"hnd1\", api_method=\"openOrders\"}[$__range])) by (provider)",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         }
       ],
       "title": "Historical data",
@@ -2520,7 +3089,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 43
       },
       "id": 23,
       "panels": [
@@ -3329,7 +3898,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 44
       },
       "id": 32,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-hyperliquid-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-hyperliquid-us-west.json
@@ -861,7 +861,345 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 24
+        "y": 25
+      },
+      "id": 1100,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 3
+                  },
+                  {
+                    "color": "orange",
+                    "value": 10
+                  },
+                  {
+                    "color": "red",
+                    "value": 20
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 14,
+            "w": 18,
+            "x": 0,
+            "y": 30
+          },
+          "id": 1101,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.0.0-23605486576",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"Hyperliquid\", source_region=\"sfo1\", response_status=\"success\"})) - max by (provider) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Hyperliquid\", source_region=\"sfo1\", response_status=\"success\"})",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Block lag timeline",
+          "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 108
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "% at Tip"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percent"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": 0
+                        },
+                        {
+                          "color": "orange",
+                          "value": 80
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 90
+                        },
+                        {
+                          "color": "green",
+                          "value": 99
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 85
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "SR"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 68
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 14,
+            "w": 6,
+            "x": 18,
+            "y": 30
+          },
+          "id": 1102,
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "% at Tip"
+              }
+            ]
+          },
+          "pluginVersion": "13.0.0-23605486576",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "100 * (1 - avg_over_time((clamp_min(scalar(max(response_latency_seconds{metric_type=\"block_number\", blockchain=\"Hyperliquid\", source_region=\"sfo1\", response_status=\"success\"})) - max by (provider) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Hyperliquid\", source_region=\"sfo1\", response_status=\"success\"}), 0) > bool 2)[$__range:1m]))",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"sfo1\", response_status=\"success\"}[$__range])) by (provider)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"sfo1\"}[$__range])) by (provider)",
+              "format": "table",
+              "instant": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Block lag summary",
+          "transformations": [
+            {
+              "id": "merge",
+              "options": {}
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value #A": 1,
+                  "Value #B": 2,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value #A": "% at Tip",
+                  "Value #B": "SR",
+                  "provider": "Provider"
+                }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": true,
+                    "field": "% at Tip"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "title": "Block lag",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 42
       },
       "id": 7,
       "panels": [
@@ -955,8 +1293,8 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 24
           },
@@ -964,7 +1302,6 @@
           "options": {
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1005,97 +1342,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "dRPC"
+                  "options": "Success Rate"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "dRPC-Growth"
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 24
           },
           "id": 33,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.2.0-17638611789.patch2",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"sfo1\", api_method=\"eth_call\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"sfo1\", api_method=\"eth_call\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "exemplar": false,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"sfo1\", api_method=\"eth_call\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"sfo1\", api_method=\"eth_call\"}[$__range])) by (provider)",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1191,8 +1562,8 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 32
           },
@@ -1200,7 +1571,6 @@
           "options": {
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1241,97 +1611,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "dRPC"
+                  "options": "Success Rate"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "dRPC-Growth"
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 32
           },
           "id": 35,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.2.0-17638611789.patch2",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"sfo1\", api_method=\"eth_getBalance\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"sfo1\", api_method=\"eth_getBalance\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "exemplar": false,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"sfo1\", api_method=\"eth_getBalance\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"sfo1\", api_method=\"eth_getBalance\"}[$__range])) by (provider)",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1427,8 +1831,8 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 40
           },
@@ -1436,7 +1840,6 @@
           "options": {
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1477,97 +1880,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "dRPC"
+                  "options": "Success Rate"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "dRPC-Growth"
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 40
           },
           "id": 63,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.2.0-17638611789.patch2",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"sfo1\", api_method=\"eth_getLogs\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"sfo1\", api_method=\"eth_getLogs\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "exemplar": false,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"sfo1\", api_method=\"eth_getLogs\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"sfo1\", api_method=\"eth_getLogs\"}[$__range])) by (provider)",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1659,8 +2096,8 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 48
           },
@@ -1668,7 +2105,6 @@
           "options": {
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1709,97 +2145,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "dRPC"
+                  "options": "Success Rate"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "dRPC-Growth"
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 48
           },
           "id": 44,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.2.0-17638611789.patch2",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"sfo1\", api_method=\"eth_getTransactionReceipt\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"sfo1\", api_method=\"eth_getTransactionReceipt\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "exemplar": false,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"sfo1\", api_method=\"eth_getTransactionReceipt\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"sfo1\", api_method=\"eth_getTransactionReceipt\"}[$__range])) by (provider)",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -1895,8 +2365,8 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 56
           },
@@ -1904,7 +2374,6 @@
           "options": {
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1945,97 +2414,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "dRPC"
+                  "options": "Success Rate"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "dRPC-Growth"
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 56
           },
           "id": 34,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.2.0-17638611789.patch2",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"sfo1\", api_method=\"eth_blockNumber\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"sfo1\", api_method=\"eth_blockNumber\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "exemplar": false,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"sfo1\", api_method=\"eth_blockNumber\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"sfo1\", api_method=\"eth_blockNumber\"}[$__range])) by (provider)",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -2131,8 +2634,8 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 64
           },
@@ -2140,7 +2643,6 @@
           "options": {
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -2181,97 +2683,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "dRPC"
+                  "options": "Success Rate"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "dRPC-Growth"
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 64
           },
           "id": 67,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.2.0-17638611789.patch2",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"sfo1\", api_method=\"clearinghouseState\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"sfo1\", api_method=\"clearinghouseState\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "exemplar": false,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"sfo1\", api_method=\"clearinghouseState\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"sfo1\", api_method=\"clearinghouseState\"}[$__range])) by (provider)",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "datasource": {
@@ -2367,8 +2903,8 @@
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 20,
+            "h": 12,
+            "w": 18,
             "x": 0,
             "y": 72
           },
@@ -2376,7 +2912,6 @@
           "options": {
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -2417,97 +2952,131 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "dRPC"
+                  "options": "Success Rate"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "dRPC-Growth"
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
+            "h": 12,
+            "w": 6,
+            "x": 18,
             "y": 72
           },
           "id": 69,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.2.0-17638611789.patch2",
+          "pluginVersion": "13.0.0-23605486576",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"sfo1\", api_method=\"openOrders\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=\"sfo1\", api_method=\"openOrders\"}[$__range])) by (provider)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
-              "instant": false,
-              "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
-              "refId": "A",
-              "useBackend": false
+              "exemplar": false,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"sfo1\", api_method=\"openOrders\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"sfo1\", api_method=\"openOrders\"}[$__range])) by (provider)",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
             }
           ],
           "title": "Success rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
         }
       ],
       "title": "Historical data",
@@ -2519,7 +3088,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 25
+        "y": 43
       },
       "id": 23,
       "panels": [
@@ -3328,7 +3897,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 44
       },
       "id": 32,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-hyperliquid.json
+++ b/dashboards/dashboards/compare-dashboard-hyperliquid.json
@@ -327,10 +327,6 @@
                       "sfo1": {
                         "index": 3,
                         "text": "US West"
-                      },
-                      "sin1": {
-                        "index": 1,
-                        "text": "SG"
                       }
                     },
                     "type": "value"
@@ -480,7 +476,6 @@
             "cellOptions": {
               "type": "auto"
             },
-            "filterable": true,
             "footer": {
               "reducers": []
             },
@@ -518,19 +513,83 @@
           {
             "matcher": {
               "id": "byName",
-              "options": "1"
+              "options": "Provider"
             },
             "properties": [
               {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "Chainstack": {
+                        "index": 0,
+                        "text": "Chainstack-Growth"
+                      },
+                      "dRPC": {
+                        "index": 1,
+                        "text": "dRPC-Growth"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
+              },
+              {
                 "id": "custom.width",
                 "value": 120
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Region"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "options": {
+                      "fra1": {
+                        "index": 0,
+                        "text": "EU"
+                      },
+                      "sfo1": {
+                        "index": 2,
+                        "text": "US West"
+                      },
+                      "hnd1": {
+                        "index": 1,
+                        "text": "JP"
+                      }
+                    },
+                    "type": "value"
+                  }
+                ]
               },
+              {
+                "id": "custom.width",
+                "value": 80
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "SR"
+            },
+            "properties": [
               {
                 "id": "custom.cellOptions",
                 "value": {
                   "mode": "basic",
                   "type": "gauge"
                 }
+              },
+              {
+                "id": "custom.width",
+                "value": 120
               }
             ]
           }
@@ -557,13 +616,12 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", response_status=\"success\", api_method=~\"(eth_call|eth_getBalance|eth_getLogs|eth_getTransactionReceipt|eth_blockNumber)\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=~\"fra1|sfo1|hnd1\"} >= 0)[$__range:$__interval])) by (provider, source_region)\r\n/\r\nsum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", api_method=~\"(eth_call|eth_getBalance|eth_getLogs|eth_getTransactionReceipt|eth_blockNumber)\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", source_region=~\"fra1|sfo1|hnd1\"} >= 0)[$__range:$__interval])) by (provider, source_region)",
+          "expr": "sum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", response_status=\"success\"} >= 0)[$__range:$__interval])) by (provider, source_region)\r\n/\r\nsum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\"} >= 0)[$__range:$__interval])) by (provider, source_region)",
+          "format": "table",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": true,
           "interval": "",
-          "legendFormat": "{{provider}} - {{source_region}}",
-          "range": false,
           "refId": "A",
           "useBackend": false
         }
@@ -571,64 +629,22 @@
       "title": "Success rate",
       "transformations": [
         {
-          "id": "joinByField",
-          "options": {
-            "byField": "Time",
-            "mode": "outer"
-          }
-        },
-        {
           "id": "organize",
           "options": {
             "excludeByName": {
               "Time": true
             },
-            "includeByName": {},
             "indexByName": {
-              "Alchemy-Growth - fra1": 1,
-              "Alchemy-Growth - hnd1": 2,
-              "Alchemy-Growth - sfo1": 3,
-              "Chainstack - fra1": 4,
-              "Chainstack - hnd1": 5,
-              "Chainstack - sfo1": 6,
-              "HypeRPC-Free - fra1": 7,
-              "HypeRPC-Free - hnd1": 8,
-              "HypeRPC-Free - sfo1": 9,
-              "Quicknode-Growth - fra1": 10,
-              "Quicknode-Growth - hnd1": 11,
-              "Quicknode-Growth - sfo1": 12,
-              "Time": 0
+              "Value": 2,
+              "provider": 0,
+              "source_region": 1
             },
             "renameByName": {
-              "Alchemy-Growth - fra1": "Alchemy-Growth - EU",
-              "Alchemy-Growth - hnd1": "Alchemy-Growth - JP",
-              "Alchemy-Growth - kix1": "Alchemy-Growth - JP",
-              "Alchemy-Growth - sfo1": "Alchemy-Growth - US West",
-              "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
-              "Chainstack - fra1": "Chainstack-Growth - EU",
-              "Chainstack - hnd1": "Chainstack-Growth - JP",
-              "Chainstack - kix1": "Chainstack-Growth - JP",
-              "Chainstack - sfo1": "Chainstack-Growth - US West",
-              "Chainstack - sin1": "Chainstack-Growth - SG",
-              "HypeRPC-Free - fra1": "HypeRPC-Free - EU",
-              "HypeRPC-Free - hnd1": "HypeRPC-Free - JP",
-              "HypeRPC-Free - sfo1": "HypeRPC-Free - US West",
-              "Quicknode-Growth - fra1": "Quicknode-Growth - EU",
-              "Quicknode-Growth - hnd1": "Quicknode-Growth - JP",
-              "Quicknode-Growth - kix1": "Quicknode-Growth - JP",
-              "Quicknode-Growth - sfo1": "Quicknode-Growth - US West",
-              "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
-              "dRPC - fra1": "dRPC-Growth - EU",
-              "dRPC - hnd1": "dRPC-Growth - JP",
-              "dRPC - kix1": "dRPC-Growth - JP",
-              "dRPC - sfo1": "dRPC-Growth - US West",
-              "dRPC - sin1": "dRPC-Growth - SG"
+              "Value": "SR",
+              "provider": "Provider",
+              "source_region": "Region"
             }
           }
-        },
-        {
-          "id": "transpose",
-          "options": {}
         }
       ],
       "type": "table"
@@ -1231,12 +1247,10 @@
               "Alchemy-Growth hnd1": "Alchemy-Growth - JP",
               "Alchemy-Growth kix1": "Alchemy-Growth - JP",
               "Alchemy-Growth sfo1": "Alchemy-Growth - US West",
-              "Alchemy-Growth sin1": "Alchemy-Growth - SG",
               "Chainstack fra1": "Chainstack-Growth - EU",
               "Chainstack hnd1": "Chainstack-Growth - JP",
               "Chainstack kix1": "Chainstack-Growth - JP",
               "Chainstack sfo1": "Chainstack-Growth - US West",
-              "Chainstack sin1": "Chainstack-Growth - SG",
               "HypeRPC-Free fra1": "HypeRPC-Free - EU",
               "HypeRPC-Free hnd1": "HypeRPC-Free - JP",
               "HypeRPC-Free sfo1": "HypeRPC-Free - US West",
@@ -1244,12 +1258,10 @@
               "Quicknode-Growth hnd1": "Quicknode-Growth - JP",
               "Quicknode-Growth kix1": "Quicknode-Growth - JP",
               "Quicknode-Growth sfo1": "Quicknode-Growth - US West",
-              "Quicknode-Growth sin1": "Quicknode-Growth - SG",
               "dRPC fra1": "dRPC-Growth - EU",
               "dRPC hnd1": "dRPC-Growth - JP",
               "dRPC kix1": "dRPC-Growth - JP",
-              "dRPC sfo1": "dRPC-Growth - US West",
-              "dRPC sin1": "dRPC-Growth - SG"
+              "dRPC sfo1": "dRPC-Growth - US West"
             }
           }
         }
@@ -1416,12 +1428,10 @@
               "Alchemy-Growth hnd1": "Alchemy-Growth - JP",
               "Alchemy-Growth kix1": "Alchemy-Growth - JP",
               "Alchemy-Growth sfo1": "Alchemy-Growth - US West",
-              "Alchemy-Growth sin1": "Alchemy-Growth - SG",
               "Chainstack fra1": "Chainstack-Growth - EU",
               "Chainstack hnd1": "Chainstack-Growth - JP",
               "Chainstack kix1": "Chainstack-Growth - JP",
               "Chainstack sfo1": "Chainstack-Growth - US West",
-              "Chainstack sin1": "Chainstack-Growth - SG",
               "HypeRPC-Free fra1": "HypeRPC-Free - EU",
               "HypeRPC-Free hnd1": "HypeRPC-Free - JP",
               "HypeRPC-Free sfo1": "HypeRPC-Free - US West",
@@ -1429,12 +1439,10 @@
               "Quicknode-Growth hnd1": "Quicknode-Growth - JP",
               "Quicknode-Growth kix1": "Quicknode-Growth - JP",
               "Quicknode-Growth sfo1": "Quicknode-Growth - US West",
-              "Quicknode-Growth sin1": "Quicknode-Growth - SG",
               "dRPC fra1": "dRPC-Growth - EU",
               "dRPC hnd1": "dRPC-Growth - JP",
               "dRPC kix1": "dRPC-Growth - JP",
-              "dRPC sfo1": "dRPC-Growth - US West",
-              "dRPC sin1": "dRPC-Growth - SG"
+              "dRPC sfo1": "dRPC-Growth - US West"
             }
           }
         }
@@ -1590,12 +1598,10 @@
               "Alchemy-Growth hnd1": "Alchemy-Growth - JP",
               "Alchemy-Growth kix1": "Alchemy-Growth - JP",
               "Alchemy-Growth sfo1": "Alchemy-Growth - US West",
-              "Alchemy-Growth sin1": "Alchemy-Growth - SG",
               "Chainstack fra1": "Chainstack-Growth - EU",
               "Chainstack hnd1": "Chainstack-Growth - JP",
               "Chainstack kix1": "Chainstack-Growth - JP",
               "Chainstack sfo1": "Chainstack-Growth - US West",
-              "Chainstack sin1": "Chainstack-Growth - SG",
               "HypeRPC-Free fra1": "HypeRPC-Free - EU",
               "HypeRPC-Free hnd1": "HypeRPC-Free - JP",
               "HypeRPC-Free sfo1": "HypeRPC-Free - US West",
@@ -1603,12 +1609,10 @@
               "Quicknode-Growth hnd1": "Quicknode-Growth - JP",
               "Quicknode-Growth kix1": "Quicknode-Growth - JP",
               "Quicknode-Growth sfo1": "Quicknode-Growth - US West",
-              "Quicknode-Growth sin1": "Quicknode-Growth - SG",
               "dRPC fra1": "dRPC-Growth - EU",
               "dRPC hnd1": "dRPC-Growth - JP",
               "dRPC kix1": "dRPC-Growth - JP",
-              "dRPC sfo1": "dRPC-Growth - US West",
-              "dRPC sin1": "dRPC-Growth - SG"
+              "dRPC sfo1": "dRPC-Growth - US West"
             }
           }
         }
@@ -1622,6 +1626,548 @@
         "w": 24,
         "x": 0,
         "y": 35
+      },
+      "id": 200,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Each row is a provider-region. Lag is relative to the best provider in the same region. Color shows severity: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20).",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 3
+                  },
+                  {
+                    "color": "orange",
+                    "value": 10
+                  },
+                  {
+                    "color": "red",
+                    "value": 20
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Alchemy-Growth - fra1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Alchemy-Growth - EU"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Alchemy-Growth - hnd1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Alchemy-Growth - JP"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Alchemy-Growth - sfo1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Alchemy-Growth - US"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack - fra1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth - EU"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack - hnd1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth - JP"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack - sfo1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth - US"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Helius-Developer - fra1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Helius-Developer - EU"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Helius-Developer - hnd1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Helius-Developer - JP"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Helius-Developer - sfo1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Helius-Developer - US"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Quicknode-Growth - fra1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Quicknode-Growth - EU"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Quicknode-Growth - hnd1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Quicknode-Growth - JP"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Quicknode-Growth - sfo1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Quicknode-Growth - US"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC - fra1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth - EU"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC - hnd1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth - JP"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC - sfo1"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth - US"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 14,
+            "w": 18,
+            "x": 0,
+            "y": 36
+          },
+          "id": 201,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Hyperliquid\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Hyperliquid\", response_status=\"success\"}))",
+              "legendFormat": "{{provider}} - {{source_region}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Block lag timeline",
+          "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Block lag tracking summary. % at Tip = percentage of time slot lag \u2264 2 (tip is best provider in same region). Success Rate = getLatestBlockhash reliability.",
+          "fieldConfig": {
+            "defaults": {
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
+              },
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 108
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Region"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "fra1": {
+                            "index": 0,
+                            "text": "EU"
+                          },
+                          "sfo1": {
+                            "index": 2,
+                            "text": "US"
+                          },
+                          "hnd1": {
+                            "index": 1,
+                            "text": "JP"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 60
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "% at Tip"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percent"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": 0
+                        },
+                        {
+                          "color": "orange",
+                          "value": 80
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 90
+                        },
+                        {
+                          "color": "green",
+                          "value": 99
+                        }
+                      ]
+                    }
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 85
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "SR"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 68
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 14,
+            "w": 6,
+            "x": 18,
+            "y": 36
+          },
+          "id": 202,
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "% at Tip"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "100 * (1 - avg_over_time((clamp_min(-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Hyperliquid\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Hyperliquid\", response_status=\"success\"})), 0) > bool 2)[$__range:1m]))",
+              "format": "table",
+              "instant": true,
+              "refId": "A"
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", response_status=\"success\"}[$__range])) by (provider, source_region)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\"}[$__range])) by (provider, source_region)",
+              "format": "table",
+              "instant": true,
+              "refId": "B"
+            }
+          ],
+          "title": "Block lag summary",
+          "transformations": [
+            {
+              "id": "merge",
+              "options": {}
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value #A": 2,
+                  "Value #B": 3,
+                  "provider": 0,
+                  "source_region": 1
+                },
+                "renameByName": {
+                  "Value #A": "% at Tip",
+                  "Value #B": "SR",
+                  "provider": "Provider",
+                  "source_region": "Region"
+                }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": true,
+                    "field": "% at Tip"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "title": "Block lag",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 36
       },
       "id": 105,
       "panels": [
@@ -1689,7 +2235,7 @@
           },
           "gridPos": {
             "h": 12,
-            "w": 19,
+            "w": 18,
             "x": 0,
             "y": 36
           },
@@ -1697,7 +2243,6 @@
           "options": {
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -1763,12 +2308,10 @@
                   "Alchemy-Growth - hnd1": "Alchemy-Growth - JP",
                   "Alchemy-Growth - kix1": "Alchemy-Growth - JP (Osaka)",
                   "Alchemy-Growth - sfo1": "Alchemy-Growth - US West",
-                  "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
                   "Chainstack - fra1": "Chainstack-Growth - EU",
                   "Chainstack - hnd1": "Chainstack-Growth - JP",
                   "Chainstack - kix1": "Chainstack-Growth - JP (Osaka)",
                   "Chainstack - sfo1": "Chainstack-Growth - US West",
-                  "Chainstack - sin1": "Chainstack-Growth - SG",
                   "HypeRPC-Free - fra1": "HypeRPC-Free - EU",
                   "HypeRPC-Free - hnd1": "HypeRPC-Free - JP",
                   "HypeRPC-Free - sfo1": "HypeRPC-Free - US West",
@@ -1776,12 +2319,10 @@
                   "Quicknode-Growth - hnd1": "Quicknode-Growth - JP",
                   "Quicknode-Growth - kix1": "Quicknode-Growth - JP (Osaka)",
                   "Quicknode-Growth - sfo1": "Quicknode-Growth - US West",
-                  "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
                   "dRPC - fra1": "dRPC-Growth - EU",
                   "dRPC - hnd1": "dRPC-Growth - JP",
                   "dRPC - kix1": "dRPC-Growth - JP (Osaka)",
-                  "dRPC - sfo1": "dRPC-Growth - US West",
-                  "dRPC - sin1": "dRPC-Growth - SG"
+                  "dRPC - sfo1": "dRPC-Growth - US West"
                 }
               }
             }
@@ -1796,12 +2337,8 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
-              },
               "custom": {
-                "align": "left",
+                "align": "auto",
                 "cellOptions": {
                   "type": "auto"
                 },
@@ -1809,45 +2346,104 @@
                   "reducers": []
                 },
                 "inspect": false,
-                "wrapHeaderText": false
+                "minWidth": 110
               },
-              "decimals": 2,
-              "mappings": [
-                {
-                  "options": {
-                    "from": 0.9999,
-                    "result": {
-                      "index": 0,
-                      "text": "100.0%"
-                    },
-                    "to": 1
-                  },
-                  "type": "range"
-                }
-              ],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "1"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
                     "id": "custom.width",
-                    "value": 70
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Region"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "fra1": {
+                            "index": 0,
+                            "text": "EU"
+                          },
+                          "sfo1": {
+                            "index": 2,
+                            "text": "US"
+                          },
+                          "hnd1": {
+                            "index": 1,
+                            "text": "JP"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 72
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
@@ -1855,8 +2451,8 @@
           },
           "gridPos": {
             "h": 12,
-            "w": 5,
-            "x": 19,
+            "w": 6,
+            "x": 18,
             "y": 36
           },
           "id": 83,
@@ -1865,88 +2461,40 @@
             "showHeader": false,
             "sortBy": []
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", api_method=\"eth_call\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", api_method=\"eth_call\"}[$__range])) by (provider, source_region)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", api_method=\"eth_call\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", api_method=\"eth_call\"}[$__range])) by (provider, source_region)",
+              "format": "table",
               "instant": true,
-              "interval": "",
-              "legendFormat": "{{provider}} - {{source_region}}",
-              "range": false,
-              "refId": "A",
-              "useBackend": false
+              "refId": "A"
             }
           ],
           "title": "Success rate",
           "transformations": [
-            {
-              "id": "joinByField",
-              "options": {
-                "byField": "Time",
-                "mode": "outer"
-              }
-            },
             {
               "id": "organize",
               "options": {
                 "excludeByName": {
                   "Time": true
                 },
-                "includeByName": {},
                 "indexByName": {
-                  "Alchemy-Growth - fra1": 1,
-                  "Alchemy-Growth - hnd1": 2,
-                  "Alchemy-Growth - sfo1": 3,
-                  "Chainstack - fra1": 4,
-                  "Chainstack - hnd1": 5,
-                  "Chainstack - sfo1": 6,
-                  "HypeRPC-Free - fra1": 7,
-                  "HypeRPC-Free - hnd1": 8,
-                  "HypeRPC-Free - sfo1": 9,
-                  "Quicknode-Growth - fra1": 10,
-                  "Quicknode-Growth - hnd1": 11,
-                  "Quicknode-Growth - sfo1": 12,
-                  "Time": 0
+                  "Value": 2,
+                  "provider": 0,
+                  "source_region": 1
                 },
                 "renameByName": {
-                  "Alchemy-Growth - fra1": "Alchemy-Growth - EU",
-                  "Alchemy-Growth - hnd1": "Alchemy-Growth - JP",
-                  "Alchemy-Growth - kix1": "Alchemy-Growth - JP (Osaka)",
-                  "Alchemy-Growth - sfo1": "Alchemy-Growth - US West",
-                  "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
-                  "Chainstack - fra1": "Chainstack-Growth - EU",
-                  "Chainstack - hnd1": "Chainstack-Growth - JP",
-                  "Chainstack - kix1": "Chainstack-Growth - JP (Osaka)",
-                  "Chainstack - sfo1": "Chainstack-Growth - US West",
-                  "Chainstack - sin1": "Chainstack-Growth - SG",
-                  "HypeRPC-Free - fra1": "HypeRPC-Free - EU",
-                  "HypeRPC-Free - hnd1": "HypeRPC-Free - JP",
-                  "HypeRPC-Free - sfo1": "HypeRPC-Free - US West",
-                  "Quicknode-Growth - fra1": "Quicknode-Growth - EU",
-                  "Quicknode-Growth - hnd1": "Quicknode-Growth - JP",
-                  "Quicknode-Growth - kix1": "Quicknode-Growth - JP (Osaka)",
-                  "Quicknode-Growth - sfo1": "Quicknode-Growth - US West",
-                  "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
-                  "dRPC - fra1": "dRPC-Growth - EU",
-                  "dRPC - hnd1": "dRPC-Growth - JP",
-                  "dRPC - kix1": "dRPC-Growth - JP (Osaka)",
-                  "dRPC - sfo1": "dRPC-Growth - US West",
-                  "dRPC - sin1": "dRPC-Growth - SG"
+                  "Value": "Success Rate",
+                  "provider": "Provider",
+                  "source_region": "Region"
                 }
               }
-            },
-            {
-              "id": "transpose",
-              "options": {}
             }
           ],
           "type": "table"
@@ -2015,7 +2563,7 @@
           },
           "gridPos": {
             "h": 12,
-            "w": 19,
+            "w": 18,
             "x": 0,
             "y": 48
           },
@@ -2023,7 +2571,6 @@
           "options": {
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -2089,12 +2636,10 @@
                   "Alchemy-Growth - hnd1": "Alchemy-Growth - JP",
                   "Alchemy-Growth - kix1": "Alchemy-Growth - JP (Osaka)",
                   "Alchemy-Growth - sfo1": "Alchemy-Growth - US West",
-                  "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
                   "Chainstack - fra1": "Chainstack-Growth - EU",
                   "Chainstack - hnd1": "Chainstack-Growth - JP",
                   "Chainstack - kix1": "Chainstack-Growth - JP (Osaka)",
                   "Chainstack - sfo1": "Chainstack-Growth - US West",
-                  "Chainstack - sin1": "Chainstack-Growth - SG",
                   "HypeRPC-Free - fra1": "HypeRPC-Free - EU",
                   "HypeRPC-Free - hnd1": "HypeRPC-Free - JP",
                   "HypeRPC-Free - sfo1": "HypeRPC-Free - US West",
@@ -2102,12 +2647,10 @@
                   "Quicknode-Growth - hnd1": "Quicknode-Growth - JP",
                   "Quicknode-Growth - kix1": "Quicknode-Growth - JP (Osaka)",
                   "Quicknode-Growth - sfo1": "Quicknode-Growth - US West",
-                  "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
                   "dRPC - fra1": "dRPC-Growth - EU",
                   "dRPC - hnd1": "dRPC-Growth - JP",
                   "dRPC - kix1": "dRPC-Growth - JP (Osaka)",
-                  "dRPC - sfo1": "dRPC-Growth - US West",
-                  "dRPC - sin1": "dRPC-Growth - SG"
+                  "dRPC - sfo1": "dRPC-Growth - US West"
                 }
               }
             }
@@ -2122,12 +2665,8 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
-              },
               "custom": {
-                "align": "left",
+                "align": "auto",
                 "cellOptions": {
                   "type": "auto"
                 },
@@ -2135,45 +2674,104 @@
                   "reducers": []
                 },
                 "inspect": false,
-                "wrapHeaderText": false
+                "minWidth": 110
               },
-              "decimals": 2,
-              "mappings": [
-                {
-                  "options": {
-                    "from": 0.9999,
-                    "result": {
-                      "index": 0,
-                      "text": "100.0%"
-                    },
-                    "to": 1
-                  },
-                  "type": "range"
-                }
-              ],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "1"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
                     "id": "custom.width",
-                    "value": 70
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Region"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "fra1": {
+                            "index": 0,
+                            "text": "EU"
+                          },
+                          "sfo1": {
+                            "index": 2,
+                            "text": "US"
+                          },
+                          "hnd1": {
+                            "index": 1,
+                            "text": "JP"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 72
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
@@ -2181,97 +2779,50 @@
           },
           "gridPos": {
             "h": 12,
-            "w": 5,
-            "x": 19,
+            "w": 6,
+            "x": 18,
             "y": 48
           },
           "id": 72,
           "options": {
             "cellHeight": "sm",
-            "showHeader": false
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", api_method=\"eth_getBalance\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", api_method=\"eth_getBalance\"}[$__range])) by (provider, source_region)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", api_method=\"eth_getBalance\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", api_method=\"eth_getBalance\"}[$__range])) by (provider, source_region)",
+              "format": "table",
               "instant": true,
-              "interval": "",
-              "legendFormat": "{{provider}} - {{source_region}}",
-              "range": false,
-              "refId": "A",
-              "useBackend": false
+              "refId": "A"
             }
           ],
           "title": "Success rate",
           "transformations": [
-            {
-              "id": "joinByField",
-              "options": {
-                "byField": "Time",
-                "mode": "outer"
-              }
-            },
             {
               "id": "organize",
               "options": {
                 "excludeByName": {
                   "Time": true
                 },
-                "includeByName": {},
                 "indexByName": {
-                  "Alchemy-Growth - fra1": 1,
-                  "Alchemy-Growth - hnd1": 2,
-                  "Alchemy-Growth - sfo1": 3,
-                  "Chainstack - fra1": 4,
-                  "Chainstack - hnd1": 5,
-                  "Chainstack - sfo1": 6,
-                  "HypeRPC-Free - fra1": 7,
-                  "HypeRPC-Free - hnd1": 8,
-                  "HypeRPC-Free - sfo1": 9,
-                  "Quicknode-Growth - fra1": 10,
-                  "Quicknode-Growth - hnd1": 11,
-                  "Quicknode-Growth - sfo1": 12,
-                  "Time": 0
+                  "Value": 2,
+                  "provider": 0,
+                  "source_region": 1
                 },
                 "renameByName": {
-                  "Alchemy-Growth - fra1": "Alchemy-Growth - EU",
-                  "Alchemy-Growth - hnd1": "Alchemy-Growth - JP",
-                  "Alchemy-Growth - kix1": "Alchemy-Growth - JP (Osaka)",
-                  "Alchemy-Growth - sfo1": "Alchemy-Growth - US West",
-                  "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
-                  "Chainstack - fra1": "Chainstack-Growth - EU",
-                  "Chainstack - hnd1": "Chainstack-Growth - JP",
-                  "Chainstack - kix1": "Chainstack-Growth - JP (Osaka)",
-                  "Chainstack - sfo1": "Chainstack-Growth - US West",
-                  "Chainstack - sin1": "Chainstack-Growth - SG",
-                  "HypeRPC-Free - fra1": "HypeRPC-Free - EU",
-                  "HypeRPC-Free - hnd1": "HypeRPC-Free - JP",
-                  "HypeRPC-Free - sfo1": "HypeRPC-Free - US West",
-                  "Quicknode-Growth - fra1": "Quicknode-Growth - EU",
-                  "Quicknode-Growth - hnd1": "Quicknode-Growth - JP",
-                  "Quicknode-Growth - kix1": "Quicknode-Growth - JP (Osaka)",
-                  "Quicknode-Growth - sfo1": "Quicknode-Growth - US West",
-                  "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
-                  "dRPC - fra1": "dRPC-Growth - EU",
-                  "dRPC - hnd1": "dRPC-Growth - JP",
-                  "dRPC - kix1": "dRPC-Growth - JP (Osaka)",
-                  "dRPC - sfo1": "dRPC-Growth - US West",
-                  "dRPC - sin1": "dRPC-Growth - SG"
+                  "Value": "Success Rate",
+                  "provider": "Provider",
+                  "source_region": "Region"
                 }
               }
-            },
-            {
-              "id": "transpose",
-              "options": {}
             }
           ],
           "type": "table"
@@ -2340,7 +2891,7 @@
           },
           "gridPos": {
             "h": 12,
-            "w": 19,
+            "w": 18,
             "x": 0,
             "y": 60
           },
@@ -2348,7 +2899,6 @@
           "options": {
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -2414,12 +2964,10 @@
                   "Alchemy-Growth - hnd1": "Alchemy-Growth - JP",
                   "Alchemy-Growth - kix1": "Alchemy-Growth - JP (Osaka)",
                   "Alchemy-Growth - sfo1": "Alchemy-Growth - US West",
-                  "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
                   "Chainstack - fra1": "Chainstack-Growth - EU",
                   "Chainstack - hnd1": "Chainstack-Growth - JP",
                   "Chainstack - kix1": "Chainstack-Growth - JP (Osaka)",
                   "Chainstack - sfo1": "Chainstack-Growth - US West",
-                  "Chainstack - sin1": "Chainstack-Growth - SG",
                   "HypeRPC-Free - fra1": "HypeRPC-Free - EU",
                   "HypeRPC-Free - hnd1": "HypeRPC-Free - JP",
                   "HypeRPC-Free - sfo1": "HypeRPC-Free - US West",
@@ -2427,12 +2975,10 @@
                   "Quicknode-Growth - hnd1": "Quicknode-Growth - JP",
                   "Quicknode-Growth - kix1": "Quicknode-Growth - JP (Osaka)",
                   "Quicknode-Growth - sfo1": "Quicknode-Growth - US West",
-                  "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
                   "dRPC - fra1": "dRPC-Growth - EU",
                   "dRPC - hnd1": "dRPC-Growth - JP",
                   "dRPC - kix1": "dRPC-Growth - JP (Osaka)",
-                  "dRPC - sfo1": "dRPC-Growth - US West",
-                  "dRPC - sin1": "dRPC-Growth - SG"
+                  "dRPC - sfo1": "dRPC-Growth - US West"
                 }
               }
             }
@@ -2447,12 +2993,8 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
-              },
               "custom": {
-                "align": "left",
+                "align": "auto",
                 "cellOptions": {
                   "type": "auto"
                 },
@@ -2460,45 +3002,104 @@
                   "reducers": []
                 },
                 "inspect": false,
-                "wrapHeaderText": false
+                "minWidth": 110
               },
-              "decimals": 2,
-              "mappings": [
-                {
-                  "options": {
-                    "from": 0.9999,
-                    "result": {
-                      "index": 0,
-                      "text": "100.0%"
-                    },
-                    "to": 1
-                  },
-                  "type": "range"
-                }
-              ],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "1"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
                     "id": "custom.width",
-                    "value": 70
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Region"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "fra1": {
+                            "index": 0,
+                            "text": "EU"
+                          },
+                          "sfo1": {
+                            "index": 2,
+                            "text": "US"
+                          },
+                          "hnd1": {
+                            "index": 1,
+                            "text": "JP"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 72
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
@@ -2506,97 +3107,50 @@
           },
           "gridPos": {
             "h": 12,
-            "w": 5,
-            "x": 19,
+            "w": 6,
+            "x": 18,
             "y": 60
           },
           "id": 98,
           "options": {
             "cellHeight": "sm",
-            "showHeader": false
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", api_method=\"eth_getLogs\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", api_method=\"eth_getLogs\"}[$__range])) by (provider, source_region)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", api_method=\"eth_getLogs\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", api_method=\"eth_getLogs\"}[$__range])) by (provider, source_region)",
+              "format": "table",
               "instant": true,
-              "interval": "",
-              "legendFormat": "{{provider}} - {{source_region}}",
-              "range": false,
-              "refId": "A",
-              "useBackend": false
+              "refId": "A"
             }
           ],
           "title": "Success rate",
           "transformations": [
-            {
-              "id": "joinByField",
-              "options": {
-                "byField": "Time",
-                "mode": "outer"
-              }
-            },
             {
               "id": "organize",
               "options": {
                 "excludeByName": {
                   "Time": true
                 },
-                "includeByName": {},
                 "indexByName": {
-                  "Alchemy-Growth - fra1": 1,
-                  "Alchemy-Growth - hnd1": 2,
-                  "Alchemy-Growth - sfo1": 3,
-                  "Chainstack - fra1": 4,
-                  "Chainstack - hnd1": 5,
-                  "Chainstack - sfo1": 6,
-                  "HypeRPC-Free - fra1": 7,
-                  "HypeRPC-Free - hnd1": 8,
-                  "HypeRPC-Free - sfo1": 9,
-                  "Quicknode-Growth - fra1": 10,
-                  "Quicknode-Growth - hnd1": 11,
-                  "Quicknode-Growth - sfo1": 12,
-                  "Time": 0
+                  "Value": 2,
+                  "provider": 0,
+                  "source_region": 1
                 },
                 "renameByName": {
-                  "Alchemy-Growth - fra1": "Alchemy-Growth - EU",
-                  "Alchemy-Growth - hnd1": "Alchemy-Growth - JP",
-                  "Alchemy-Growth - kix1": "Alchemy-Growth - JP (Osaka)",
-                  "Alchemy-Growth - sfo1": "Alchemy-Growth - US West",
-                  "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
-                  "Chainstack - fra1": "Chainstack-Growth - EU",
-                  "Chainstack - hnd1": "Chainstack-Growth - JP",
-                  "Chainstack - kix1": "Chainstack-Growth - JP (Osaka)",
-                  "Chainstack - sfo1": "Chainstack-Growth - US West",
-                  "Chainstack - sin1": "Chainstack-Growth - SG",
-                  "HypeRPC-Free - fra1": "HypeRPC-Free - EU",
-                  "HypeRPC-Free - hnd1": "HypeRPC-Free - JP",
-                  "HypeRPC-Free - sfo1": "HypeRPC-Free - US West",
-                  "Quicknode-Growth - fra1": "Quicknode-Growth - EU",
-                  "Quicknode-Growth - hnd1": "Quicknode-Growth - JP",
-                  "Quicknode-Growth - kix1": "Quicknode-Growth - JP (Osaka)",
-                  "Quicknode-Growth - sfo1": "Quicknode-Growth - US West",
-                  "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
-                  "dRPC - fra1": "dRPC-Growth - EU",
-                  "dRPC - hnd1": "dRPC-Growth - JP",
-                  "dRPC - kix1": "dRPC-Growth - JP (Osaka)",
-                  "dRPC - sfo1": "dRPC-Growth - US West",
-                  "dRPC - sin1": "dRPC-Growth - SG"
+                  "Value": "Success Rate",
+                  "provider": "Provider",
+                  "source_region": "Region"
                 }
               }
-            },
-            {
-              "id": "transpose",
-              "options": {}
             }
           ],
           "type": "table"
@@ -2665,7 +3219,7 @@
           },
           "gridPos": {
             "h": 12,
-            "w": 19,
+            "w": 18,
             "x": 0,
             "y": 72
           },
@@ -2673,7 +3227,6 @@
           "options": {
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -2739,12 +3292,10 @@
                   "Alchemy-Growth - hnd1": "Alchemy-Growth - JP",
                   "Alchemy-Growth - kix1": "Alchemy-Growth - JP (Osaka)",
                   "Alchemy-Growth - sfo1": "Alchemy-Growth - US West",
-                  "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
                   "Chainstack - fra1": "Chainstack-Growth - EU",
                   "Chainstack - hnd1": "Chainstack-Growth - JP",
                   "Chainstack - kix1": "Chainstack-Growth - JP (Osaka)",
                   "Chainstack - sfo1": "Chainstack-Growth - US West",
-                  "Chainstack - sin1": "Chainstack-Growth - SG",
                   "HypeRPC-Free - fra1": "HypeRPC-Free - EU",
                   "HypeRPC-Free - hnd1": "HypeRPC-Free - JP",
                   "HypeRPC-Free - sfo1": "HypeRPC-Free - US West",
@@ -2752,12 +3303,10 @@
                   "Quicknode-Growth - hnd1": "Quicknode-Growth - JP",
                   "Quicknode-Growth - kix1": "Quicknode-Growth - JP (Osaka)",
                   "Quicknode-Growth - sfo1": "Quicknode-Growth - US West",
-                  "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
                   "dRPC - fra1": "dRPC-Growth - EU",
                   "dRPC - hnd1": "dRPC-Growth - JP",
                   "dRPC - kix1": "dRPC-Growth - JP (Osaka)",
-                  "dRPC - sfo1": "dRPC-Growth - US West",
-                  "dRPC - sin1": "dRPC-Growth - SG"
+                  "dRPC - sfo1": "dRPC-Growth - US West"
                 }
               }
             }
@@ -2772,12 +3321,8 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
-              },
               "custom": {
-                "align": "left",
+                "align": "auto",
                 "cellOptions": {
                   "type": "auto"
                 },
@@ -2785,45 +3330,104 @@
                   "reducers": []
                 },
                 "inspect": false,
-                "wrapHeaderText": false
+                "minWidth": 110
               },
-              "decimals": 2,
-              "mappings": [
-                {
-                  "options": {
-                    "from": 0.999999,
-                    "result": {
-                      "index": 0,
-                      "text": "100.0%"
-                    },
-                    "to": 1
-                  },
-                  "type": "range"
-                }
-              ],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "1"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
                     "id": "custom.width",
-                    "value": 70
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Region"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "fra1": {
+                            "index": 0,
+                            "text": "EU"
+                          },
+                          "sfo1": {
+                            "index": 2,
+                            "text": "US"
+                          },
+                          "hnd1": {
+                            "index": 1,
+                            "text": "JP"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 72
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
@@ -2831,97 +3435,50 @@
           },
           "gridPos": {
             "h": 12,
-            "w": 5,
-            "x": 19,
+            "w": 6,
+            "x": 18,
             "y": 72
           },
           "id": 74,
           "options": {
             "cellHeight": "sm",
-            "showHeader": false
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", api_method=\"eth_getTransactionReceipt\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", api_method=\"eth_getTransactionReceipt\"}[$__range])) by (provider, source_region)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", api_method=\"eth_getTransactionReceipt\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", api_method=\"eth_getTransactionReceipt\"}[$__range])) by (provider, source_region)",
+              "format": "table",
               "instant": true,
-              "interval": "",
-              "legendFormat": "{{provider}} - {{source_region}}",
-              "range": false,
-              "refId": "A",
-              "useBackend": false
+              "refId": "A"
             }
           ],
           "title": "Success rate",
           "transformations": [
-            {
-              "id": "joinByField",
-              "options": {
-                "byField": "Time",
-                "mode": "outer"
-              }
-            },
             {
               "id": "organize",
               "options": {
                 "excludeByName": {
                   "Time": true
                 },
-                "includeByName": {},
                 "indexByName": {
-                  "Alchemy-Growth - fra1": 1,
-                  "Alchemy-Growth - hnd1": 2,
-                  "Alchemy-Growth - sfo1": 3,
-                  "Chainstack - fra1": 4,
-                  "Chainstack - hnd1": 5,
-                  "Chainstack - sfo1": 6,
-                  "HypeRPC-Free - fra1": 7,
-                  "HypeRPC-Free - hnd1": 8,
-                  "HypeRPC-Free - sfo1": 9,
-                  "Quicknode-Growth - fra1": 10,
-                  "Quicknode-Growth - hnd1": 11,
-                  "Quicknode-Growth - sfo1": 12,
-                  "Time": 0
+                  "Value": 2,
+                  "provider": 0,
+                  "source_region": 1
                 },
                 "renameByName": {
-                  "Alchemy-Growth - fra1": "Alchemy-Growth - EU",
-                  "Alchemy-Growth - hnd1": "Alchemy-Growth - JP",
-                  "Alchemy-Growth - kix1": "Alchemy-Growth - JP (Osaka)",
-                  "Alchemy-Growth - sfo1": "Alchemy-Growth - US West",
-                  "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
-                  "Chainstack - fra1": "Chainstack-Growth - EU",
-                  "Chainstack - hnd1": "Chainstack-Growth - JP",
-                  "Chainstack - kix1": "Chainstack-Growth - JP (Osaka)",
-                  "Chainstack - sfo1": "Chainstack-Growth - US West",
-                  "Chainstack - sin1": "Chainstack-Growth - SG",
-                  "HypeRPC-Free - fra1": "HypeRPC-Free - EU",
-                  "HypeRPC-Free - hnd1": "HypeRPC-Free - JP",
-                  "HypeRPC-Free - sfo1": "HypeRPC-Free - US West",
-                  "Quicknode-Growth - fra1": "Quicknode-Growth - EU",
-                  "Quicknode-Growth - hnd1": "Quicknode-Growth - JP",
-                  "Quicknode-Growth - kix1": "Quicknode-Growth - JP (Osaka)",
-                  "Quicknode-Growth - sfo1": "Quicknode-Growth - US West",
-                  "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
-                  "dRPC - fra1": "dRPC-Growth - EU",
-                  "dRPC - hnd1": "dRPC-Growth - JP",
-                  "dRPC - kix1": "dRPC-Growth - JP (Osaka)",
-                  "dRPC - sfo1": "dRPC-Growth - US West",
-                  "dRPC - sin1": "dRPC-Growth - SG"
+                  "Value": "Success Rate",
+                  "provider": "Provider",
+                  "source_region": "Region"
                 }
               }
-            },
-            {
-              "id": "transpose",
-              "options": {}
             }
           ],
           "type": "table"
@@ -2990,7 +3547,7 @@
           },
           "gridPos": {
             "h": 12,
-            "w": 19,
+            "w": 18,
             "x": 0,
             "y": 84
           },
@@ -2998,7 +3555,6 @@
           "options": {
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -3066,12 +3622,10 @@
                   "Alchemy-Growth - hnd1": "Alchemy-Growth - JP",
                   "Alchemy-Growth - kix1": "Alchemy-Growth - JP (Osaka)",
                   "Alchemy-Growth - sfo1": "Alchemy-Growth - US West",
-                  "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
                   "Chainstack - fra1": "Chainstack-Growth - EU",
                   "Chainstack - hnd1": "Chainstack-Growth - JP",
                   "Chainstack - kix1": "Chainstack-Growth - JP (Osaka)",
                   "Chainstack - sfo1": "Chainstack-Growth - US West",
-                  "Chainstack - sin1": "Chainstack-Growth - SG",
                   "HypeRPC-Free - fra1": "HypeRPC-Free - EU",
                   "HypeRPC-Free - hnd1": "HypeRPC-Free - JP",
                   "HypeRPC-Free - sfo1": "HypeRPC-Free - US West",
@@ -3079,12 +3633,10 @@
                   "Quicknode-Growth - hnd1": "Quicknode-Growth - JP",
                   "Quicknode-Growth - kix1": "Quicknode-Growth - JP (Osaka)",
                   "Quicknode-Growth - sfo1": "Quicknode-Growth - US West",
-                  "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
                   "dRPC - fra1": "dRPC-Growth - EU",
                   "dRPC - hnd1": "dRPC-Growth - JP",
                   "dRPC - kix1": "dRPC-Growth - JP (Osaka)",
-                  "dRPC - sfo1": "dRPC-Growth - US West",
-                  "dRPC - sin1": "dRPC-Growth - SG"
+                  "dRPC - sfo1": "dRPC-Growth - US West"
                 }
               }
             }
@@ -3099,12 +3651,8 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
-              },
               "custom": {
-                "align": "left",
+                "align": "auto",
                 "cellOptions": {
                   "type": "auto"
                 },
@@ -3112,45 +3660,104 @@
                   "reducers": []
                 },
                 "inspect": false,
-                "wrapHeaderText": false
+                "minWidth": 110
               },
-              "decimals": 2,
-              "mappings": [
-                {
-                  "options": {
-                    "from": 0.999901,
-                    "result": {
-                      "index": 0,
-                      "text": "100.0%"
-                    },
-                    "to": 1
-                  },
-                  "type": "range"
-                }
-              ],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "1"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
                     "id": "custom.width",
-                    "value": 70
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Region"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "fra1": {
+                            "index": 0,
+                            "text": "EU"
+                          },
+                          "sfo1": {
+                            "index": 2,
+                            "text": "US"
+                          },
+                          "hnd1": {
+                            "index": 1,
+                            "text": "JP"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 72
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
@@ -3158,97 +3765,50 @@
           },
           "gridPos": {
             "h": 12,
-            "w": 5,
-            "x": 19,
+            "w": 6,
+            "x": 18,
             "y": 84
           },
           "id": 78,
           "options": {
             "cellHeight": "sm",
-            "showHeader": false
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", api_method=\"eth_blockNumber\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", provider=~\"(Chainstack|Alchemy-Growth|Quicknode-Growth|dRPC)\", api_method=\"eth_blockNumber\"}[$__range])) by (provider, source_region)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
+              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", api_method=\"eth_blockNumber\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", api_method=\"eth_blockNumber\"}[$__range])) by (provider, source_region)",
+              "format": "table",
               "instant": true,
-              "interval": "",
-              "legendFormat": "{{provider}} - {{source_region}}",
-              "range": false,
-              "refId": "A",
-              "useBackend": false
+              "refId": "A"
             }
           ],
           "title": "Success rate",
           "transformations": [
-            {
-              "id": "joinByField",
-              "options": {
-                "byField": "Time",
-                "mode": "outer"
-              }
-            },
             {
               "id": "organize",
               "options": {
                 "excludeByName": {
                   "Time": true
                 },
-                "includeByName": {},
                 "indexByName": {
-                  "Alchemy-Growth - fra1": 1,
-                  "Alchemy-Growth - hnd1": 2,
-                  "Alchemy-Growth - sfo1": 3,
-                  "Chainstack - fra1": 4,
-                  "Chainstack - hnd1": 5,
-                  "Chainstack - sfo1": 6,
-                  "HypeRPC-Free - fra1": 7,
-                  "HypeRPC-Free - hnd1": 8,
-                  "HypeRPC-Free - sfo1": 9,
-                  "Quicknode-Growth - fra1": 10,
-                  "Quicknode-Growth - hnd1": 11,
-                  "Quicknode-Growth - sfo1": 12,
-                  "Time": 0
+                  "Value": 2,
+                  "provider": 0,
+                  "source_region": 1
                 },
                 "renameByName": {
-                  "Alchemy-Growth - fra1": "Alchemy-Growth - EU",
-                  "Alchemy-Growth - hnd1": "Alchemy-Growth - JP",
-                  "Alchemy-Growth - kix1": "Alchemy-Growth - JP (Osaka)",
-                  "Alchemy-Growth - sfo1": "Alchemy-Growth - US West",
-                  "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
-                  "Chainstack - fra1": "Chainstack-Growth - EU",
-                  "Chainstack - hnd1": "Chainstack-Growth - JP",
-                  "Chainstack - kix1": "Chainstack-Growth - JP (Osaka)",
-                  "Chainstack - sfo1": "Chainstack-Growth - US West",
-                  "Chainstack - sin1": "Chainstack-Growth - SG",
-                  "HypeRPC-Free - fra1": "HypeRPC-Free - EU",
-                  "HypeRPC-Free - hnd1": "HypeRPC-Free - JP",
-                  "HypeRPC-Free - sfo1": "HypeRPC-Free - US West",
-                  "Quicknode-Growth - fra1": "Quicknode-Growth - EU",
-                  "Quicknode-Growth - hnd1": "Quicknode-Growth - JP",
-                  "Quicknode-Growth - kix1": "Quicknode-Growth - JP (Osaka)",
-                  "Quicknode-Growth - sfo1": "Quicknode-Growth - US West",
-                  "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
-                  "dRPC - fra1": "dRPC-Growth - EU",
-                  "dRPC - hnd1": "dRPC-Growth - JP",
-                  "dRPC - kix1": "dRPC-Growth - JP (Osaka)",
-                  "dRPC - sfo1": "dRPC-Growth - US West",
-                  "dRPC - sin1": "dRPC-Growth - SG"
+                  "Value": "Success Rate",
+                  "provider": "Provider",
+                  "source_region": "Region"
                 }
               }
-            },
-            {
-              "id": "transpose",
-              "options": {}
             }
           ],
           "type": "table"
@@ -3317,7 +3877,7 @@
           },
           "gridPos": {
             "h": 12,
-            "w": 19,
+            "w": 18,
             "x": 0,
             "y": 96
           },
@@ -3325,7 +3885,6 @@
           "options": {
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -3393,12 +3952,10 @@
                   "Alchemy-Growth - hnd1": "Alchemy-Growth - JP",
                   "Alchemy-Growth - kix1": "Alchemy-Growth - JP (Osaka)",
                   "Alchemy-Growth - sfo1": "Alchemy-Growth - US West",
-                  "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
                   "Chainstack - fra1": "Chainstack-Growth - EU",
                   "Chainstack - hnd1": "Chainstack-Growth - JP",
                   "Chainstack - kix1": "Chainstack-Growth - JP (Osaka)",
                   "Chainstack - sfo1": "Chainstack-Growth - US West",
-                  "Chainstack - sin1": "Chainstack-Growth - SG",
                   "HypeRPC-Free - fra1": "HypeRPC-Free - EU",
                   "HypeRPC-Free - hnd1": "HypeRPC-Free - JP",
                   "HypeRPC-Free - sfo1": "HypeRPC-Free - US West",
@@ -3406,12 +3963,10 @@
                   "Quicknode-Growth - hnd1": "Quicknode-Growth - JP",
                   "Quicknode-Growth - kix1": "Quicknode-Growth - JP (Osaka)",
                   "Quicknode-Growth - sfo1": "Quicknode-Growth - US West",
-                  "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
                   "dRPC - fra1": "dRPC-Growth - EU",
                   "dRPC - hnd1": "dRPC-Growth - JP",
                   "dRPC - kix1": "dRPC-Growth - JP (Osaka)",
-                  "dRPC - sfo1": "dRPC-Growth - US West",
-                  "dRPC - sin1": "dRPC-Growth - SG"
+                  "dRPC - sfo1": "dRPC-Growth - US West"
                 }
               }
             }
@@ -3426,12 +3981,8 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
-              },
               "custom": {
-                "align": "left",
+                "align": "auto",
                 "cellOptions": {
                   "type": "auto"
                 },
@@ -3439,45 +3990,104 @@
                   "reducers": []
                 },
                 "inspect": false,
-                "wrapHeaderText": false
+                "minWidth": 110
               },
-              "decimals": 2,
-              "mappings": [
-                {
-                  "options": {
-                    "from": 0.999901,
-                    "result": {
-                      "index": 0,
-                      "text": "100.0%"
-                    },
-                    "to": 1
-                  },
-                  "type": "range"
-                }
-              ],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "1"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
                     "id": "custom.width",
-                    "value": 70
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Region"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "fra1": {
+                            "index": 0,
+                            "text": "EU"
+                          },
+                          "sfo1": {
+                            "index": 2,
+                            "text": "US"
+                          },
+                          "hnd1": {
+                            "index": 1,
+                            "text": "JP"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 72
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
@@ -3485,97 +4095,50 @@
           },
           "gridPos": {
             "h": 12,
-            "w": 5,
-            "x": 19,
+            "w": 6,
+            "x": 18,
             "y": 96
           },
           "id": 101,
           "options": {
             "cellHeight": "sm",
-            "showHeader": false
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", api_method=\"clearinghouseState\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", api_method=\"clearinghouseState\"}[$__range])) by (provider, source_region)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
+              "format": "table",
               "instant": true,
-              "interval": "",
-              "legendFormat": "{{provider}} - {{source_region}}",
-              "range": false,
-              "refId": "A",
-              "useBackend": false
+              "refId": "A"
             }
           ],
           "title": "Success rate",
           "transformations": [
-            {
-              "id": "joinByField",
-              "options": {
-                "byField": "Time",
-                "mode": "outer"
-              }
-            },
             {
               "id": "organize",
               "options": {
                 "excludeByName": {
                   "Time": true
                 },
-                "includeByName": {},
                 "indexByName": {
-                  "Alchemy-Growth - fra1": 1,
-                  "Alchemy-Growth - hnd1": 2,
-                  "Alchemy-Growth - sfo1": 3,
-                  "Chainstack - fra1": 4,
-                  "Chainstack - hnd1": 5,
-                  "Chainstack - sfo1": 6,
-                  "HypeRPC-Free - fra1": 7,
-                  "HypeRPC-Free - hnd1": 8,
-                  "HypeRPC-Free - sfo1": 9,
-                  "Quicknode-Growth - fra1": 10,
-                  "Quicknode-Growth - hnd1": 11,
-                  "Quicknode-Growth - sfo1": 12,
-                  "Time": 0
+                  "Value": 2,
+                  "provider": 0,
+                  "source_region": 1
                 },
                 "renameByName": {
-                  "Alchemy-Growth - fra1": "Alchemy-Growth - EU",
-                  "Alchemy-Growth - hnd1": "Alchemy-Growth - JP",
-                  "Alchemy-Growth - kix1": "Alchemy-Growth - JP (Osaka)",
-                  "Alchemy-Growth - sfo1": "Alchemy-Growth - US West",
-                  "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
-                  "Chainstack - fra1": "Chainstack-Growth - EU",
-                  "Chainstack - hnd1": "Chainstack-Growth - JP",
-                  "Chainstack - kix1": "Chainstack-Growth - JP (Osaka)",
-                  "Chainstack - sfo1": "Chainstack-Growth - US West",
-                  "Chainstack - sin1": "Chainstack-Growth - SG",
-                  "HypeRPC-Free - fra1": "HypeRPC-Free - EU",
-                  "HypeRPC-Free - hnd1": "HypeRPC-Free - JP",
-                  "HypeRPC-Free - sfo1": "HypeRPC-Free - US West",
-                  "Quicknode-Growth - fra1": "Quicknode-Growth - EU",
-                  "Quicknode-Growth - hnd1": "Quicknode-Growth - JP",
-                  "Quicknode-Growth - kix1": "Quicknode-Growth - JP (Osaka)",
-                  "Quicknode-Growth - sfo1": "Quicknode-Growth - US West",
-                  "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
-                  "dRPC - fra1": "dRPC-Growth - EU",
-                  "dRPC - hnd1": "dRPC-Growth - JP",
-                  "dRPC - kix1": "dRPC-Growth - JP (Osaka)",
-                  "dRPC - sfo1": "dRPC-Growth - US West",
-                  "dRPC - sin1": "dRPC-Growth - SG"
+                  "Value": "Success Rate",
+                  "provider": "Provider",
+                  "source_region": "Region"
                 }
               }
-            },
-            {
-              "id": "transpose",
-              "options": {}
             }
           ],
           "type": "table"
@@ -3644,7 +4207,7 @@
           },
           "gridPos": {
             "h": 12,
-            "w": 19,
+            "w": 18,
             "x": 0,
             "y": 108
           },
@@ -3652,7 +4215,6 @@
           "options": {
             "legend": {
               "calcs": [
-                "min",
                 "p95",
                 "max"
               ],
@@ -3720,12 +4282,10 @@
                   "Alchemy-Growth - hnd1": "Alchemy-Growth - JP",
                   "Alchemy-Growth - kix1": "Alchemy-Growth - JP (Osaka)",
                   "Alchemy-Growth - sfo1": "Alchemy-Growth - US West",
-                  "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
                   "Chainstack - fra1": "Chainstack-Growth - EU",
                   "Chainstack - hnd1": "Chainstack-Growth - JP",
                   "Chainstack - kix1": "Chainstack-Growth - JP (Osaka)",
                   "Chainstack - sfo1": "Chainstack-Growth - US West",
-                  "Chainstack - sin1": "Chainstack-Growth - SG",
                   "HypeRPC-Free - fra1": "HypeRPC-Free - EU",
                   "HypeRPC-Free - hnd1": "HypeRPC-Free - JP",
                   "HypeRPC-Free - sfo1": "HypeRPC-Free - US West",
@@ -3733,12 +4293,10 @@
                   "Quicknode-Growth - hnd1": "Quicknode-Growth - JP",
                   "Quicknode-Growth - kix1": "Quicknode-Growth - JP (Osaka)",
                   "Quicknode-Growth - sfo1": "Quicknode-Growth - US West",
-                  "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
                   "dRPC - fra1": "dRPC-Growth - EU",
                   "dRPC - hnd1": "dRPC-Growth - JP",
                   "dRPC - kix1": "dRPC-Growth - JP (Osaka)",
-                  "dRPC - sfo1": "dRPC-Growth - US West",
-                  "dRPC - sin1": "dRPC-Growth - SG"
+                  "dRPC - sfo1": "dRPC-Growth - US West"
                 }
               }
             }
@@ -3753,12 +4311,8 @@
           "description": "Success rate of requests where response has 200 status code and contains no error field in JSON RPC response.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
-              },
               "custom": {
-                "align": "left",
+                "align": "auto",
                 "cellOptions": {
                   "type": "auto"
                 },
@@ -3766,45 +4320,104 @@
                   "reducers": []
                 },
                 "inspect": false,
-                "wrapHeaderText": false
+                "minWidth": 110
               },
-              "decimals": 2,
-              "mappings": [
-                {
-                  "options": {
-                    "from": 0.999901,
-                    "result": {
-                      "index": 0,
-                      "text": "100.0%"
-                    },
-                    "to": 1
-                  },
-                  "type": "range"
-                }
-              ],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
                     "color": "green",
                     "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "1"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
                     "id": "custom.width",
-                    "value": 70
+                    "value": 150
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Region"
+                },
+                "properties": [
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "fra1": {
+                            "index": 0,
+                            "text": "EU"
+                          },
+                          "sfo1": {
+                            "index": 2,
+                            "text": "US"
+                          },
+                          "hnd1": {
+                            "index": 1,
+                            "text": "JP"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 72
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Success Rate"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
@@ -3812,97 +4425,50 @@
           },
           "gridPos": {
             "h": 12,
-            "w": 5,
-            "x": 19,
+            "w": 6,
+            "x": 18,
             "y": 108
           },
           "id": 102,
           "options": {
             "cellHeight": "sm",
-            "showHeader": false
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.4.0-19378664917",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
                 "type": "prometheus",
                 "uid": "grafanacloud-prom"
               },
-              "disableTextWrap": false,
               "editorMode": "code",
               "exemplar": false,
               "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", api_method=\"openOrders\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", api_method=\"openOrders\"}[$__range])) by (provider, source_region)",
-              "fullMetaSearch": false,
-              "includeNullMetadata": true,
+              "format": "table",
               "instant": true,
-              "interval": "",
-              "legendFormat": "{{provider}} - {{source_region}}",
-              "range": false,
-              "refId": "A",
-              "useBackend": false
+              "refId": "A"
             }
           ],
           "title": "Success rate",
           "transformations": [
-            {
-              "id": "joinByField",
-              "options": {
-                "byField": "Time",
-                "mode": "outer"
-              }
-            },
             {
               "id": "organize",
               "options": {
                 "excludeByName": {
                   "Time": true
                 },
-                "includeByName": {},
                 "indexByName": {
-                  "Alchemy-Growth - fra1": 1,
-                  "Alchemy-Growth - hnd1": 2,
-                  "Alchemy-Growth - sfo1": 3,
-                  "Chainstack - fra1": 4,
-                  "Chainstack - hnd1": 5,
-                  "Chainstack - sfo1": 6,
-                  "HypeRPC-Free - fra1": 7,
-                  "HypeRPC-Free - hnd1": 8,
-                  "HypeRPC-Free - sfo1": 9,
-                  "Quicknode-Growth - fra1": 10,
-                  "Quicknode-Growth - hnd1": 11,
-                  "Quicknode-Growth - sfo1": 12,
-                  "Time": 0
+                  "Value": 2,
+                  "provider": 0,
+                  "source_region": 1
                 },
                 "renameByName": {
-                  "Alchemy-Growth - fra1": "Alchemy-Growth - EU",
-                  "Alchemy-Growth - hnd1": "Alchemy-Growth - JP",
-                  "Alchemy-Growth - kix1": "Alchemy-Growth - JP (Osaka)",
-                  "Alchemy-Growth - sfo1": "Alchemy-Growth - US West",
-                  "Alchemy-Growth - sin1": "Alchemy-Growth - SG",
-                  "Chainstack - fra1": "Chainstack-Growth - EU",
-                  "Chainstack - hnd1": "Chainstack-Growth - JP",
-                  "Chainstack - kix1": "Chainstack-Growth - JP (Osaka)",
-                  "Chainstack - sfo1": "Chainstack-Growth - US West",
-                  "Chainstack - sin1": "Chainstack-Growth - SG",
-                  "HypeRPC-Free - fra1": "HypeRPC-Free - EU",
-                  "HypeRPC-Free - hnd1": "HypeRPC-Free - JP",
-                  "HypeRPC-Free - sfo1": "HypeRPC-Free - US West",
-                  "Quicknode-Growth - fra1": "Quicknode-Growth - EU",
-                  "Quicknode-Growth - hnd1": "Quicknode-Growth - JP",
-                  "Quicknode-Growth - kix1": "Quicknode-Growth - JP (Osaka)",
-                  "Quicknode-Growth - sfo1": "Quicknode-Growth - US West",
-                  "Quicknode-Growth - sin1": "Quicknode-Growth - SG",
-                  "dRPC - fra1": "dRPC-Growth - EU",
-                  "dRPC - hnd1": "dRPC-Growth - JP",
-                  "dRPC - kix1": "dRPC-Growth - JP (Osaka)",
-                  "dRPC - sfo1": "dRPC-Growth - US West",
-                  "dRPC - sin1": "dRPC-Growth - SG"
+                  "Value": "Success Rate",
+                  "provider": "Provider",
+                  "source_region": "Region"
                 }
               }
-            },
-            {
-              "id": "transpose",
-              "options": {}
             }
           ],
           "type": "table"


### PR DESCRIPTION
## Summary

- Add Block lag row (timeline + summary table) to global and all 3 regional Hyperliquid dashboards (eu, japan, us-west), using the post-PR #66 query patterns.
- Refactor global **Success rate** table to Provider/Region/SR layout with gauge cell on SR (replaces old joinByField+transpose cross-tab).
- Historical data: resize timeseries (global w=19→18; regional h=8→12, w=20→18), drop "min" from legend calcs, and replace regional per-method SR stat panels with tables matching the Solana/TON gold standard.
- Replace leftover `sin1`/`SG` display labels with `hnd1`/`JP` — Hyperliquid's Japan region uses `hnd1`, and `sin1` was dead from the old template.

## Intentionally skipped

- No "Transaction landing" row (Solana-only).
- No "Chainstack vs. dRPC" / "Chainstack vs. Helius" rows — Hyperliquid only compares against Alchemy and Quicknode.
- The existing "Chainstack vs. Alchemy" and "Chainstack vs. Quicknode" comparison rows were left untouched (out of scope).

## Test plan

- [x] Pushed to Grafana via `grafana_sync.py push` and visually reviewed all 4 dashboards.
- [x] Verified Block lag summary uses `[$__range:1m]` subquery for `% at Tip` and raw `[$__range]` for SR.
- [x] Verified `hnd1` is displayed as `JP` in the global SR table, per-method historical SR tables, and per-method timeseries legends.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added block lag monitoring section with timeline visualization and summary table displaying per-provider latency metrics.

* **Improvements**
  * Reformatted success rate displays as sortable tables for enhanced provider comparison and data analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->