### PR TITLE
fix(dashboards): unify aggregated success-rate panels

### DIFF
--- a/dashboards/dashboards/compare-dashboard-arbitrum-eu.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum-eu.json
@@ -183,6 +183,18 @@
                 "value": "Chainstack-Growth"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
+              }
+            ]
           }
         ]
       },
@@ -267,6 +279,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -461,6 +485,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -900,6 +936,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1253,6 +1301,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1519,6 +1579,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1789,6 +1861,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2053,6 +2137,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2315,6 +2411,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -2585,6 +2693,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2849,6 +2969,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -3111,6 +3243,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }

--- a/dashboards/dashboards/compare-dashboard-arbitrum-eu.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum-eu.json
@@ -318,7 +318,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"fra1\"}[$__range])) by (provider)",
+          "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"fra1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"fra1\"}[$__range])) by (provider)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": true,
@@ -332,6 +332,12 @@
       "title": "",
       "type": "gauge",
       "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns"
+          }
+        },
         {
           "id": "sortBy",
           "options": {
@@ -1135,7 +1141,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"fra1\"}[$__range])) by (provider)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"fra1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"fra1\"}[$__range])) by (provider)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-arbitrum-eu.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum-eu.json
@@ -330,27 +330,7 @@
         }
       ],
       "title": "",
-      "type": "gauge",
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "mode": "columns"
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": false,
-                "field": "provider"
-              }
-            ]
-          }
-        }
-      ]
+      "type": "gauge"
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-arbitrum-eu.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum-eu.json
@@ -1448,6 +1448,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -1703,6 +1715,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -1960,6 +1984,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2212,6 +2248,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2463,6 +2511,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -2720,6 +2780,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2972,6 +3044,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3223,6 +3307,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-arbitrum-eu.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum-eu.json
@@ -254,7 +254,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "decimals": 2
         },
         "overrides": [
           {
@@ -317,7 +318,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"fra1\", response_status=\"success\"} >= 0)[$__range:$__interval])) by (provider)\r\n/\r\nsum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"fra1\"} >= 0)[$__range:$__interval])) by (provider)",
+          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"fra1\"}[$__range])) by (provider)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": true,
@@ -329,7 +330,21 @@
         }
       ],
       "title": "",
-      "type": "gauge"
+      "type": "gauge",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "provider"
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-arbitrum-japan.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum-japan.json
@@ -254,7 +254,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "decimals": 2
         },
         "overrides": [
           {
@@ -304,7 +305,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"hnd1\", response_status=\"success\"} >= 0)[$__range:$__interval])) by (provider)\r\n/\r\nsum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"hnd1\"} >= 0)[$__range:$__interval])) by (provider)",
+          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"hnd1\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"hnd1\"}[$__range])) by (provider)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": true,
@@ -315,7 +316,21 @@
           "useBackend": false
         }
       ],
-      "type": "gauge"
+      "type": "gauge",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "provider"
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-arbitrum-japan.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum-japan.json
@@ -187,6 +187,18 @@
                 "value": "Chainstack-Growth"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
+              }
+            ]
           }
         ]
       },
@@ -267,6 +279,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -444,6 +468,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -886,6 +922,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1240,6 +1288,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1507,6 +1567,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1778,6 +1850,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2043,6 +2127,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2306,6 +2402,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -2577,6 +2685,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2842,6 +2962,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -3105,6 +3237,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }

--- a/dashboards/dashboards/compare-dashboard-arbitrum-japan.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum-japan.json
@@ -305,7 +305,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"hnd1\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"hnd1\"}[$__range])) by (provider)",
+          "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"hnd1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"hnd1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"hnd1\"}[$__range])) by (provider)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": true,
@@ -318,6 +318,12 @@
       ],
       "type": "gauge",
       "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns"
+          }
+        },
         {
           "id": "sortBy",
           "options": {
@@ -1121,7 +1127,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"hnd1\", response_status=\"success\"}[$__range])) by (provider)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"hnd1\"}[$__range])) by (provider)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"hnd1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"hnd1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"hnd1\"}[$__range])) by (provider)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-arbitrum-japan.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum-japan.json
@@ -1435,6 +1435,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -1691,6 +1703,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -1949,6 +1973,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2202,6 +2238,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2454,6 +2502,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -2712,6 +2772,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2965,6 +3037,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3217,6 +3301,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-arbitrum-japan.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum-japan.json
@@ -316,27 +316,7 @@
           "useBackend": false
         }
       ],
-      "type": "gauge",
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "mode": "columns"
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": false,
-                "field": "provider"
-              }
-            ]
-          }
-        }
-      ]
+      "type": "gauge"
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-arbitrum-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum-us-west.json
@@ -1433,6 +1433,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -1689,6 +1701,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -1947,6 +1971,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2200,6 +2236,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2452,6 +2500,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -2710,6 +2770,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2963,6 +3035,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3215,6 +3299,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-arbitrum-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum-us-west.json
@@ -305,7 +305,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"sfo1\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"sfo1\"}[$__range])) by (provider)",
+          "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"sfo1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"sfo1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"sfo1\"}[$__range])) by (provider)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": true,
@@ -318,6 +318,12 @@
       ],
       "type": "gauge",
       "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns"
+          }
+        },
         {
           "id": "sortBy",
           "options": {
@@ -1119,7 +1125,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"sfo1\", response_status=\"success\"}[$__range])) by (provider)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"sfo1\"}[$__range])) by (provider)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"sfo1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"sfo1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"sfo1\"}[$__range])) by (provider)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-arbitrum-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum-us-west.json
@@ -187,6 +187,18 @@
                 "value": "Chainstack-Growth"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
+              }
+            ]
           }
         ]
       },
@@ -267,6 +279,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -444,6 +468,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -884,6 +920,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1238,6 +1286,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1505,6 +1565,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1776,6 +1848,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2041,6 +2125,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2304,6 +2400,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -2575,6 +2683,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2840,6 +2960,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -3103,6 +3235,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }

--- a/dashboards/dashboards/compare-dashboard-arbitrum-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum-us-west.json
@@ -254,7 +254,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "decimals": 2
         },
         "overrides": [
           {
@@ -304,7 +305,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"sfo1\", response_status=\"success\"} >= 0)[$__range:$__interval])) by (provider)\r\n/\r\nsum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"sfo1\"} >= 0)[$__range:$__interval])) by (provider)",
+          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"sfo1\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", source_region=\"sfo1\"}[$__range])) by (provider)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": true,
@@ -315,7 +316,21 @@
           "useBackend": false
         }
       ],
-      "type": "gauge"
+      "type": "gauge",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "provider"
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-arbitrum-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum-us-west.json
@@ -316,27 +316,7 @@
           "useBackend": false
         }
       ],
-      "type": "gauge",
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "mode": "columns"
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": false,
-                "field": "provider"
-              }
-            ]
-          }
-        }
-      ]
+      "type": "gauge"
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-arbitrum.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum.json
@@ -590,7 +590,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\"}[$__range])) by (provider, source_region)",
+          "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n  or on(provider, source_region)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\"}[$__range])) by (provider, source_region))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\"}[$__range])) by (provider, source_region)",
           "format": "table",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -1869,7 +1869,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", response_status=\"success\"}[$__range])) by (provider, source_region)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\"}[$__range])) by (provider, source_region)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n  or on(provider, source_region)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\"}[$__range])) by (provider, source_region))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\"}[$__range])) by (provider, source_region)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-arbitrum.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum.json
@@ -2255,6 +2255,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2583,6 +2595,18 @@
                   "provider": "Provider",
                   "source_region": "Region"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -2913,6 +2937,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3242,6 +3278,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3570,6 +3618,18 @@
                   "provider": "Provider",
                   "source_region": "Region"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -3902,6 +3962,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -4231,6 +4303,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -4559,6 +4643,18 @@
                   "provider": "Provider",
                   "source_region": "Region"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-arbitrum.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum.json
@@ -460,7 +460,7 @@
           "mappings": [
             {
               "options": {
-                "from": 0.99991,
+                "from": 0.99995,
                 "result": {
                   "index": 0,
                   "text": "100.0%"
@@ -590,7 +590,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", response_status=\"success\"} >= 0)[$__range:$__interval])) by (provider, source_region)\r\n/\r\nsum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\"} >= 0)[$__range:$__interval])) by (provider, source_region)",
+          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\"}[$__range])) by (provider, source_region)",
           "format": "table",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -618,6 +618,18 @@
               "provider": "Provider",
               "source_region": "Region"
             }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "Provider"
+              }
+            ]
           }
         }
       ],

--- a/dashboards/dashboards/compare-dashboard-base-eu.json
+++ b/dashboards/dashboards/compare-dashboard-base-eu.json
@@ -254,7 +254,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "decimals": 2
         },
         "overrides": [
           {
@@ -314,7 +315,21 @@
           "useBackend": false
         }
       ],
-      "type": "gauge"
+      "type": "gauge",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "provider"
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-base-eu.json
+++ b/dashboards/dashboards/compare-dashboard-base-eu.json
@@ -1432,6 +1432,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -1687,6 +1699,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -1944,6 +1968,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2196,6 +2232,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2447,6 +2495,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -2704,6 +2764,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2956,6 +3028,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3207,6 +3291,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-base-eu.json
+++ b/dashboards/dashboards/compare-dashboard-base-eu.json
@@ -187,6 +187,18 @@
                 "value": "Chainstack-Growth"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
+              }
+            ]
           }
         ]
       },
@@ -267,6 +279,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -443,6 +467,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -884,6 +920,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1237,6 +1285,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1503,6 +1563,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1773,6 +1845,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2037,6 +2121,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2299,6 +2395,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -2569,6 +2677,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2833,6 +2953,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -3095,6 +3227,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }

--- a/dashboards/dashboards/compare-dashboard-base-eu.json
+++ b/dashboards/dashboards/compare-dashboard-base-eu.json
@@ -304,7 +304,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"fra1\"}[$__range])) by (provider)",
+          "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"fra1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"fra1\"}[$__range])) by (provider)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -317,6 +317,12 @@
       ],
       "type": "gauge",
       "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns"
+          }
+        },
         {
           "id": "sortBy",
           "options": {
@@ -1119,7 +1125,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"fra1\"}[$__range])) by (provider)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"fra1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"fra1\"}[$__range])) by (provider)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-base-eu.json
+++ b/dashboards/dashboards/compare-dashboard-base-eu.json
@@ -315,27 +315,7 @@
           "useBackend": false
         }
       ],
-      "type": "gauge",
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "mode": "columns"
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": false,
-                "field": "provider"
-              }
-            ]
-          }
-        }
-      ]
+      "type": "gauge"
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-base-japan.json
+++ b/dashboards/dashboards/compare-dashboard-base-japan.json
@@ -304,7 +304,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"hnd1\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"hnd1\"}[$__range])) by (provider)",
+          "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"hnd1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"hnd1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"hnd1\"}[$__range])) by (provider)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -317,6 +317,12 @@
       ],
       "type": "gauge",
       "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns"
+          }
+        },
         {
           "id": "sortBy",
           "options": {
@@ -1118,7 +1124,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"hnd1\", response_status=\"success\"}[$__range])) by (provider)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"hnd1\"}[$__range])) by (provider)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"hnd1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"hnd1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"hnd1\"}[$__range])) by (provider)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-base-japan.json
+++ b/dashboards/dashboards/compare-dashboard-base-japan.json
@@ -187,6 +187,18 @@
                 "value": "Chainstack-Growth"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
+              }
+            ]
           }
         ]
       },
@@ -267,6 +279,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -443,6 +467,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -883,6 +919,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1236,6 +1284,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1502,6 +1562,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1772,6 +1844,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2036,6 +2120,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2298,6 +2394,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -2568,6 +2676,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2832,6 +2952,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -3094,6 +3226,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }

--- a/dashboards/dashboards/compare-dashboard-base-japan.json
+++ b/dashboards/dashboards/compare-dashboard-base-japan.json
@@ -254,7 +254,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "decimals": 2
         },
         "overrides": [
           {
@@ -314,7 +315,21 @@
           "useBackend": false
         }
       ],
-      "type": "gauge"
+      "type": "gauge",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "provider"
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-base-japan.json
+++ b/dashboards/dashboards/compare-dashboard-base-japan.json
@@ -1431,6 +1431,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -1686,6 +1698,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -1943,6 +1967,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2195,6 +2231,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2446,6 +2494,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -2703,6 +2763,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2955,6 +3027,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3206,6 +3290,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-base-japan.json
+++ b/dashboards/dashboards/compare-dashboard-base-japan.json
@@ -315,27 +315,7 @@
           "useBackend": false
         }
       ],
-      "type": "gauge",
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "mode": "columns"
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": false,
-                "field": "provider"
-              }
-            ]
-          }
-        }
-      ]
+      "type": "gauge"
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-base-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-base-us-west.json
@@ -187,6 +187,18 @@
                 "value": "Chainstack-Growth"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
+              }
+            ]
           }
         ]
       },
@@ -267,6 +279,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -443,6 +467,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -883,6 +919,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1236,6 +1284,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1502,6 +1562,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1772,6 +1844,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2036,6 +2120,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2298,6 +2394,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -2568,6 +2676,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2832,6 +2952,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -3094,6 +3226,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }

--- a/dashboards/dashboards/compare-dashboard-base-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-base-us-west.json
@@ -304,7 +304,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"sfo1\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"sfo1\"}[$__range])) by (provider)",
+          "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"sfo1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"sfo1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"sfo1\"}[$__range])) by (provider)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -317,6 +317,12 @@
       ],
       "type": "gauge",
       "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns"
+          }
+        },
         {
           "id": "sortBy",
           "options": {
@@ -1118,7 +1124,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"sfo1\", response_status=\"success\"}[$__range])) by (provider)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"sfo1\"}[$__range])) by (provider)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"sfo1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"sfo1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", source_region=\"sfo1\"}[$__range])) by (provider)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-base-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-base-us-west.json
@@ -254,7 +254,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "decimals": 2
         },
         "overrides": [
           {
@@ -314,7 +315,21 @@
           "useBackend": false
         }
       ],
-      "type": "gauge"
+      "type": "gauge",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "provider"
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-base-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-base-us-west.json
@@ -1431,6 +1431,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -1686,6 +1698,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -1943,6 +1967,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2195,6 +2231,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2446,6 +2494,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -2703,6 +2763,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2955,6 +3027,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3206,6 +3290,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-base-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-base-us-west.json
@@ -315,27 +315,7 @@
           "useBackend": false
         }
       ],
-      "type": "gauge",
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "mode": "columns"
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": false,
-                "field": "provider"
-              }
-            ]
-          }
-        }
-      ]
+      "type": "gauge"
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-base.json
+++ b/dashboards/dashboards/compare-dashboard-base.json
@@ -2243,6 +2243,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2571,6 +2583,18 @@
                   "provider": "Provider",
                   "source_region": "Region"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -2901,6 +2925,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3229,6 +3265,18 @@
                   "provider": "Provider",
                   "source_region": "Region"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -3559,6 +3607,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3887,6 +3947,18 @@
                   "provider": "Provider",
                   "source_region": "Region"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -4217,6 +4289,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -4545,6 +4629,18 @@
                   "provider": "Provider",
                   "source_region": "Region"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-base.json
+++ b/dashboards/dashboards/compare-dashboard-base.json
@@ -578,7 +578,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\"}[$__range])) by (provider, source_region)",
+          "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n  or on(provider, source_region)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\"}[$__range])) by (provider, source_region))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\"}[$__range])) by (provider, source_region)",
           "format": "table",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -1857,7 +1857,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", response_status=\"success\"}[$__range])) by (provider, source_region)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\"}[$__range])) by (provider, source_region)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n  or on(provider, source_region)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\"}[$__range])) by (provider, source_region))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\"}[$__range])) by (provider, source_region)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-base.json
+++ b/dashboards/dashboards/compare-dashboard-base.json
@@ -448,7 +448,7 @@
           "mappings": [
             {
               "options": {
-                "from": 0.99991,
+                "from": 0.99995,
                 "result": {
                   "index": 0,
                   "text": "100.0%"
@@ -578,7 +578,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", response_status=\"success\"} >= 0)[$__range:$__interval])) by (provider, source_region)\r\n/\r\nsum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\"} >= 0)[$__range:$__interval])) by (provider, source_region)",
+          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\"}[$__range])) by (provider, source_region)",
           "format": "table",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -606,6 +606,18 @@
               "provider": "Provider",
               "source_region": "Region"
             }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "Provider"
+              }
+            ]
           }
         }
       ],

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain-eu.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain-eu.json
@@ -254,7 +254,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "decimals": 2
         },
         "overrides": [
           {
@@ -314,7 +315,21 @@
           "useBackend": false
         }
       ],
-      "type": "gauge"
+      "type": "gauge",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "provider"
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain-eu.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain-eu.json
@@ -187,6 +187,18 @@
                 "value": "Chainstack-Growth"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
+              }
+            ]
           }
         ]
       },
@@ -267,6 +279,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -442,6 +466,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -882,6 +918,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1235,6 +1283,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1501,6 +1561,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1771,6 +1843,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2035,6 +2119,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2297,6 +2393,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -2566,6 +2674,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2829,6 +2949,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -3090,6 +3222,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain-eu.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain-eu.json
@@ -1430,6 +1430,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -1685,6 +1697,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -1942,6 +1966,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2194,6 +2230,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2445,6 +2493,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -2701,6 +2761,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2952,6 +3024,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3202,6 +3286,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain-eu.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain-eu.json
@@ -315,27 +315,7 @@
           "useBackend": false
         }
       ],
-      "type": "gauge",
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "mode": "columns"
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": false,
-                "field": "provider"
-              }
-            ]
-          }
-        }
-      ]
+      "type": "gauge"
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain-eu.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain-eu.json
@@ -304,7 +304,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"fra1\"}[$__range])) by (provider)",
+          "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"fra1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"fra1\"}[$__range])) by (provider)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -317,6 +317,12 @@
       ],
       "type": "gauge",
       "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns"
+          }
+        },
         {
           "id": "sortBy",
           "options": {
@@ -1117,7 +1123,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"fra1\"}[$__range])) by (provider)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"fra1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"fra1\"}[$__range])) by (provider)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain-singapore.json
@@ -187,6 +187,18 @@
                 "value": "Chainstack-Growth"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
+              }
+            ]
           }
         ]
       },
@@ -267,6 +279,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -442,6 +466,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -882,6 +918,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1235,6 +1283,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1501,6 +1561,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1771,6 +1843,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2035,6 +2119,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2296,6 +2392,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -2565,6 +2673,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2828,6 +2948,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -3089,6 +3221,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain-singapore.json
@@ -254,7 +254,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "decimals": 2
         },
         "overrides": [
           {
@@ -314,7 +315,21 @@
           "useBackend": false
         }
       ],
-      "type": "gauge"
+      "type": "gauge",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "provider"
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain-singapore.json
@@ -1430,6 +1430,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -1685,6 +1697,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -1942,6 +1966,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2194,6 +2230,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2444,6 +2492,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -2700,6 +2760,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2951,6 +3023,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3201,6 +3285,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain-singapore.json
@@ -304,7 +304,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"sin1\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"sin1\"}[$__range])) by (provider)",
+          "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"sin1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"sin1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"sin1\"}[$__range])) by (provider)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -317,6 +317,12 @@
       ],
       "type": "gauge",
       "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns"
+          }
+        },
         {
           "id": "sortBy",
           "options": {
@@ -1117,7 +1123,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"sin1\", response_status=\"success\"}[$__range])) by (provider)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"sin1\"}[$__range])) by (provider)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"sin1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"sin1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"sin1\"}[$__range])) by (provider)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain-singapore.json
@@ -315,27 +315,7 @@
           "useBackend": false
         }
       ],
-      "type": "gauge",
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "mode": "columns"
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": false,
-                "field": "provider"
-              }
-            ]
-          }
-        }
-      ]
+      "type": "gauge"
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain-us-west.json
@@ -187,6 +187,18 @@
                 "value": "Chainstack-Growth"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
+              }
+            ]
           }
         ]
       },
@@ -267,6 +279,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -442,6 +466,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -882,6 +918,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1235,6 +1283,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1501,6 +1561,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1771,6 +1843,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2035,6 +2119,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2297,6 +2393,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -2567,6 +2675,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2831,6 +2951,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -3093,6 +3225,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain-us-west.json
@@ -304,7 +304,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"sfo1\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"sfo1\"}[$__range])) by (provider)",
+          "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"sfo1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"sfo1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"sfo1\"}[$__range])) by (provider)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -317,6 +317,12 @@
       ],
       "type": "gauge",
       "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns"
+          }
+        },
         {
           "id": "sortBy",
           "options": {
@@ -1117,7 +1123,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"sfo1\", response_status=\"success\"}[$__range])) by (provider)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"sfo1\"}[$__range])) by (provider)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"sfo1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"sfo1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", source_region=\"sfo1\"}[$__range])) by (provider)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain-us-west.json
@@ -254,7 +254,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "decimals": 2
         },
         "overrides": [
           {
@@ -314,7 +315,21 @@
           "useBackend": false
         }
       ],
-      "type": "gauge"
+      "type": "gauge",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "provider"
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain-us-west.json
@@ -1430,6 +1430,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -1685,6 +1697,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -1942,6 +1966,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2194,6 +2230,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2445,6 +2493,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -2702,6 +2762,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2954,6 +3026,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3205,6 +3289,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain-us-west.json
@@ -315,27 +315,7 @@
           "useBackend": false
         }
       ],
-      "type": "gauge",
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "mode": "columns"
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": false,
-                "field": "provider"
-              }
-            ]
-          }
-        }
-      ]
+      "type": "gauge"
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain.json
@@ -448,7 +448,7 @@
           "mappings": [
             {
               "options": {
-                "from": 0.99991,
+                "from": 0.99995,
                 "result": {
                   "index": 0,
                   "text": "100.0%"
@@ -578,7 +578,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", response_status=\"success\"} >= 0)[$__range:$__interval])) by (provider, source_region)\r\n/\r\nsum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\"} >= 0)[$__range:$__interval])) by (provider, source_region)",
+          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\"}[$__range])) by (provider, source_region)",
           "format": "table",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -606,6 +606,18 @@
               "provider": "Provider",
               "source_region": "Region"
             }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "Provider"
+              }
+            ]
           }
         }
       ],

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain.json
@@ -578,7 +578,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\"}[$__range])) by (provider, source_region)",
+          "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n  or on(provider, source_region)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\"}[$__range])) by (provider, source_region))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\"}[$__range])) by (provider, source_region)",
           "format": "table",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -1845,7 +1845,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", response_status=\"success\"}[$__range])) by (provider, source_region)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\"}[$__range])) by (provider, source_region)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n  or on(provider, source_region)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\"}[$__range])) by (provider, source_region))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\"}[$__range])) by (provider, source_region)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain.json
@@ -2223,6 +2223,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2543,6 +2555,18 @@
                   "provider": "Provider",
                   "source_region": "Region"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -2865,6 +2889,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3186,6 +3222,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3506,6 +3554,18 @@
                   "provider": "Provider",
                   "source_region": "Region"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -3830,6 +3890,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -4147,6 +4219,18 @@
                   "provider": "Provider",
                   "source_region": "Region"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -4469,6 +4553,18 @@
                   "provider": "Provider",
                   "source_region": "Region"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-ethereum-eu.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum-eu.json
@@ -304,7 +304,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"fra1\"}[$__range])) by (provider)",
+          "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"fra1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"fra1\"}[$__range])) by (provider)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -317,6 +317,12 @@
       ],
       "type": "gauge",
       "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns"
+          }
+        },
         {
           "id": "sortBy",
           "options": {
@@ -1044,7 +1050,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"fra1\"}[$__range])) by (provider)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"fra1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"fra1\"}[$__range])) by (provider)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-ethereum-eu.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum-eu.json
@@ -254,7 +254,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "decimals": 2
         },
         "overrides": [
           {
@@ -314,7 +315,21 @@
           "useBackend": false
         }
       ],
-      "type": "gauge"
+      "type": "gauge",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "provider"
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-ethereum-eu.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum-eu.json
@@ -1357,6 +1357,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -1612,6 +1624,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -1869,6 +1893,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2121,6 +2157,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2372,6 +2420,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -2628,6 +2688,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2879,6 +2951,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3129,6 +3213,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-ethereum-eu.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum-eu.json
@@ -187,6 +187,18 @@
                 "value": "Chainstack-Growth"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
+              }
+            ]
           }
         ]
       },
@@ -267,6 +279,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -443,6 +467,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -809,6 +845,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1162,6 +1210,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1428,6 +1488,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1698,6 +1770,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1962,6 +2046,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2224,6 +2320,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -2493,6 +2601,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2756,6 +2876,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -3017,6 +3149,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }

--- a/dashboards/dashboards/compare-dashboard-ethereum-eu.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum-eu.json
@@ -315,27 +315,7 @@
           "useBackend": false
         }
       ],
-      "type": "gauge",
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "mode": "columns"
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": false,
-                "field": "provider"
-              }
-            ]
-          }
-        }
-      ]
+      "type": "gauge"
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-ethereum-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum-singapore.json
@@ -1431,6 +1431,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -1686,6 +1698,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -1943,6 +1967,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2195,6 +2231,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2445,6 +2493,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -2701,6 +2761,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2952,6 +3024,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3202,6 +3286,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-ethereum-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum-singapore.json
@@ -187,6 +187,18 @@
                 "value": "Chainstack-Growth"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
+              }
+            ]
           }
         ]
       },
@@ -267,6 +279,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -443,6 +467,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -883,6 +919,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1236,6 +1284,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1502,6 +1562,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1772,6 +1844,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2036,6 +2120,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2297,6 +2393,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -2566,6 +2674,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2829,6 +2949,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -3090,6 +3222,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }

--- a/dashboards/dashboards/compare-dashboard-ethereum-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum-singapore.json
@@ -254,7 +254,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "decimals": 2
         },
         "overrides": [
           {
@@ -314,7 +315,21 @@
           "useBackend": false
         }
       ],
-      "type": "gauge"
+      "type": "gauge",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "provider"
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-ethereum-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum-singapore.json
@@ -304,7 +304,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"sin1\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"sin1\"}[$__range])) by (provider)",
+          "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"sin1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"sin1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"sin1\"}[$__range])) by (provider)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -317,6 +317,12 @@
       ],
       "type": "gauge",
       "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns"
+          }
+        },
         {
           "id": "sortBy",
           "options": {
@@ -1118,7 +1124,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"sin1\", response_status=\"success\"}[$__range])) by (provider)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"sin1\"}[$__range])) by (provider)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"sin1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"sin1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"sin1\"}[$__range])) by (provider)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-ethereum-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum-singapore.json
@@ -315,27 +315,7 @@
           "useBackend": false
         }
       ],
-      "type": "gauge",
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "mode": "columns"
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": false,
-                "field": "provider"
-              }
-            ]
-          }
-        }
-      ]
+      "type": "gauge"
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-ethereum-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum-us-west.json
@@ -1431,6 +1431,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -1686,6 +1698,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -1943,6 +1967,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2195,6 +2231,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2445,6 +2493,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -2701,6 +2761,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2952,6 +3024,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3202,6 +3286,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-ethereum-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum-us-west.json
@@ -187,6 +187,18 @@
                 "value": "Chainstack-Growth"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
+              }
+            ]
           }
         ]
       },
@@ -267,6 +279,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -443,6 +467,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -883,6 +919,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1236,6 +1284,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1502,6 +1562,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1772,6 +1844,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2036,6 +2120,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2297,6 +2393,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -2566,6 +2674,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2829,6 +2949,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -3090,6 +3222,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }

--- a/dashboards/dashboards/compare-dashboard-ethereum-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum-us-west.json
@@ -254,7 +254,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "decimals": 2
         },
         "overrides": [
           {
@@ -314,7 +315,21 @@
           "useBackend": false
         }
       ],
-      "type": "gauge"
+      "type": "gauge",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "provider"
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-ethereum-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum-us-west.json
@@ -304,7 +304,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"sfo1\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"sfo1\"}[$__range])) by (provider)",
+          "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"sfo1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"sfo1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"sfo1\"}[$__range])) by (provider)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -317,6 +317,12 @@
       ],
       "type": "gauge",
       "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns"
+          }
+        },
         {
           "id": "sortBy",
           "options": {
@@ -1118,7 +1124,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"sfo1\", response_status=\"success\"}[$__range])) by (provider)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"sfo1\"}[$__range])) by (provider)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"sfo1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"sfo1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", source_region=\"sfo1\"}[$__range])) by (provider)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-ethereum-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum-us-west.json
@@ -315,27 +315,7 @@
           "useBackend": false
         }
       ],
-      "type": "gauge",
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "mode": "columns"
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": false,
-                "field": "provider"
-              }
-            ]
-          }
-        }
-      ]
+      "type": "gauge"
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-ethereum.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum.json
@@ -449,7 +449,7 @@
           "mappings": [
             {
               "options": {
-                "from": 0.99991,
+                "from": 0.99995,
                 "result": {
                   "index": 0,
                   "text": "100.0%"
@@ -579,7 +579,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", response_status=\"success\"} >= 0)[$__range:$__interval])) by (provider, source_region)\r\n/\r\nsum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\"} >= 0)[$__range:$__interval])) by (provider, source_region)",
+          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\"}[$__range])) by (provider, source_region)",
           "format": "table",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -607,6 +607,18 @@
               "provider": "Provider",
               "source_region": "Region"
             }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "Provider"
+              }
+            ]
           }
         }
       ],

--- a/dashboards/dashboards/compare-dashboard-ethereum.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum.json
@@ -579,7 +579,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\"}[$__range])) by (provider, source_region)",
+          "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n  or on(provider, source_region)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\"}[$__range])) by (provider, source_region))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\"}[$__range])) by (provider, source_region)",
           "format": "table",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -1823,7 +1823,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", response_status=\"success\"}[$__range])) by (provider, source_region)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\"}[$__range])) by (provider, source_region)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n  or on(provider, source_region)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\"}[$__range])) by (provider, source_region))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\"}[$__range])) by (provider, source_region)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-ethereum.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum.json
@@ -2205,6 +2205,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2530,6 +2542,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2850,6 +2874,18 @@
                   "provider": "Provider",
                   "source_region": "Region"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -3172,6 +3208,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3492,6 +3540,18 @@
                   "provider": "Provider",
                   "source_region": "Region"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -3816,6 +3876,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -4136,6 +4208,18 @@
                   "provider": "Provider",
                   "source_region": "Region"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -4458,6 +4542,18 @@
                   "provider": "Provider",
                   "source_region": "Region"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-hyperliquid-eu.json
+++ b/dashboards/dashboards/compare-dashboard-hyperliquid-eu.json
@@ -1125,7 +1125,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"fra1\"}[$__range])) by (provider)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"fra1\", api_method=~\"(eth_call|eth_getBalance|eth_getLogs|eth_getTransactionReceipt|eth_blockNumber)\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"fra1\", api_method=~\"(eth_call|eth_getBalance|eth_getLogs|eth_getTransactionReceipt|eth_blockNumber)\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"fra1\", api_method=~\"(eth_call|eth_getBalance|eth_getLogs|eth_getTransactionReceipt|eth_blockNumber)\"}[$__range])) by (provider)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-hyperliquid-eu.json
+++ b/dashboards/dashboards/compare-dashboard-hyperliquid-eu.json
@@ -1445,6 +1445,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -1713,6 +1725,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -1983,6 +2007,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2247,6 +2283,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -2517,6 +2565,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2786,6 +2846,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3054,6 +3126,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-hyperliquid-eu.json
+++ b/dashboards/dashboards/compare-dashboard-hyperliquid-eu.json
@@ -904,6 +904,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },

--- a/dashboards/dashboards/compare-dashboard-hyperliquid-japan.json
+++ b/dashboards/dashboards/compare-dashboard-hyperliquid-japan.json
@@ -924,6 +924,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },

--- a/dashboards/dashboards/compare-dashboard-hyperliquid-japan.json
+++ b/dashboards/dashboards/compare-dashboard-hyperliquid-japan.json
@@ -1465,6 +1465,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -1733,6 +1745,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -2003,6 +2027,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2267,6 +2303,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -2537,6 +2585,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2806,6 +2866,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3074,6 +3146,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-hyperliquid-japan.json
+++ b/dashboards/dashboards/compare-dashboard-hyperliquid-japan.json
@@ -1145,7 +1145,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"hnd1\", response_status=\"success\"}[$__range])) by (provider)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"hnd1\"}[$__range])) by (provider)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"hnd1\", api_method=~\"(eth_call|eth_getBalance|eth_getLogs|eth_getTransactionReceipt|eth_blockNumber)\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"hnd1\", api_method=~\"(eth_call|eth_getBalance|eth_getLogs|eth_getTransactionReceipt|eth_blockNumber)\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"hnd1\", api_method=~\"(eth_call|eth_getBalance|eth_getLogs|eth_getTransactionReceipt|eth_blockNumber)\"}[$__range])) by (provider)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-hyperliquid-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-hyperliquid-us-west.json
@@ -1464,6 +1464,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -1732,6 +1744,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -2002,6 +2026,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2266,6 +2302,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -2536,6 +2584,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2805,6 +2865,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3073,6 +3145,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-hyperliquid-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-hyperliquid-us-west.json
@@ -1144,7 +1144,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"sfo1\", response_status=\"success\"}[$__range])) by (provider)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"sfo1\"}[$__range])) by (provider)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"sfo1\", api_method=~\"(eth_call|eth_getBalance|eth_getLogs|eth_getTransactionReceipt|eth_blockNumber)\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"sfo1\", api_method=~\"(eth_call|eth_getBalance|eth_getLogs|eth_getTransactionReceipt|eth_blockNumber)\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", source_region=\"sfo1\", api_method=~\"(eth_call|eth_getBalance|eth_getLogs|eth_getTransactionReceipt|eth_blockNumber)\"}[$__range])) by (provider)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-hyperliquid-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-hyperliquid-us-west.json
@@ -923,6 +923,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },

--- a/dashboards/dashboards/compare-dashboard-hyperliquid.json
+++ b/dashboards/dashboards/compare-dashboard-hyperliquid.json
@@ -2507,6 +2507,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2834,6 +2846,18 @@
                   "provider": "Provider",
                   "source_region": "Region"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -3163,6 +3187,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3490,6 +3526,18 @@
                   "provider": "Provider",
                   "source_region": "Region"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -3821,6 +3869,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -4151,6 +4211,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -4480,6 +4552,18 @@
                   "provider": "Provider",
                   "source_region": "Region"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-hyperliquid.json
+++ b/dashboards/dashboards/compare-dashboard-hyperliquid.json
@@ -616,7 +616,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\"}[$__range])) by (provider, source_region)",
+          "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", api_method=~\"(eth_call|eth_getBalance|eth_getLogs|eth_getTransactionReceipt|eth_blockNumber)\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n  or on(provider, source_region)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", api_method=~\"(eth_call|eth_getBalance|eth_getLogs|eth_getTransactionReceipt|eth_blockNumber)\"}[$__range])) by (provider, source_region))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", api_method=~\"(eth_call|eth_getBalance|eth_getLogs|eth_getTransactionReceipt|eth_blockNumber)\"}[$__range])) by (provider, source_region)",
           "format": "table",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -2122,7 +2122,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", response_status=\"success\"}[$__range])) by (provider, source_region)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\"}[$__range])) by (provider, source_region)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", api_method=~\"(eth_call|eth_getBalance|eth_getLogs|eth_getTransactionReceipt|eth_blockNumber)\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n  or on(provider, source_region)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", api_method=~\"(eth_call|eth_getBalance|eth_getLogs|eth_getTransactionReceipt|eth_blockNumber)\"}[$__range])) by (provider, source_region))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", api_method=~\"(eth_call|eth_getBalance|eth_getLogs|eth_getTransactionReceipt|eth_blockNumber)\"}[$__range])) by (provider, source_region)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-hyperliquid.json
+++ b/dashboards/dashboards/compare-dashboard-hyperliquid.json
@@ -486,7 +486,7 @@
           "mappings": [
             {
               "options": {
-                "from": 0.99991,
+                "from": 0.99995,
                 "result": {
                   "index": 0,
                   "text": "100.0%"
@@ -616,7 +616,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", response_status=\"success\"} >= 0)[$__range:$__interval])) by (provider, source_region)\r\n/\r\nsum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\"} >= 0)[$__range:$__interval])) by (provider, source_region)",
+          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\"}[$__range])) by (provider, source_region)",
           "format": "table",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -644,6 +644,18 @@
               "provider": "Provider",
               "source_region": "Region"
             }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "Provider"
+              }
+            ]
           }
         }
       ],

--- a/dashboards/dashboards/compare-dashboard-monad-eu.json
+++ b/dashboards/dashboards/compare-dashboard-monad-eu.json
@@ -254,7 +254,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "decimals": 2
         },
         "overrides": [
           {
@@ -304,7 +305,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"fra1\", response_status=\"success\"} >= 0)[$__range:$__interval])) by (provider)\r\n/\r\nsum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"fra1\"} >= 0)[$__range:$__interval])) by (provider)",
+          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"fra1\"}[$__range])) by (provider)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": true,
@@ -315,7 +316,21 @@
           "useBackend": false
         }
       ],
-      "type": "gauge"
+      "type": "gauge",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "provider"
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-monad-eu.json
+++ b/dashboards/dashboards/compare-dashboard-monad-eu.json
@@ -1436,6 +1436,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -1692,6 +1704,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -1950,6 +1974,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2203,6 +2239,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2455,6 +2503,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -2713,6 +2773,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2966,6 +3038,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3218,6 +3302,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-monad-eu.json
+++ b/dashboards/dashboards/compare-dashboard-monad-eu.json
@@ -187,6 +187,18 @@
                 "value": "Chainstack-Growth"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
+              }
+            ]
           }
         ]
       },
@@ -267,6 +279,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -448,6 +472,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -887,6 +923,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1241,6 +1289,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1508,6 +1568,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1779,6 +1851,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2044,6 +2128,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2307,6 +2403,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -2578,6 +2686,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2843,6 +2963,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -3106,6 +3238,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }

--- a/dashboards/dashboards/compare-dashboard-monad-eu.json
+++ b/dashboards/dashboards/compare-dashboard-monad-eu.json
@@ -305,7 +305,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"fra1\"}[$__range])) by (provider)",
+          "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"fra1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"fra1\"}[$__range])) by (provider)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": true,
@@ -318,6 +318,12 @@
       ],
       "type": "gauge",
       "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns"
+          }
+        },
         {
           "id": "sortBy",
           "options": {
@@ -1122,7 +1128,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"fra1\"}[$__range])) by (provider)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"fra1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"fra1\"}[$__range])) by (provider)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-monad-eu.json
+++ b/dashboards/dashboards/compare-dashboard-monad-eu.json
@@ -316,27 +316,7 @@
           "useBackend": false
         }
       ],
-      "type": "gauge",
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "mode": "columns"
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": false,
-                "field": "provider"
-              }
-            ]
-          }
-        }
-      ]
+      "type": "gauge"
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-monad-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-monad-singapore.json
@@ -187,6 +187,18 @@
                 "value": "Chainstack-Growth"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
+              }
+            ]
           }
         ]
       },
@@ -267,6 +279,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -444,6 +468,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -886,6 +922,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1240,6 +1288,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1507,6 +1567,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1778,6 +1850,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2043,6 +2127,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2306,6 +2402,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -2577,6 +2685,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2842,6 +2962,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -3105,6 +3237,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }

--- a/dashboards/dashboards/compare-dashboard-monad-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-monad-singapore.json
@@ -305,7 +305,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"sin1\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"sin1\"}[$__range])) by (provider)",
+          "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"sin1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"sin1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"sin1\"}[$__range])) by (provider)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": true,
@@ -318,6 +318,12 @@
       ],
       "type": "gauge",
       "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns"
+          }
+        },
         {
           "id": "sortBy",
           "options": {
@@ -1121,7 +1127,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"sin1\", response_status=\"success\"}[$__range])) by (provider)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"sin1\"}[$__range])) by (provider)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"sin1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"sin1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"sin1\"}[$__range])) by (provider)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-monad-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-monad-singapore.json
@@ -254,7 +254,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "decimals": 2
         },
         "overrides": [
           {
@@ -304,7 +305,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"sin1\", response_status=\"success\"} >= 0)[$__range:$__interval])) by (provider)\r\n/\r\nsum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"sin1\"} >= 0)[$__range:$__interval])) by (provider)",
+          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"sin1\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"sin1\"}[$__range])) by (provider)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": true,
@@ -315,7 +316,21 @@
           "useBackend": false
         }
       ],
-      "type": "gauge"
+      "type": "gauge",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "provider"
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-monad-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-monad-singapore.json
@@ -1435,6 +1435,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -1691,6 +1703,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -1949,6 +1973,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2202,6 +2238,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2454,6 +2502,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -2712,6 +2772,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2965,6 +3037,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3217,6 +3301,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-monad-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-monad-singapore.json
@@ -316,27 +316,7 @@
           "useBackend": false
         }
       ],
-      "type": "gauge",
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "mode": "columns"
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": false,
-                "field": "provider"
-              }
-            ]
-          }
-        }
-      ]
+      "type": "gauge"
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-monad-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-monad-us-west.json
@@ -254,7 +254,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "decimals": 2
         },
         "overrides": [
           {
@@ -304,7 +305,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"sfo1\", response_status=\"success\"} >= 0)[$__range:$__interval])) by (provider)\r\n/\r\nsum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"sfo1\"} >= 0)[$__range:$__interval])) by (provider)",
+          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"sfo1\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"sfo1\"}[$__range])) by (provider)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": true,
@@ -315,7 +316,21 @@
           "useBackend": false
         }
       ],
-      "type": "gauge"
+      "type": "gauge",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "provider"
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-monad-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-monad-us-west.json
@@ -305,7 +305,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"sfo1\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"sfo1\"}[$__range])) by (provider)",
+          "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"sfo1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"sfo1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"sfo1\"}[$__range])) by (provider)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": true,
@@ -318,6 +318,12 @@
       ],
       "type": "gauge",
       "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns"
+          }
+        },
         {
           "id": "sortBy",
           "options": {
@@ -1119,7 +1125,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"sfo1\", response_status=\"success\"}[$__range])) by (provider)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"sfo1\"}[$__range])) by (provider)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"sfo1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"sfo1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", source_region=\"sfo1\"}[$__range])) by (provider)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-monad-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-monad-us-west.json
@@ -1433,6 +1433,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -1689,6 +1701,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -1947,6 +1971,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2200,6 +2236,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2452,6 +2500,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -2710,6 +2770,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2963,6 +3035,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3215,6 +3299,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-monad-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-monad-us-west.json
@@ -187,6 +187,18 @@
                 "value": "Chainstack-Growth"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
+              }
+            ]
           }
         ]
       },
@@ -267,6 +279,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -444,6 +468,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -884,6 +920,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1238,6 +1286,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1505,6 +1565,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1776,6 +1848,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2041,6 +2125,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2304,6 +2400,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -2575,6 +2683,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2840,6 +2960,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -3103,6 +3235,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }

--- a/dashboards/dashboards/compare-dashboard-monad-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-monad-us-west.json
@@ -316,27 +316,7 @@
           "useBackend": false
         }
       ],
-      "type": "gauge",
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "mode": "columns"
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": false,
-                "field": "provider"
-              }
-            ]
-          }
-        }
-      ]
+      "type": "gauge"
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-monad.json
+++ b/dashboards/dashboards/compare-dashboard-monad.json
@@ -2283,6 +2283,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2619,6 +2631,18 @@
                   "provider": "Provider",
                   "source_region": "Region"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -2957,6 +2981,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3294,6 +3330,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3630,6 +3678,18 @@
                   "provider": "Provider",
                   "source_region": "Region"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -3970,6 +4030,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -4307,6 +4379,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -4643,6 +4727,18 @@
                   "provider": "Provider",
                   "source_region": "Region"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-monad.json
+++ b/dashboards/dashboards/compare-dashboard-monad.json
@@ -583,7 +583,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\"}[$__range])) by (provider, source_region)",
+          "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n  or on(provider, source_region)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\"}[$__range])) by (provider, source_region))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\"}[$__range])) by (provider, source_region)",
           "format": "table",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -1889,7 +1889,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", response_status=\"success\"}[$__range])) by (provider, source_region)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\"}[$__range])) by (provider, source_region)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n  or on(provider, source_region)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\"}[$__range])) by (provider, source_region))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\"}[$__range])) by (provider, source_region)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-monad.json
+++ b/dashboards/dashboards/compare-dashboard-monad.json
@@ -453,7 +453,7 @@
           "mappings": [
             {
               "options": {
-                "from": 0.99991,
+                "from": 0.99995,
                 "result": {
                   "index": 0,
                   "text": "100.0%"
@@ -583,7 +583,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", response_status=\"success\"} >= 0)[$__range:$__interval])) by (provider, source_region)\r\n/\r\nsum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\"} >= 0)[$__range:$__interval])) by (provider, source_region)",
+          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\"}[$__range])) by (provider, source_region)",
           "format": "table",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -611,6 +611,18 @@
               "provider": "Provider",
               "source_region": "Region"
             }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "Provider"
+              }
+            ]
           }
         }
       ],

--- a/dashboards/dashboards/compare-dashboard-solana-eu.json
+++ b/dashboards/dashboards/compare-dashboard-solana-eu.json
@@ -2686,7 +2686,7 @@
                 "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
-                "axisLabel": "",
+                "axisLabel": "Slots",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "barWidthFactor": 0.6,
@@ -2729,7 +2729,8 @@
                   }
                 ]
               },
-              "unit": "s"
+              "unit": "short",
+              "decimals": 0
             },
             "overrides": [
               {

--- a/dashboards/dashboards/compare-dashboard-solana-eu.json
+++ b/dashboards/dashboards/compare-dashboard-solana-eu.json
@@ -254,7 +254,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "decimals": 2
         },
         "overrides": [
           {
@@ -314,7 +315,21 @@
           "useBackend": false
         }
       ],
-      "type": "gauge"
+      "type": "gauge",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "provider"
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-solana-eu.json
+++ b/dashboards/dashboards/compare-dashboard-solana-eu.json
@@ -1300,6 +1300,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -1555,6 +1567,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -1812,6 +1836,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2067,6 +2103,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -2324,6 +2372,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2579,6 +2639,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-solana-eu.json
+++ b/dashboards/dashboards/compare-dashboard-solana-eu.json
@@ -315,27 +315,7 @@
           "useBackend": false
         }
       ],
-      "type": "gauge",
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "mode": "columns"
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": false,
-                "field": "provider"
-              }
-            ]
-          }
-        }
-      ]
+      "type": "gauge"
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-solana-eu.json
+++ b/dashboards/dashboards/compare-dashboard-solana-eu.json
@@ -304,7 +304,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"fra1\"}[$__range])) by (provider)",
+          "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"fra1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"fra1\"}[$__range])) by (provider)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -317,6 +317,12 @@
       ],
       "type": "gauge",
       "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns"
+          }
+        },
         {
           "id": "sortBy",
           "options": {
@@ -983,7 +989,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"fra1\"}[$__range])) by (provider)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"fra1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"fra1\"}[$__range])) by (provider)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-solana-eu.json
+++ b/dashboards/dashboards/compare-dashboard-solana-eu.json
@@ -187,6 +187,18 @@
                 "value": "Chainstack-Growth"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
+              }
+            ]
           }
         ]
       },
@@ -267,6 +279,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -438,6 +462,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -746,6 +782,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1101,6 +1149,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1367,6 +1427,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1637,6 +1709,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1903,6 +1987,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -2173,6 +2269,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2439,6 +2547,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }

--- a/dashboards/dashboards/compare-dashboard-solana-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-solana-singapore.json
@@ -254,7 +254,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "decimals": 2
         },
         "overrides": [
           {
@@ -314,7 +315,21 @@
           "useBackend": false
         }
       ],
-      "type": "gauge"
+      "type": "gauge",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "provider"
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-solana-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-solana-singapore.json
@@ -1300,6 +1300,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -1555,6 +1567,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -1812,6 +1836,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2067,6 +2103,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -2324,6 +2372,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2579,6 +2639,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-solana-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-solana-singapore.json
@@ -315,27 +315,7 @@
           "useBackend": false
         }
       ],
-      "type": "gauge",
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "mode": "columns"
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": false,
-                "field": "provider"
-              }
-            ]
-          }
-        }
-      ]
+      "type": "gauge"
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-solana-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-solana-singapore.json
@@ -187,6 +187,18 @@
                 "value": "Chainstack-Growth"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
+              }
+            ]
           }
         ]
       },
@@ -267,6 +279,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -438,6 +462,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -746,6 +782,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1101,6 +1149,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1367,6 +1427,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1637,6 +1709,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1903,6 +1987,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -2173,6 +2269,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2439,6 +2547,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }

--- a/dashboards/dashboards/compare-dashboard-solana-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-solana-singapore.json
@@ -304,7 +304,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sin1\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sin1\"}[$__range])) by (provider)",
+          "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sin1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sin1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sin1\"}[$__range])) by (provider)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -317,6 +317,12 @@
       ],
       "type": "gauge",
       "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns"
+          }
+        },
         {
           "id": "sortBy",
           "options": {
@@ -983,7 +989,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sin1\", response_status=\"success\"}[$__range])) by (provider)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sin1\"}[$__range])) by (provider)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sin1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sin1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sin1\"}[$__range])) by (provider)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-solana-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-solana-us-west.json
@@ -304,7 +304,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sfo1\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sfo1\"}[$__range])) by (provider)",
+          "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sfo1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sfo1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sfo1\"}[$__range])) by (provider)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -317,6 +317,12 @@
       ],
       "type": "gauge",
       "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns"
+          }
+        },
         {
           "id": "sortBy",
           "options": {
@@ -984,7 +990,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sfo1\", response_status=\"success\"}[$__range])) by (provider)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sfo1\"}[$__range])) by (provider)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sfo1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sfo1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", source_region=\"sfo1\"}[$__range])) by (provider)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-solana-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-solana-us-west.json
@@ -254,7 +254,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "decimals": 2
         },
         "overrides": [
           {
@@ -314,7 +315,21 @@
           "useBackend": false
         }
       ],
-      "type": "gauge"
+      "type": "gauge",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "provider"
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-solana-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-solana-us-west.json
@@ -187,6 +187,18 @@
                 "value": "Chainstack-Growth"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
+              }
+            ]
           }
         ]
       },
@@ -267,6 +279,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -439,6 +463,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -747,6 +783,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1102,6 +1150,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1368,6 +1428,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1638,6 +1710,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1904,6 +1988,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -2174,6 +2270,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2440,6 +2548,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }

--- a/dashboards/dashboards/compare-dashboard-solana-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-solana-us-west.json
@@ -1301,6 +1301,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -1556,6 +1568,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -1813,6 +1837,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2068,6 +2104,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -2325,6 +2373,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2580,6 +2640,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-solana-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-solana-us-west.json
@@ -315,27 +315,7 @@
           "useBackend": false
         }
       ],
-      "type": "gauge",
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "mode": "columns"
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": false,
-                "field": "provider"
-              }
-            ]
-          }
-        }
-      ]
+      "type": "gauge"
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-solana.json
+++ b/dashboards/dashboards/compare-dashboard-solana.json
@@ -2351,6 +2351,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2696,6 +2708,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3040,6 +3064,18 @@
                   "provider": "Provider",
                   "source_region": "Region"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -3388,6 +3424,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3732,6 +3780,18 @@
                   "provider": "Provider",
                   "source_region": "Region"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -4078,6 +4138,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -4400,6 +4472,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-solana.json
+++ b/dashboards/dashboards/compare-dashboard-solana.json
@@ -595,7 +595,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\"}[$__range])) by (provider, source_region)",
+          "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n  or on(provider, source_region)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\"}[$__range])) by (provider, source_region))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\"}[$__range])) by (provider, source_region)",
           "format": "table",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -1949,7 +1949,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", response_status=\"success\"}[$__range])) by (provider, source_region)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\"}[$__range])) by (provider, source_region)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n  or on(provider, source_region)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\"}[$__range])) by (provider, source_region))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\"}[$__range])) by (provider, source_region)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-solana.json
+++ b/dashboards/dashboards/compare-dashboard-solana.json
@@ -4184,7 +4184,7 @@
                 "axisBorderShow": false,
                 "axisCenteredZero": false,
                 "axisColorMode": "text",
-                "axisLabel": "",
+                "axisLabel": "Slots",
                 "axisPlacement": "auto",
                 "barAlignment": 0,
                 "barWidthFactor": 0.6,
@@ -4227,7 +4227,8 @@
                   }
                 ]
               },
-              "unit": "s"
+              "unit": "short",
+              "decimals": 0
             },
             "overrides": [
               {

--- a/dashboards/dashboards/compare-dashboard-solana.json
+++ b/dashboards/dashboards/compare-dashboard-solana.json
@@ -465,7 +465,7 @@
           "mappings": [
             {
               "options": {
-                "from": 0.99991,
+                "from": 0.99995,
                 "result": {
                   "index": 0,
                   "text": "100.0%"
@@ -595,7 +595,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", response_status=\"success\"} >= 0)[$__range:$__interval])) by (provider, source_region)\r\n/\r\nsum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\"} >= 0)[$__range:$__interval])) by (provider, source_region)",
+          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\"}[$__range])) by (provider, source_region)",
           "format": "table",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -623,6 +623,18 @@
               "provider": "Provider",
               "source_region": "Region"
             }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "Provider"
+              }
+            ]
           }
         }
       ],

--- a/dashboards/dashboards/compare-dashboard-ton-eu.json
+++ b/dashboards/dashboards/compare-dashboard-ton-eu.json
@@ -254,7 +254,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "decimals": 2
         },
         "overrides": [
           {
@@ -314,7 +315,21 @@
           "useBackend": false
         }
       ],
-      "type": "gauge"
+      "type": "gauge",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "provider"
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-ton-eu.json
+++ b/dashboards/dashboards/compare-dashboard-ton-eu.json
@@ -1281,6 +1281,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -1536,6 +1548,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -1793,6 +1817,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2049,6 +2085,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2304,6 +2352,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-ton-eu.json
+++ b/dashboards/dashboards/compare-dashboard-ton-eu.json
@@ -187,6 +187,18 @@
                 "value": "Chainstack-Growth"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
+              }
+            ]
           }
         ]
       },
@@ -267,6 +279,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -434,6 +458,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -1082,6 +1118,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1348,6 +1396,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1618,6 +1678,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1886,6 +1958,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2152,6 +2236,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }

--- a/dashboards/dashboards/compare-dashboard-ton-eu.json
+++ b/dashboards/dashboards/compare-dashboard-ton-eu.json
@@ -304,7 +304,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"fra1\"}[$__range])) by (provider)",
+          "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"fra1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"fra1\"}[$__range])) by (provider)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -317,6 +317,12 @@
       ],
       "type": "gauge",
       "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns"
+          }
+        },
         {
           "id": "sortBy",
           "options": {
@@ -964,7 +970,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"fra1\"}[$__range])) by (provider)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"fra1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"fra1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"fra1\"}[$__range])) by (provider)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-ton-eu.json
+++ b/dashboards/dashboards/compare-dashboard-ton-eu.json
@@ -315,27 +315,7 @@
           "useBackend": false
         }
       ],
-      "type": "gauge",
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "mode": "columns"
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": false,
-                "field": "provider"
-              }
-            ]
-          }
-        }
-      ]
+      "type": "gauge"
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-ton-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-ton-singapore.json
@@ -254,7 +254,8 @@
               }
             ]
           },
-          "unit": "percentunit"
+          "unit": "percentunit",
+          "decimals": 2
         },
         "overrides": [
           {
@@ -314,7 +315,21 @@
           "useBackend": false
         }
       ],
-      "type": "gauge"
+      "type": "gauge",
+      "transformations": [
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "provider"
+              }
+            ]
+          }
+        }
+      ]
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-ton-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-ton-singapore.json
@@ -1281,6 +1281,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -1536,6 +1548,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -1793,6 +1817,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2049,6 +2085,18 @@
                   "provider": "Provider"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2304,6 +2352,18 @@
                   "Value": "Success Rate",
                   "provider": "Provider"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-ton-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-ton-singapore.json
@@ -187,6 +187,18 @@
                 "value": "Chainstack-Growth"
               }
             ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
+              }
+            ]
           }
         ]
       },
@@ -267,6 +279,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -434,6 +458,18 @@
               {
                 "id": "displayName",
                 "value": "Chainstack-Growth"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "dRPC"
+            },
+            "properties": [
+              {
+                "id": "displayName",
+                "value": "dRPC-Growth"
               }
             ]
           }
@@ -1082,6 +1118,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1348,6 +1396,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1618,6 +1678,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -1886,6 +1958,18 @@
                     "value": "Chainstack-Growth"
                   }
                 ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
               }
             ]
           },
@@ -2152,6 +2236,18 @@
                   {
                     "id": "displayName",
                     "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
                   }
                 ]
               }

--- a/dashboards/dashboards/compare-dashboard-ton-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-ton-singapore.json
@@ -304,7 +304,7 @@
           },
           "disableTextWrap": false,
           "editorMode": "code",
-          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"sin1\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"sin1\"}[$__range])) by (provider)",
+          "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"sin1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"sin1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"sin1\"}[$__range])) by (provider)",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
           "instant": false,
@@ -317,6 +317,12 @@
       ],
       "type": "gauge",
       "transformations": [
+        {
+          "id": "labelsToFields",
+          "options": {
+            "mode": "columns"
+          }
+        },
         {
           "id": "sortBy",
           "options": {
@@ -964,7 +970,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"sin1\", response_status=\"success\"}[$__range])) by (provider)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"sin1\"}[$__range])) by (provider)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"sin1\", response_status=\"success\"}[$__range])) by (provider)\r\n  or on(provider)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"sin1\"}[$__range])) by (provider))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", source_region=\"sin1\"}[$__range])) by (provider)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-ton-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-ton-singapore.json
@@ -315,27 +315,7 @@
           "useBackend": false
         }
       ],
-      "type": "gauge",
-      "transformations": [
-        {
-          "id": "labelsToFields",
-          "options": {
-            "mode": "columns"
-          }
-        },
-        {
-          "id": "sortBy",
-          "options": {
-            "fields": {},
-            "sort": [
-              {
-                "desc": false,
-                "field": "provider"
-              }
-            ]
-          }
-        }
-      ]
+      "type": "gauge"
     },
     {
       "gridPos": {

--- a/dashboards/dashboards/compare-dashboard-ton.json
+++ b/dashboards/dashboards/compare-dashboard-ton.json
@@ -596,7 +596,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\"}[$__range])) by (provider, source_region)",
+          "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n  or on(provider, source_region)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\"}[$__range])) by (provider, source_region))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\"}[$__range])) by (provider, source_region)",
           "format": "table",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -1641,7 +1641,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", response_status=\"success\"}[$__range])) by (provider, source_region)\n/\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\"}[$__range])) by (provider, source_region)",
+              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n  or on(provider, source_region)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\"}[$__range])) by (provider, source_region))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\"}[$__range])) by (provider, source_region)",
               "format": "table",
               "instant": true,
               "refId": "B"

--- a/dashboards/dashboards/compare-dashboard-ton.json
+++ b/dashboards/dashboards/compare-dashboard-ton.json
@@ -2026,6 +2026,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -2353,6 +2365,18 @@
                   "provider": "Provider",
                   "source_region": "Region"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],
@@ -2682,6 +2706,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3010,6 +3046,18 @@
                   "source_region": "Region"
                 }
               }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
             }
           ],
           "type": "table"
@@ -3337,6 +3385,18 @@
                   "provider": "Provider",
                   "source_region": "Region"
                 }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
               }
             }
           ],

--- a/dashboards/dashboards/compare-dashboard-ton.json
+++ b/dashboards/dashboards/compare-dashboard-ton.json
@@ -466,7 +466,7 @@
           "mappings": [
             {
               "options": {
-                "from": 0.99991,
+                "from": 0.99995,
                 "result": {
                   "index": 0,
                   "text": "100.0%"
@@ -596,7 +596,7 @@
           "disableTextWrap": false,
           "editorMode": "code",
           "exemplar": false,
-          "expr": "sum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", response_status=\"success\"} >= 0)[$__range:$__interval])) by (provider, source_region)\r\n/\r\nsum(count_over_time((response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\"} >= 0)[$__range:$__interval])) by (provider, source_region)",
+          "expr": "sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\"}[$__range])) by (provider, source_region)",
           "format": "table",
           "fullMetaSearch": false,
           "includeNullMetadata": true,
@@ -624,6 +624,18 @@
               "provider": "Provider",
               "source_region": "Region"
             }
+          }
+        },
+        {
+          "id": "sortBy",
+          "options": {
+            "fields": {},
+            "sort": [
+              {
+                "desc": false,
+                "field": "Provider"
+              }
+            ]
           }
         }
       ],

--- a/dashboards/uv.lock
+++ b/dashboards/uv.lock
@@ -1,0 +1,418 @@
+version = 1
+revision = 3
+requires-python = ">=3.9"
+resolution-markers = [
+    "python_full_version >= '3.10'",
+    "python_full_version < '3.10'",
+]
+
+[[package]]
+name = "certifi"
+version = "2026.2.25"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/af/2d/7bf41579a8986e348fa033a31cdd0e4121114f6bce2457e8876010b092dd/certifi-2026.2.25.tar.gz", hash = "sha256:e887ab5cee78ea814d3472169153c2d12cd43b14bd03329a39a9c6e2e80bfba7", size = 155029, upload-time = "2026-02-25T02:54:17.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9a/3c/c17fb3ca2d9c3acff52e30b309f538586f9f5b9c9cf454f3845fc9af4881/certifi-2026.2.25-py3-none-any.whl", hash = "sha256:027692e4402ad994f1c42e52a4997a9763c646b73e4096e4d5d6db8af1d6f0fa", size = 153684, upload-time = "2026-02-25T02:54:15.766Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/08/0f303cb0b529e456bb116f2d50565a482694fbb94340bf56d44677e7ed03/charset_normalizer-3.4.7-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:cdd68a1fb318e290a2077696b7eb7a21a49163c455979c639bf5a5dcdc46617d", size = 315182, upload-time = "2026-04-02T09:25:40.673Z" },
+    { url = "https://files.pythonhosted.org/packages/24/47/b192933e94b546f1b1fe4df9cc1f84fcdbf2359f8d1081d46dd029b50207/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e17b8d5d6a8c47c85e68ca8379def1303fd360c3e22093a807cd34a71cd082b8", size = 209329, upload-time = "2026-04-02T09:25:42.354Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b4/01fa81c5ca6141024d89a8fc15968002b71da7f825dd14113207113fabbd/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:511ef87c8aec0783e08ac18565a16d435372bc1ac25a91e6ac7f5ef2b0bff790", size = 231230, upload-time = "2026-04-02T09:25:44.281Z" },
+    { url = "https://files.pythonhosted.org/packages/20/f7/7b991776844dfa058017e600e6e55ff01984a063290ca5622c0b63162f68/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:007d05ec7321d12a40227aae9e2bc6dca73f3cb21058999a1df9e193555a9dcc", size = 225890, upload-time = "2026-04-02T09:25:45.475Z" },
+    { url = "https://files.pythonhosted.org/packages/20/e7/bed0024a0f4ab0c8a9c64d4445f39b30c99bd1acd228291959e3de664247/charset_normalizer-3.4.7-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cf29836da5119f3c8a8a70667b0ef5fdca3bb12f80fd06487cfa575b3909b393", size = 216930, upload-time = "2026-04-02T09:25:46.58Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/ab/b18f0ab31cdd7b3ddb8bb76c4a414aeb8160c9810fdf1bc62f269a539d87/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_armv7l.whl", hash = "sha256:12d8baf840cc7889b37c7c770f478adea7adce3dcb3944d02ec87508e2dcf153", size = 202109, upload-time = "2026-04-02T09:25:48.031Z" },
+    { url = "https://files.pythonhosted.org/packages/82/e5/7e9440768a06dfb3075936490cb82dbf0ee20a133bf0dd8551fa096914ec/charset_normalizer-3.4.7-cp310-cp310-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d560742f3c0d62afaccf9f41fe485ed69bd7661a241f86a3ef0f0fb8b1a397af", size = 214684, upload-time = "2026-04-02T09:25:49.245Z" },
+    { url = "https://files.pythonhosted.org/packages/71/94/8c61d8da9f062fdf457c80acfa25060ec22bf1d34bbeaca4350f13bcfd07/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:b14b2d9dac08e28bb8046a1a0434b1750eb221c8f5b87a68f4fa11a6f97b5e34", size = 212785, upload-time = "2026-04-02T09:25:50.671Z" },
+    { url = "https://files.pythonhosted.org/packages/66/cd/6e9889c648e72c0ab2e5967528bb83508f354d706637bc7097190c874e13/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_armv7l.whl", hash = "sha256:bc17a677b21b3502a21f66a8cc64f5bfad4df8a0b8434d661666f8ce90ac3af1", size = 203055, upload-time = "2026-04-02T09:25:51.802Z" },
+    { url = "https://files.pythonhosted.org/packages/92/2e/7a951d6a08aefb7eb8e1b54cdfb580b1365afdd9dd484dc4bee9e5d8f258/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:750e02e074872a3fad7f233b47734166440af3cdea0add3e95163110816d6752", size = 232502, upload-time = "2026-04-02T09:25:53.388Z" },
+    { url = "https://files.pythonhosted.org/packages/58/d5/abcf2d83bf8e0a1286df55cd0dc1d49af0da4282aa77e986df343e7de124/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_riscv64.whl", hash = "sha256:4e5163c14bffd570ef2affbfdd77bba66383890797df43dc8b4cc7d6f500bf53", size = 214295, upload-time = "2026-04-02T09:25:54.765Z" },
+    { url = "https://files.pythonhosted.org/packages/47/3a/7d4cd7ed54be99973a0dc176032cba5cb1f258082c31fa6df35cff46acfc/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:6ed74185b2db44f41ef35fd1617c5888e59792da9bbc9190d6c7300617182616", size = 227145, upload-time = "2026-04-02T09:25:55.904Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/98/3a45bf8247889cf28262ebd3d0872edff11565b2a1e3064ccb132db3fbb0/charset_normalizer-3.4.7-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:94e1885b270625a9a828c9793b4d52a64445299baa1fea5a173bf1d3dd9a1a5a", size = 218884, upload-time = "2026-04-02T09:25:57.074Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/80/2e8b7f8915ed5c9ef13aa828d82738e33888c485b65ebf744d615040c7ea/charset_normalizer-3.4.7-cp310-cp310-win32.whl", hash = "sha256:6785f414ae0f3c733c437e0f3929197934f526d19dfaa75e18fdb4f94c6fb374", size = 148343, upload-time = "2026-04-02T09:25:58.199Z" },
+    { url = "https://files.pythonhosted.org/packages/35/1b/3b8c8c77184af465ee9ad88b5aea46ea6b2e1f7b9dc9502891e37af21e30/charset_normalizer-3.4.7-cp310-cp310-win_amd64.whl", hash = "sha256:6696b7688f54f5af4462118f0bfa7c1621eeb87154f77fa04b9295ce7a8f2943", size = 159174, upload-time = "2026-04-02T09:25:59.322Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/feb40dca40dbb21e0a908801782d9288c64fc8d8e562c2098e9994c8c21b/charset_normalizer-3.4.7-cp310-cp310-win_arm64.whl", hash = "sha256:66671f93accb62ed07da56613636f3641f1a12c13046ce91ffc923721f23c008", size = 147805, upload-time = "2026-04-02T09:26:00.756Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/d7/b5b7020a0565c2e9fa8c09f4b5fa6232feb326b8c20081ccded47ea368fd/charset_normalizer-3.4.7-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:7641bb8895e77f921102f72833904dcd9901df5d6d72a2ab8f31d04b7e51e4e7", size = 309705, upload-time = "2026-04-02T09:26:02.191Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/53/58c29116c340e5456724ecd2fff4196d236b98f3da97b404bc5e51ac3493/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:202389074300232baeb53ae2569a60901f7efadd4245cf3a3bf0617d60b439d7", size = 206419, upload-time = "2026-04-02T09:26:03.583Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/02/e8146dc6591a37a00e5144c63f29fb7c97a734ea8a111190783c0e60ab63/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:30b8d1d8c52a48c2c5690e152c169b673487a2a58de1ec7393196753063fcd5e", size = 227901, upload-time = "2026-04-02T09:26:04.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/73/77486c4cd58f1267bf17db420e930c9afa1b3be3fe8c8b8ebbebc9624359/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:532bc9bf33a68613fd7d65e4b1c71a6a38d7d42604ecf239c77392e9b4e8998c", size = 222742, upload-time = "2026-04-02T09:26:06.36Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/fa/f74eb381a7d94ded44739e9d94de18dc5edc9c17fb8c11f0a6890696c0a9/charset_normalizer-3.4.7-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2fe249cb4651fd12605b7288b24751d8bfd46d35f12a20b1ba33dea122e690df", size = 214061, upload-time = "2026-04-02T09:26:08.347Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/92/42bd3cefcf7687253fb86694b45f37b733c97f59af3724f356fa92b8c344/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_armv7l.whl", hash = "sha256:65bcd23054beab4d166035cabbc868a09c1a49d1efe458fe8e4361215df40265", size = 199239, upload-time = "2026-04-02T09:26:09.823Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/3d/069e7184e2aa3b3cddc700e3dd267413dc259854adc3380421c805c6a17d/charset_normalizer-3.4.7-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:08e721811161356f97b4059a9ba7bafb23ea5ee2255402c42881c214e173c6b4", size = 210173, upload-time = "2026-04-02T09:26:10.953Z" },
+    { url = "https://files.pythonhosted.org/packages/62/51/9d56feb5f2e7074c46f93e0ebdbe61f0848ee246e2f0d89f8e20b89ebb8f/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:e060d01aec0a910bdccb8be71faf34e7799ce36950f8294c8bf612cba65a2c9e", size = 209841, upload-time = "2026-04-02T09:26:12.142Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/59/893d8f99cc4c837dda1fe2f1139079703deb9f321aabcb032355de13b6c7/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_armv7l.whl", hash = "sha256:38c0109396c4cfc574d502df99742a45c72c08eff0a36158b6f04000043dbf38", size = 200304, upload-time = "2026-04-02T09:26:13.711Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/1d/ee6f3be3464247578d1ed5c46de545ccc3d3ff933695395c402c21fa6b77/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:1c2a768fdd44ee4a9339a9b0b130049139b8ce3c01d2ce09f67f5a68048d477c", size = 229455, upload-time = "2026-04-02T09:26:14.941Z" },
+    { url = "https://files.pythonhosted.org/packages/54/bb/8fb0a946296ea96a488928bdce8ef99023998c48e4713af533e9bb98ef07/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:1a87ca9d5df6fe460483d9a5bbf2b18f620cbed41b432e2bddb686228282d10b", size = 210036, upload-time = "2026-04-02T09:26:16.478Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/bc/015b2387f913749f82afd4fcba07846d05b6d784dd16123cb66860e0237d/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:d635aab80466bc95771bb78d5370e74d36d1fe31467b6b29b8b57b2a3cd7d22c", size = 224739, upload-time = "2026-04-02T09:26:17.751Z" },
+    { url = "https://files.pythonhosted.org/packages/17/ab/63133691f56baae417493cba6b7c641571a2130eb7bceba6773367ab9ec5/charset_normalizer-3.4.7-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ae196f021b5e7c78e918242d217db021ed2a6ace2bc6ae94c0fc596221c7f58d", size = 216277, upload-time = "2026-04-02T09:26:18.981Z" },
+    { url = "https://files.pythonhosted.org/packages/06/6d/3be70e827977f20db77c12a97e6a9f973631a45b8d186c084527e53e77a4/charset_normalizer-3.4.7-cp311-cp311-win32.whl", hash = "sha256:adb2597b428735679446b46c8badf467b4ca5f5056aae4d51a19f9570301b1ad", size = 147819, upload-time = "2026-04-02T09:26:20.295Z" },
+    { url = "https://files.pythonhosted.org/packages/20/d9/5f67790f06b735d7c7637171bbfd89882ad67201891b7275e51116ed8207/charset_normalizer-3.4.7-cp311-cp311-win_amd64.whl", hash = "sha256:8e385e4267ab76874ae30db04c627faaaf0b509e1ccc11a95b3fc3e83f855c00", size = 159281, upload-time = "2026-04-02T09:26:21.74Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/83/6413f36c5a34afead88ce6f66684d943d91f233d76dd083798f9602b75ae/charset_normalizer-3.4.7-cp311-cp311-win_arm64.whl", hash = "sha256:d4a48e5b3c2a489fae013b7589308a40146ee081f6f509e047e0e096084ceca1", size = 147843, upload-time = "2026-04-02T09:26:22.901Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/01/1b/ef725f8eb19b5a261b30f78efa9252ef9d017985cb499102f6f49834cd12/charset_normalizer-3.4.7-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:177a0ba5f0211d488e295aaf82707237e331c24788d8d76c96c5a41594723217", size = 299121, upload-time = "2026-04-02T09:28:14.372Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/22/2f12878fbc680fbbb52386cd39a379801f62eaca74fc8b323381325f0f04/charset_normalizer-3.4.7-cp39-cp39-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e0d51f618228538a3e8f46bd246f87a6cd030565e015803691603f55e12afb5", size = 200612, upload-time = "2026-04-02T09:28:16.162Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/b6/10c84e789126ca97d4a7228863a30481e786980a8b8cfcbf4f30658ca63c/charset_normalizer-3.4.7-cp39-cp39-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:14265bfe1f09498b9d8ec91e9ec9fa52775edf90fcbde092b25f4a33d444fea9", size = 221041, upload-time = "2026-04-02T09:28:17.554Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7b/c414866a138400b2e81973d006da7f694cfeaf895ef07d2cba9a8743841a/charset_normalizer-3.4.7-cp39-cp39-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:87fad7d9ba98c86bcb41b2dc8dbb326619be2562af1f8ff50776a39e55721c5a", size = 216323, upload-time = "2026-04-02T09:28:18.863Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/92/bdcf94997e06b223d826df3abed45a5ad6e17f609b7df9d25cd23b5bde30/charset_normalizer-3.4.7-cp39-cp39-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f22dec1690b584cea26fade98b2435c132c1b5f68e39f5a0b7627cd7ae31f1dc", size = 208419, upload-time = "2026-04-02T09:28:20.332Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/64/3f9142293c88b1b10e199649ed1330f070c2a68e305335a5819fa7f25fa7/charset_normalizer-3.4.7-cp39-cp39-manylinux_2_31_armv7l.whl", hash = "sha256:d61f00a0869d77422d9b2aba989e2d24afa6ffd552af442e0e58de4f35ea6d00", size = 195016, upload-time = "2026-04-02T09:28:21.657Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/d1/d8a6b7dd5c5636b76ce0d080bc57d8e56c7bbd6bc2ac941529a35e41d84a/charset_normalizer-3.4.7-cp39-cp39-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6370e8686f662e6a3941ee48ed4742317cafbe5707e36406e9df792cdb535776", size = 206115, upload-time = "2026-04-02T09:28:23.259Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/8c/60ebe912379627d023eb96995b40bc50308729f210f43d66109ca0a7bbd2/charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:a6c5863edfbe888d9eff9c8b8087354e27618d9da76425c119293f11712a6319", size = 204022, upload-time = "2026-04-02T09:28:24.779Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2a/41816ceda78a551cbfdfbeab6f3891152b0e3f758ce6580c2c18c829f774/charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_armv7l.whl", hash = "sha256:ed065083d0898c9d5b4bbec7b026fd755ff7454e6e8b73a67f8c744b13986e24", size = 195914, upload-time = "2026-04-02T09:28:26.181Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/9b/7c7f4b7f11525fcbdfba752455314ac60646bae91cdd671d531c1f7a97c6/charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_ppc64le.whl", hash = "sha256:2cd4a60d0e2fb04537162c62bbbb4182f53541fe0ede35cdf270a1c1e723cc42", size = 222159, upload-time = "2026-04-02T09:28:27.504Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/57/301682e7469bdbfa2ce219a804f0668b2266ab8520570d85d3b3ef483ea3/charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_riscv64.whl", hash = "sha256:813c0e0132266c08eb87469a642cb30aaff57c5f426255419572aaeceeaa7bf4", size = 206154, upload-time = "2026-04-02T09:28:28.848Z" },
+    { url = "https://files.pythonhosted.org/packages/20/ec/90339ff5cdc598b265748c1f231c7d7fbd9123a92cee10f757e0b1448de4/charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_s390x.whl", hash = "sha256:07d9e39b01743c3717745f4c530a6349eadbfa043c7577eef86c502c15df2c67", size = 217423, upload-time = "2026-04-02T09:28:30.248Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/e7/a7a6147f8e3375676309cf584b25c72a3bab784ea4085b0011fa07b23aeb/charset_normalizer-3.4.7-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:c0f081d69a6e58272819b70288d3221a6ee64b98df852631c80f293514d3b274", size = 210604, upload-time = "2026-04-02T09:28:31.736Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/62/d9340c7a79c393e57807d7fb6c57e82060687891f81b74d3201958b919c1/charset_normalizer-3.4.7-cp39-cp39-win32.whl", hash = "sha256:8751d2787c9131302398b11e6c8068053dcb55d5a8964e114b6e196cf16cb366", size = 144631, upload-time = "2026-04-02T09:28:33.158Z" },
+    { url = "https://files.pythonhosted.org/packages/21/e7/92901117e2ddc8facfe8235a3ecd4eb482185b2ad5d5b6606b37c1afea06/charset_normalizer-3.4.7-cp39-cp39-win_amd64.whl", hash = "sha256:12a6fff75f6bc66711b73a2f0addfc4c8c15a20e805146a02d147a318962c444", size = 154710, upload-time = "2026-04-02T09:28:34.557Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4f/e1fb138201ad9a32499dd9a98aa4a5a5441fbf7f56b52b619a54b7ee8777/charset_normalizer-3.4.7-cp39-cp39-win_arm64.whl", hash = "sha256:bb8cc7534f51d9a017b93e3e85b260924f909601c3df002bcdb58ddb4dc41a5c", size = 143716, upload-time = "2026-04-02T09:28:35.908Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "exceptiongroup"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "grafana-sync"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "python-dotenv", version = "1.2.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "python-dotenv", version = "1.2.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "requests", version = "2.32.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "requests", version = "2.33.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest", version = "8.4.2", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "pytest", version = "9.0.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "requests", specifier = ">=2.32.0" },
+]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=8.0.0" }]
+
+[[package]]
+name = "idna"
+version = "3.11"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f2/97/ebf4da567aa6827c909642694d71c9fcf53e5b504f2d96afea02718862f3/iniconfig-2.1.0.tar.gz", hash = "sha256:3abbd2e30b36733fee78f9c7f7308f2d0050e88f0087fd25c2645f63c773e1c7", size = 4793, upload-time = "2025-03-19T20:09:59.721Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/e1/e6716421ea10d38022b952c159d5161ca1193197fb744506875fbb87ea7b/iniconfig-2.1.0-py3-none-any.whl", hash = "sha256:9deba5723312380e77435581c6bf4935c94cbfab9b1ed33ef8d238ea168eb760", size = 6050, upload-time = "2025-03-19T20:10:01.071Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/de/0d2b39fb4af88a0258f3bac87dfcbb48e73fbdea4a2ed0e2213f9a4c2f9a/packaging-26.1.tar.gz", hash = "sha256:f042152b681c4bfac5cae2742a55e103d27ab2ec0f3d88037136b6bfe7c9c5de", size = 215519, upload-time = "2026-04-14T21:12:49.362Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7a/c2/920ef838e2f0028c8262f16101ec09ebd5969864e5a64c4c05fad0617c56/packaging-26.1-py3-none-any.whl", hash = "sha256:5d9c0669c6285e491e0ced2eee587eaf67b670d94a19e94e3984a481aba6802f", size = 95831, upload-time = "2026-04-14T21:12:47.56Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "8.4.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version < '3.10' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version < '3.10'" },
+    { name = "iniconfig", version = "2.1.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
+    { name = "packaging", marker = "python_full_version < '3.10'" },
+    { name = "pluggy", marker = "python_full_version < '3.10'" },
+    { name = "pygments", marker = "python_full_version < '3.10'" },
+    { name = "tomli", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "colorama", marker = "python_full_version >= '3.10' and sys_platform == 'win32'" },
+    { name = "exceptiongroup", marker = "python_full_version == '3.10.*'" },
+    { name = "iniconfig", version = "2.3.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
+    { name = "packaging", marker = "python_full_version >= '3.10'" },
+    { name = "pluggy", marker = "python_full_version >= '3.10'" },
+    { name = "pygments", marker = "python_full_version >= '3.10'" },
+    { name = "tomli", marker = "python_full_version == '3.10.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f0/26/19cadc79a718c5edbec86fd4919a6b6d3f681039a2f6d66d14be94e75fb9/python_dotenv-1.2.1.tar.gz", hash = "sha256:42667e897e16ab0d66954af0e60a9caa94f0fd4ecf3aaf6d2d260eec1aa36ad6", size = 44221, upload-time = "2025-10-26T15:12:10.434Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/1b/a298b06749107c305e1fe0f814c6c74aea7b2f1e10989cb30f544a1b3253/python_dotenv-1.2.1-py3-none-any.whl", hash = "sha256:b81ee9561e9ca4004139c6cbba3a238c32b03e4894671e181b671e8cb8425d61", size = 21230, upload-time = "2025-10-26T15:12:09.109Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.32.5"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.10'",
+]
+dependencies = [
+    { name = "certifi", marker = "python_full_version < '3.10'" },
+    { name = "charset-normalizer", marker = "python_full_version < '3.10'" },
+    { name = "idna", marker = "python_full_version < '3.10'" },
+    { name = "urllib3", marker = "python_full_version < '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c9/74/b3ff8e6c8446842c3f5c837e9c3dfcfe2018ea6ecef224c710c85ef728f4/requests-2.32.5.tar.gz", hash = "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf", size = 134517, upload-time = "2025-08-18T20:46:02.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/db/4254e3eabe8020b458f1a747140d32277ec7a271daf1d235b70dc0b4e6e3/requests-2.32.5-py3-none-any.whl", hash = "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6", size = 64738, upload-time = "2025-08-18T20:46:00.542Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.33.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.10'",
+]
+dependencies = [
+    { name = "certifi", marker = "python_full_version >= '3.10'" },
+    { name = "charset-normalizer", marker = "python_full_version >= '3.10'" },
+    { name = "idna", marker = "python_full_version >= '3.10'" },
+    { name = "urllib3", marker = "python_full_version >= '3.10'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/22/de/48c59722572767841493b26183a0d1cc411d54fd759c5607c4590b6563a6/tomli-2.4.1.tar.gz", hash = "sha256:7c7e1a961a0b2f2472c1ac5b69affa0ae1132c39adcb67aba98568702b9cc23f", size = 17543, upload-time = "2026-03-25T20:22:03.828Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/11/db3d5885d8528263d8adc260bb2d28ebf1270b96e98f0e0268d32b8d9900/tomli-2.4.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:f8f0fc26ec2cc2b965b7a3b87cd19c5c6b8c5e5f436b984e85f486d652285c30", size = 154704, upload-time = "2026-03-25T20:21:10.473Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/f7/675db52c7e46064a9aa928885a9b20f4124ecb9bc2e1ce74c9106648d202/tomli-2.4.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4ab97e64ccda8756376892c53a72bd1f964e519c77236368527f758fbc36a53a", size = 149454, upload-time = "2026-03-25T20:21:12.036Z" },
+    { url = "https://files.pythonhosted.org/packages/61/71/81c50943cf953efa35bce7646caab3cf457a7d8c030b27cfb40d7235f9ee/tomli-2.4.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:96481a5786729fd470164b47cdb3e0e58062a496f455ee41b4403be77cb5a076", size = 237561, upload-time = "2026-03-25T20:21:13.098Z" },
+    { url = "https://files.pythonhosted.org/packages/48/c1/f41d9cb618acccca7df82aaf682f9b49013c9397212cb9f53219e3abac37/tomli-2.4.1-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5a881ab208c0baf688221f8cecc5401bd291d67e38a1ac884d6736cbcd8247e9", size = 243824, upload-time = "2026-03-25T20:21:14.569Z" },
+    { url = "https://files.pythonhosted.org/packages/22/e4/5a816ecdd1f8ca51fb756ef684b90f2780afc52fc67f987e3c61d800a46d/tomli-2.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:47149d5bd38761ac8be13a84864bf0b7b70bc051806bc3669ab1cbc56216b23c", size = 242227, upload-time = "2026-03-25T20:21:15.712Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/49/2b2a0ef529aa6eec245d25f0c703e020a73955ad7edf73e7f54ddc608aa5/tomli-2.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:ec9bfaf3ad2df51ace80688143a6a4ebc09a248f6ff781a9945e51937008fcbc", size = 247859, upload-time = "2026-03-25T20:21:17.001Z" },
+    { url = "https://files.pythonhosted.org/packages/83/bd/6c1a630eaca337e1e78c5903104f831bda934c426f9231429396ce3c3467/tomli-2.4.1-cp311-cp311-win32.whl", hash = "sha256:ff2983983d34813c1aeb0fa89091e76c3a22889ee83ab27c5eeb45100560c049", size = 97204, upload-time = "2026-03-25T20:21:18.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/59/71461df1a885647e10b6bb7802d0b8e66480c61f3f43079e0dcd315b3954/tomli-2.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:5ee18d9ebdb417e384b58fe414e8d6af9f4e7a0ae761519fb50f721de398dd4e", size = 108084, upload-time = "2026-03-25T20:21:18.978Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/83/dceca96142499c069475b790e7913b1044c1a4337e700751f48ed723f883/tomli-2.4.1-cp311-cp311-win_arm64.whl", hash = "sha256:c2541745709bad0264b7d4705ad453b76ccd191e64aa6f0fc66b69a293a45ece", size = 95285, upload-time = "2026-03-25T20:21:20.309Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/ba/42f134a3fe2b370f555f44b1d72feebb94debcab01676bf918d0cb70e9aa/tomli-2.4.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:c742f741d58a28940ce01d58f0ab2ea3ced8b12402f162f4d534dfe18ba1cd6a", size = 155924, upload-time = "2026-03-25T20:21:21.626Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/c7/62d7a17c26487ade21c5422b646110f2162f1fcc95980ef7f63e73c68f14/tomli-2.4.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7f86fd587c4ed9dd76f318225e7d9b29cfc5a9d43de44e5754db8d1128487085", size = 150018, upload-time = "2026-03-25T20:21:23.002Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/79d13d7c15f13bdef410bdd49a6485b1c37d28968314eabee452c22a7fda/tomli-2.4.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ff18e6a727ee0ab0388507b89d1bc6a22b138d1e2fa56d1ad494586d61d2eae9", size = 244948, upload-time = "2026-03-25T20:21:24.04Z" },
+    { url = "https://files.pythonhosted.org/packages/10/90/d62ce007a1c80d0b2c93e02cab211224756240884751b94ca72df8a875ca/tomli-2.4.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:136443dbd7e1dee43c68ac2694fde36b2849865fa258d39bf822c10e8068eac5", size = 253341, upload-time = "2026-03-25T20:21:25.177Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/7e/caf6496d60152ad4ed09282c1885cca4eea150bfd007da84aea07bcc0a3e/tomli-2.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:5e262d41726bc187e69af7825504c933b6794dc3fbd5945e41a79bb14c31f585", size = 248159, upload-time = "2026-03-25T20:21:26.364Z" },
+    { url = "https://files.pythonhosted.org/packages/99/e7/c6f69c3120de34bbd882c6fba7975f3d7a746e9218e56ab46a1bc4b42552/tomli-2.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5cb41aa38891e073ee49d55fbc7839cfdb2bc0e600add13874d048c94aadddd1", size = 253290, upload-time = "2026-03-25T20:21:27.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2f/4a3c322f22c5c66c4b836ec58211641a4067364f5dcdd7b974b4c5da300c/tomli-2.4.1-cp312-cp312-win32.whl", hash = "sha256:da25dc3563bff5965356133435b757a795a17b17d01dbc0f42fb32447ddfd917", size = 98141, upload-time = "2026-03-25T20:21:28.492Z" },
+    { url = "https://files.pythonhosted.org/packages/24/22/4daacd05391b92c55759d55eaee21e1dfaea86ce5c571f10083360adf534/tomli-2.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:52c8ef851d9a240f11a88c003eacb03c31fc1c9c4ec64a99a0f922b93874fda9", size = 108847, upload-time = "2026-03-25T20:21:29.386Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fd/70e768887666ddd9e9f5d85129e84910f2db2796f9096aa02b721a53098d/tomli-2.4.1-cp312-cp312-win_arm64.whl", hash = "sha256:f758f1b9299d059cc3f6546ae2af89670cb1c4d48ea29c3cacc4fe7de3058257", size = 95088, upload-time = "2026-03-25T20:21:30.677Z" },
+    { url = "https://files.pythonhosted.org/packages/07/06/b823a7e818c756d9a7123ba2cda7d07bc2dd32835648d1a7b7b7a05d848d/tomli-2.4.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:36d2bd2ad5fb9eaddba5226aa02c8ec3fa4f192631e347b3ed28186d43be6b54", size = 155866, upload-time = "2026-03-25T20:21:31.65Z" },
+    { url = "https://files.pythonhosted.org/packages/14/6f/12645cf7f08e1a20c7eb8c297c6f11d31c1b50f316a7e7e1e1de6e2e7b7e/tomli-2.4.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:eb0dc4e38e6a1fd579e5d50369aa2e10acfc9cace504579b2faabb478e76941a", size = 149887, upload-time = "2026-03-25T20:21:33.028Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e0/90637574e5e7212c09099c67ad349b04ec4d6020324539297b634a0192b0/tomli-2.4.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7f2c7f2b9ca6bdeef8f0fa897f8e05085923eb091721675170254cbc5b02897", size = 243704, upload-time = "2026-03-25T20:21:34.51Z" },
+    { url = "https://files.pythonhosted.org/packages/10/8f/d3ddb16c5a4befdf31a23307f72828686ab2096f068eaf56631e136c1fdd/tomli-2.4.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3c6818a1a86dd6dca7ddcaaf76947d5ba31aecc28cb1b67009a5877c9a64f3f", size = 251628, upload-time = "2026-03-25T20:21:36.012Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/f1/dbeeb9116715abee2485bf0a12d07a8f31af94d71608c171c45f64c0469d/tomli-2.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d312ef37c91508b0ab2cee7da26ec0b3ed2f03ce12bd87a588d771ae15dcf82d", size = 247180, upload-time = "2026-03-25T20:21:37.136Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/74/16336ffd19ed4da28a70959f92f506233bd7cfc2332b20bdb01591e8b1d1/tomli-2.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51529d40e3ca50046d7606fa99ce3956a617f9b36380da3b7f0dd3dd28e68cb5", size = 251674, upload-time = "2026-03-25T20:21:38.298Z" },
+    { url = "https://files.pythonhosted.org/packages/16/f9/229fa3434c590ddf6c0aa9af64d3af4b752540686cace29e6281e3458469/tomli-2.4.1-cp313-cp313-win32.whl", hash = "sha256:2190f2e9dd7508d2a90ded5ed369255980a1bcdd58e52f7fe24b8162bf9fedbd", size = 97976, upload-time = "2026-03-25T20:21:39.316Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/1e/71dfd96bcc1c775420cb8befe7a9d35f2e5b1309798f009dca17b7708c1e/tomli-2.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:8d65a2fbf9d2f8352685bc1364177ee3923d6baf5e7f43ea4959d7d8bc326a36", size = 108755, upload-time = "2026-03-25T20:21:40.248Z" },
+    { url = "https://files.pythonhosted.org/packages/83/7a/d34f422a021d62420b78f5c538e5b102f62bea616d1d75a13f0a88acb04a/tomli-2.4.1-cp313-cp313-win_arm64.whl", hash = "sha256:4b605484e43cdc43f0954ddae319fb75f04cc10dd80d830540060ee7cd0243cd", size = 95265, upload-time = "2026-03-25T20:21:41.219Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/fb/9a5c8d27dbab540869f7c1f8eb0abb3244189ce780ba9cd73f3770662072/tomli-2.4.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fd0409a3653af6c147209d267a0e4243f0ae46b011aa978b1080359fddc9b6cf", size = 155726, upload-time = "2026-03-25T20:21:42.23Z" },
+    { url = "https://files.pythonhosted.org/packages/62/05/d2f816630cc771ad836af54f5001f47a6f611d2d39535364f148b6a92d6b/tomli-2.4.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:a120733b01c45e9a0c34aeef92bf0cf1d56cfe81ed9d47d562f9ed591a9828ac", size = 149859, upload-time = "2026-03-25T20:21:43.386Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/66341bdb858ad9bd0ceab5a86f90eddab127cf8b046418009f2125630ecb/tomli-2.4.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:559db847dc486944896521f68d8190be1c9e719fced785720d2216fe7022b662", size = 244713, upload-time = "2026-03-25T20:21:44.474Z" },
+    { url = "https://files.pythonhosted.org/packages/df/6d/c5fad00d82b3c7a3ab6189bd4b10e60466f22cfe8a08a9394185c8a8111c/tomli-2.4.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:01f520d4f53ef97964a240a035ec2a869fe1a37dde002b57ebc4417a27ccd853", size = 252084, upload-time = "2026-03-25T20:21:45.62Z" },
+    { url = "https://files.pythonhosted.org/packages/00/71/3a69e86f3eafe8c7a59d008d245888051005bd657760e96d5fbfb0b740c2/tomli-2.4.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7f94b27a62cfad8496c8d2513e1a222dd446f095fca8987fceef261225538a15", size = 247973, upload-time = "2026-03-25T20:21:46.937Z" },
+    { url = "https://files.pythonhosted.org/packages/67/50/361e986652847fec4bd5e4a0208752fbe64689c603c7ae5ea7cb16b1c0ca/tomli-2.4.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ede3e6487c5ef5d28634ba3f31f989030ad6af71edfb0055cbbd14189ff240ba", size = 256223, upload-time = "2026-03-25T20:21:48.467Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/9a/b4173689a9203472e5467217e0154b00e260621caa227b6fa01feab16998/tomli-2.4.1-cp314-cp314-win32.whl", hash = "sha256:3d48a93ee1c9b79c04bb38772ee1b64dcf18ff43085896ea460ca8dec96f35f6", size = 98973, upload-time = "2026-03-25T20:21:49.526Z" },
+    { url = "https://files.pythonhosted.org/packages/14/58/640ac93bf230cd27d002462c9af0d837779f8773bc03dee06b5835208214/tomli-2.4.1-cp314-cp314-win_amd64.whl", hash = "sha256:88dceee75c2c63af144e456745e10101eb67361050196b0b6af5d717254dddf7", size = 109082, upload-time = "2026-03-25T20:21:50.506Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/2f/702d5e05b227401c1068f0d386d79a589bb12bf64c3d2c72ce0631e3bc49/tomli-2.4.1-cp314-cp314-win_arm64.whl", hash = "sha256:b8c198f8c1805dc42708689ed6864951fd2494f924149d3e4bce7710f8eb5232", size = 96490, upload-time = "2026-03-25T20:21:51.474Z" },
+    { url = "https://files.pythonhosted.org/packages/45/4b/b877b05c8ba62927d9865dd980e34a755de541eb65fffba52b4cc495d4d2/tomli-2.4.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:d4d8fe59808a54658fcc0160ecfb1b30f9089906c50b23bcb4c69eddc19ec2b4", size = 164263, upload-time = "2026-03-25T20:21:52.543Z" },
+    { url = "https://files.pythonhosted.org/packages/24/79/6ab420d37a270b89f7195dec5448f79400d9e9c1826df982f3f8e97b24fd/tomli-2.4.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7008df2e7655c495dd12d2a4ad038ff878d4ca4b81fccaf82b714e07eae4402c", size = 160736, upload-time = "2026-03-25T20:21:53.674Z" },
+    { url = "https://files.pythonhosted.org/packages/02/e0/3630057d8eb170310785723ed5adcdfb7d50cb7e6455f85ba8a3deed642b/tomli-2.4.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1d8591993e228b0c930c4bb0db464bdad97b3289fb981255d6c9a41aedc84b2d", size = 270717, upload-time = "2026-03-25T20:21:55.129Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/b4/1613716072e544d1a7891f548d8f9ec6ce2faf42ca65acae01d76ea06bb0/tomli-2.4.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:734e20b57ba95624ecf1841e72b53f6e186355e216e5412de414e3c51e5e3c41", size = 278461, upload-time = "2026-03-25T20:21:56.228Z" },
+    { url = "https://files.pythonhosted.org/packages/05/38/30f541baf6a3f6df77b3df16b01ba319221389e2da59427e221ef417ac0c/tomli-2.4.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8a650c2dbafa08d42e51ba0b62740dae4ecb9338eefa093aa5c78ceb546fcd5c", size = 274855, upload-time = "2026-03-25T20:21:57.653Z" },
+    { url = "https://files.pythonhosted.org/packages/77/a3/ec9dd4fd2c38e98de34223b995a3b34813e6bdadf86c75314c928350ed14/tomli-2.4.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:504aa796fe0569bb43171066009ead363de03675276d2d121ac1a4572397870f", size = 283144, upload-time = "2026-03-25T20:21:59.089Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/be/605a6261cac79fba2ec0c9827e986e00323a1945700969b8ee0b30d85453/tomli-2.4.1-cp314-cp314t-win32.whl", hash = "sha256:b1d22e6e9387bf4739fbe23bfa80e93f6b0373a7f1b96c6227c32bef95a4d7a8", size = 108683, upload-time = "2026-03-25T20:22:00.214Z" },
+    { url = "https://files.pythonhosted.org/packages/12/64/da524626d3b9cc40c168a13da8335fe1c51be12c0a63685cc6db7308daae/tomli-2.4.1-cp314-cp314t-win_amd64.whl", hash = "sha256:2c1c351919aca02858f740c6d33adea0c5deea37f9ecca1cc1ef9e884a619d26", size = 121196, upload-time = "2026-03-25T20:22:01.169Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/cd/e80b62269fc78fc36c9af5a6b89c835baa8af28ff5ad28c7028d60860320/tomli-2.4.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eab21f45c7f66c13f2a9e0e1535309cee140182a9cdae1e041d02e47291e8396", size = 100393, upload-time = "2026-03-25T20:22:02.137Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/61/cceae43728b7de99d9b847560c262873a1f6c98202171fd5ed62640b494b/tomli-2.4.1-py3-none-any.whl", hash = "sha256:0d85819802132122da43cb86656f8d1f8c6587d54ae7dcaf30e90533028b49fe", size = 14583, upload-time = "2026-03-25T20:22:03.012Z" },
+]
+
+[[package]]
+name = "typing-extensions"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "urllib3"
+version = "2.6.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]


### PR DESCRIPTION
## Summary
- Unify aggregated success-rate query across global and regional dashboards to the matrix form `count_over_time(...[$__range])` with no `>= 0` filter. Failed samples (latency=0) remain in the denominator, so ratios are accurate and identical in both places.
- Bump mapping threshold `0.99991 → 0.99995` on global Success rate panels so only the natural rounding-up-to-100 band is labelled "100.0%"; values in the 99.99% bucket no longer get hidden as 100.
- Regional aggregate gauges: explicit `decimals: 2`, alphabetical provider sort.
- Global Success rate tables: alphabetical provider sort.
- Block lag summary tables untouched (keep `% at Tip desc`).

## Test plan
- [x] Spot-check one global and one regional dashboard in Grafana: provider order stable alphabetically.
- [x] Verify gauges show 2 decimals, mapping only fires ≥ 99.995%.
- [x] Confirm a sub-100% total matches the corresponding per-method rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved success-rate calculations across all dashboards for more accurate metrics and missing-data handling.
  * Added 2-decimal precision to percent displays for clearer values across regions.
  * Standardized provider ordering in panels for consistent, predictable visualization.
  * Adjusted the 100% value mapping threshold for clearer bucket delineation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->