### PR TITLE
feat(dashboards): aggregate global block lag across regions, grey = no data

### DIFF
--- a/dashboards/dashboards/compare-dashboard-arbitrum-eu.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum-eu.json
@@ -883,7 +883,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip.",
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip, grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -902,6 +902,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7025,6 +7038,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Arbitrum (EU)",
   "uid": "arbitrum-eu-1",
-  "version": 53,
+  "version": 54,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-arbitrum-japan.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum-japan.json
@@ -869,7 +869,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip.",
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip, grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -888,6 +888,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7021,6 +7034,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Arbitrum (Japan)",
   "uid": "arbitrum-sing-1",
-  "version": 54,
+  "version": 55,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-arbitrum-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum-us-west.json
@@ -867,7 +867,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip.",
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip, grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -886,6 +886,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7019,6 +7032,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Arbitrum (US West)",
   "uid": "arbitrum-us-west-1",
-  "version": 52,
+  "version": 53,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-arbitrum.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum.json
@@ -1393,7 +1393,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider-region. Lag is relative to the best provider in the same region. Color shows severity: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20).",
+          "description": "Each row is a provider, aggregated across regions by worst region at each moment (most behind = shown). Lag is relative to the best provider in the same region. Color shows severity: green = at tip (\u22642 blocks), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20), grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1412,6 +1412,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -1438,180 +1451,24 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Alchemy-Growth - fra1"
+                  "options": "Chainstack"
                 },
                 "properties": [
                   {
                     "id": "displayName",
-                    "value": "Alchemy-Growth - EU"
+                    "value": "Chainstack-Growth"
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Alchemy-Growth - hnd1"
+                  "options": "dRPC"
                 },
                 "properties": [
                   {
                     "id": "displayName",
-                    "value": "Alchemy-Growth - JP"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Alchemy-Growth - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Alchemy-Growth - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack - hnd1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth - JP"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Helius-Developer - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Helius-Developer - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Helius-Developer - hnd1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Helius-Developer - JP"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Helius-Developer - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Helius-Developer - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Quicknode-Growth - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Quicknode-Growth - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Quicknode-Growth - hnd1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Quicknode-Growth - JP"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Quicknode-Growth - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Quicknode-Growth - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "dRPC - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "dRPC-Growth - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "dRPC - hnd1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "dRPC-Growth - JP"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "dRPC - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "dRPC-Growth - US"
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1652,8 +1509,8 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Arbitrum\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Arbitrum\", response_status=\"success\"}))",
-              "legendFormat": "{{provider}} - {{source_region}}",
+              "expr": "max by (provider) (-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Arbitrum\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Arbitrum\", response_status=\"success\"})))",
+              "legendFormat": "{{provider}}",
               "range": true,
               "refId": "A"
             }
@@ -1666,7 +1523,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Block lag tracking summary. % at Tip = percentage of time slot lag \u2264 2 (tip is best provider in same region). Success Rate = getLatestBlockhash reliability.",
+          "description": "Block lag tracking summary, aggregated across regions (weighted). % at Tip = share of region\u00d7minute samples where provider's lag \u2264 2 blocks vs best-in-region tip. SR = overall RPC success rate across all regional samples.",
           "fieldConfig": {
             "defaults": {
               "custom": {
@@ -1722,40 +1579,6 @@
                   {
                     "id": "custom.width",
                     "value": 108
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Region"
-                },
-                "properties": [
-                  {
-                    "id": "mappings",
-                    "value": [
-                      {
-                        "options": {
-                          "fra1": {
-                            "index": 0,
-                            "text": "EU"
-                          },
-                          "hnd1": {
-                            "index": 1,
-                            "text": "JP"
-                          },
-                          "sfo1": {
-                            "index": 2,
-                            "text": "US"
-                          }
-                        },
-                        "type": "value"
-                      }
-                    ]
-                  },
-                  {
-                    "id": "custom.width",
-                    "value": 60
                   }
                 ]
               },
@@ -1857,7 +1680,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "100 * (1 - avg_over_time((clamp_min(-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Arbitrum\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Arbitrum\", response_status=\"success\"})), 0) > bool 2)[$__range:1m]))",
+              "expr": "100 * (1 - avg_over_time((avg by (provider) (clamp_min(-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Arbitrum\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Arbitrum\", response_status=\"success\"})), 0) > bool 2))[$__range:1m]))",
               "format": "table",
               "instant": true,
               "refId": "A"
@@ -1869,7 +1692,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n  or on(provider, source_region)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\"}[$__range])) by (provider, source_region))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\"}[$__range])) by (provider, source_region)",
+              "expr": "sum by (provider) (\r\n  count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\", response_status=\"success\"}[$__range])\r\n  or on(provider, source_region)\r\n  (0 * count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\"}[$__range]))\r\n)\r\n/\r\nsum by (provider) (count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Arbitrum\"}[$__range]))",
               "format": "table",
               "instant": true,
               "refId": "B"
@@ -1888,16 +1711,14 @@
                   "Time": true
                 },
                 "indexByName": {
-                  "Value #A": 2,
-                  "Value #B": 3,
-                  "provider": 0,
-                  "source_region": 1
+                  "Value #A": 1,
+                  "Value #B": 2,
+                  "provider": 0
                 },
                 "renameByName": {
                   "Value #A": "% at Tip",
                   "Value #B": "SR",
-                  "provider": "Provider",
-                  "source_region": "Region"
+                  "provider": "Provider"
                 }
               }
             },
@@ -4693,6 +4514,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Arbitrum",
   "uid": "arbitrum-global-1",
-  "version": 94,
+  "version": 96,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-base-eu.json
+++ b/dashboards/dashboards/compare-dashboard-base-eu.json
@@ -867,7 +867,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip.",
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip, grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -886,6 +886,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7011,6 +7024,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Base (EU)",
   "uid": "fe3mtxna6483ke-base-germ",
-  "version": 97,
+  "version": 98,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-base-japan.json
+++ b/dashboards/dashboards/compare-dashboard-base-japan.json
@@ -866,7 +866,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip.",
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip, grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -885,6 +885,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7014,6 +7027,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Base (Japan)",
   "uid": "fe3mtxna6483ke-base-sing",
-  "version": 96,
+  "version": 97,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-base-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-base-us-west.json
@@ -866,7 +866,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip.",
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip, grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -885,6 +885,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7010,6 +7023,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Base (US West)",
   "uid": "fe3mtxna6483ke-base-us-west",
-  "version": 93,
+  "version": 94,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-base.json
+++ b/dashboards/dashboards/compare-dashboard-base.json
@@ -1381,7 +1381,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider-region. Lag is relative to the best provider in the same region. Color shows severity: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20).",
+          "description": "Each row is a provider, aggregated across regions by worst region at each moment (most behind = shown). Lag is relative to the best provider in the same region. Color shows severity: green = at tip (\u22642 blocks), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20), grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1400,6 +1400,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -1426,180 +1439,24 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Alchemy-Growth - fra1"
+                  "options": "Chainstack"
                 },
                 "properties": [
                   {
                     "id": "displayName",
-                    "value": "Alchemy-Growth - EU"
+                    "value": "Chainstack-Growth"
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Alchemy-Growth - hnd1"
+                  "options": "dRPC"
                 },
                 "properties": [
                   {
                     "id": "displayName",
-                    "value": "Alchemy-Growth - JP"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Alchemy-Growth - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Alchemy-Growth - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack - hnd1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth - JP"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Helius-Developer - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Helius-Developer - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Helius-Developer - hnd1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Helius-Developer - JP"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Helius-Developer - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Helius-Developer - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Quicknode-Growth - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Quicknode-Growth - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Quicknode-Growth - hnd1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Quicknode-Growth - JP"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Quicknode-Growth - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Quicknode-Growth - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "dRPC - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "dRPC-Growth - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "dRPC - hnd1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "dRPC-Growth - JP"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "dRPC - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "dRPC-Growth - US"
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1640,8 +1497,8 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Base\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Base\", response_status=\"success\"}))",
-              "legendFormat": "{{provider}} - {{source_region}}",
+              "expr": "max by (provider) (-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Base\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Base\", response_status=\"success\"})))",
+              "legendFormat": "{{provider}}",
               "range": true,
               "refId": "A"
             }
@@ -1654,7 +1511,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Block lag tracking summary. % at Tip = percentage of time slot lag \u2264 2 (tip is best provider in same region). Success Rate = getLatestBlockhash reliability.",
+          "description": "Block lag tracking summary, aggregated across regions (weighted). % at Tip = share of region\u00d7minute samples where provider's lag \u2264 2 blocks vs best-in-region tip. SR = overall RPC success rate across all regional samples.",
           "fieldConfig": {
             "defaults": {
               "custom": {
@@ -1710,40 +1567,6 @@
                   {
                     "id": "custom.width",
                     "value": 108
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Region"
-                },
-                "properties": [
-                  {
-                    "id": "mappings",
-                    "value": [
-                      {
-                        "options": {
-                          "fra1": {
-                            "index": 0,
-                            "text": "EU"
-                          },
-                          "hnd1": {
-                            "index": 1,
-                            "text": "JP"
-                          },
-                          "sfo1": {
-                            "index": 2,
-                            "text": "US"
-                          }
-                        },
-                        "type": "value"
-                      }
-                    ]
-                  },
-                  {
-                    "id": "custom.width",
-                    "value": 60
                   }
                 ]
               },
@@ -1845,7 +1668,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "100 * (1 - avg_over_time((clamp_min(-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Base\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Base\", response_status=\"success\"})), 0) > bool 2)[$__range:1m]))",
+              "expr": "100 * (1 - avg_over_time((avg by (provider) (clamp_min(-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Base\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Base\", response_status=\"success\"})), 0) > bool 2))[$__range:1m]))",
               "format": "table",
               "instant": true,
               "refId": "A"
@@ -1857,7 +1680,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n  or on(provider, source_region)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\"}[$__range])) by (provider, source_region))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\"}[$__range])) by (provider, source_region)",
+              "expr": "sum by (provider) (\r\n  count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\", response_status=\"success\"}[$__range])\r\n  or on(provider, source_region)\r\n  (0 * count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\"}[$__range]))\r\n)\r\n/\r\nsum by (provider) (count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Base\"}[$__range]))",
               "format": "table",
               "instant": true,
               "refId": "B"
@@ -1876,16 +1699,14 @@
                   "Time": true
                 },
                 "indexByName": {
-                  "Value #A": 2,
-                  "Value #B": 3,
-                  "provider": 0,
-                  "source_region": 1
+                  "Value #A": 1,
+                  "Value #B": 2,
+                  "provider": 0
                 },
                 "renameByName": {
                   "Value #A": "% at Tip",
                   "Value #B": "SR",
-                  "provider": "Provider",
-                  "source_region": "Region"
+                  "provider": "Provider"
                 }
               }
             },
@@ -4695,6 +4516,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Base",
   "uid": "fe3mtxna6483ke-base-global",
-  "version": 179,
+  "version": 181,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain-eu.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain-eu.json
@@ -865,7 +865,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip.",
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip, grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -884,6 +884,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7006,6 +7019,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: BNB Smart Chain (EU)",
   "uid": "bnbsc-eu-1",
-  "version": 40,
+  "version": 41,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain-singapore.json
@@ -865,7 +865,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip.",
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip, grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -884,6 +884,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7005,6 +7018,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: BNB Smart Chain (Singapore)",
   "uid": "bnbsc-sing-1",
-  "version": 38,
+  "version": 39,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain-us-west.json
@@ -865,7 +865,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip.",
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip, grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -884,6 +884,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7009,6 +7022,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: BNB Smart Chain (US West)",
   "uid": "bnbsc-us-west-1",
-  "version": 39,
+  "version": 40,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain.json
@@ -1369,7 +1369,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider-region. Lag is relative to the best provider in the same region. Color shows severity: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20).",
+          "description": "Each row is a provider, aggregated across regions by worst region at each moment (most behind = shown). Lag is relative to the best provider in the same region. Color shows severity: green = at tip (\u22642 blocks), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20), grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1388,6 +1388,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -1414,180 +1427,24 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Alchemy-Growth - fra1"
+                  "options": "Chainstack"
                 },
                 "properties": [
                   {
                     "id": "displayName",
-                    "value": "Alchemy-Growth - EU"
+                    "value": "Chainstack-Growth"
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Alchemy-Growth - sin1"
+                  "options": "dRPC"
                 },
                 "properties": [
                   {
                     "id": "displayName",
-                    "value": "Alchemy-Growth - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Alchemy-Growth - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Alchemy-Growth - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack - sin1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Helius-Developer - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Helius-Developer - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Helius-Developer - sin1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Helius-Developer - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Helius-Developer - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Helius-Developer - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Quicknode-Growth - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Quicknode-Growth - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Quicknode-Growth - sin1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Quicknode-Growth - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Quicknode-Growth - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Quicknode-Growth - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "dRPC - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "dRPC-Growth - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "dRPC - sin1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "dRPC-Growth - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "dRPC - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "dRPC-Growth - US"
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1628,8 +1485,8 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"BNB\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"BNB\", response_status=\"success\"}))",
-              "legendFormat": "{{provider}} - {{source_region}}",
+              "expr": "max by (provider) (-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"BNB\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"BNB\", response_status=\"success\"})))",
+              "legendFormat": "{{provider}}",
               "range": true,
               "refId": "A"
             }
@@ -1642,7 +1499,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Block lag tracking summary. % at Tip = percentage of time slot lag \u2264 2 (tip is best provider in same region). Success Rate = getLatestBlockhash reliability.",
+          "description": "Block lag tracking summary, aggregated across regions (weighted). % at Tip = share of region\u00d7minute samples where provider's lag \u2264 2 blocks vs best-in-region tip. SR = overall RPC success rate across all regional samples.",
           "fieldConfig": {
             "defaults": {
               "custom": {
@@ -1698,40 +1555,6 @@
                   {
                     "id": "custom.width",
                     "value": 108
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Region"
-                },
-                "properties": [
-                  {
-                    "id": "mappings",
-                    "value": [
-                      {
-                        "options": {
-                          "fra1": {
-                            "index": 0,
-                            "text": "EU"
-                          },
-                          "sfo1": {
-                            "index": 2,
-                            "text": "US"
-                          },
-                          "sin1": {
-                            "index": 1,
-                            "text": "SG"
-                          }
-                        },
-                        "type": "value"
-                      }
-                    ]
-                  },
-                  {
-                    "id": "custom.width",
-                    "value": 60
                   }
                 ]
               },
@@ -1833,7 +1656,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "100 * (1 - avg_over_time((clamp_min(-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"BNB\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"BNB\", response_status=\"success\"})), 0) > bool 2)[$__range:1m]))",
+              "expr": "100 * (1 - avg_over_time((avg by (provider) (clamp_min(-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"BNB\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"BNB\", response_status=\"success\"})), 0) > bool 2))[$__range:1m]))",
               "format": "table",
               "instant": true,
               "refId": "A"
@@ -1845,7 +1668,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n  or on(provider, source_region)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\"}[$__range])) by (provider, source_region))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\"}[$__range])) by (provider, source_region)",
+              "expr": "sum by (provider) (\r\n  count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\", response_status=\"success\"}[$__range])\r\n  or on(provider, source_region)\r\n  (0 * count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\"}[$__range]))\r\n)\r\n/\r\nsum by (provider) (count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"BNB\"}[$__range]))",
               "format": "table",
               "instant": true,
               "refId": "B"
@@ -1864,16 +1687,14 @@
                   "Time": true
                 },
                 "indexByName": {
-                  "Value #A": 2,
-                  "Value #B": 3,
-                  "provider": 0,
-                  "source_region": 1
+                  "Value #A": 1,
+                  "Value #B": 2,
+                  "provider": 0
                 },
                 "renameByName": {
                   "Value #A": "% at Tip",
                   "Value #B": "SR",
-                  "provider": "Provider",
-                  "source_region": "Region"
+                  "provider": "Provider"
                 }
               }
             },
@@ -4619,6 +4440,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: BNB Smart Chain",
   "uid": "bnbsc-global-1",
-  "version": 53,
+  "version": 55,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-ethereum-eu.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum-eu.json
@@ -792,7 +792,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip.",
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip, grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -811,6 +811,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -6933,6 +6946,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Ethereum (EU)",
   "uid": "fe3mtxna6483ke-eu",
-  "version": 88,
+  "version": 89,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-ethereum-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum-singapore.json
@@ -866,7 +866,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip.",
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip, grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -885,6 +885,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7006,6 +7019,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Ethereum (Singapore)",
   "uid": "ssss-sing",
-  "version": 60,
+  "version": 61,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-ethereum-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum-us-west.json
@@ -866,7 +866,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip.",
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip, grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -885,6 +885,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7006,6 +7019,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Ethereum (US West)",
   "uid": "fe3mtxna6483ke",
-  "version": 275,
+  "version": 276,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-ethereum.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum.json
@@ -1347,7 +1347,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider-region. Lag is relative to the best provider in the same region. Color shows severity: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20).",
+          "description": "Each row is a provider, aggregated across regions by worst region at each moment (most behind = shown). Lag is relative to the best provider in the same region. Color shows severity: green = at tip (\u22642 blocks), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20), grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1366,6 +1366,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -1392,180 +1405,24 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Alchemy-Growth - fra1"
+                  "options": "Chainstack"
                 },
                 "properties": [
                   {
                     "id": "displayName",
-                    "value": "Alchemy-Growth - EU"
+                    "value": "Chainstack-Growth"
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Alchemy-Growth - sin1"
+                  "options": "dRPC"
                 },
                 "properties": [
                   {
                     "id": "displayName",
-                    "value": "Alchemy-Growth - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Alchemy-Growth - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Alchemy-Growth - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack - sin1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Helius-Developer - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Helius-Developer - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Helius-Developer - sin1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Helius-Developer - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Helius-Developer - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Helius-Developer - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Quicknode-Growth - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Quicknode-Growth - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Quicknode-Growth - sin1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Quicknode-Growth - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Quicknode-Growth - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Quicknode-Growth - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "dRPC - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "dRPC-Growth - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "dRPC - sin1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "dRPC-Growth - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "dRPC - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "dRPC-Growth - US"
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1606,8 +1463,8 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Ethereum\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Ethereum\", response_status=\"success\"}))",
-              "legendFormat": "{{provider}} - {{source_region}}",
+              "expr": "max by (provider) (-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Ethereum\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Ethereum\", response_status=\"success\"})))",
+              "legendFormat": "{{provider}}",
               "range": true,
               "refId": "A"
             }
@@ -1620,7 +1477,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Block lag tracking summary. % at Tip = percentage of time slot lag \u2264 2 (tip is best provider in same region). Success Rate = getLatestBlockhash reliability.",
+          "description": "Block lag tracking summary, aggregated across regions (weighted). % at Tip = share of region\u00d7minute samples where provider's lag \u2264 2 blocks vs best-in-region tip. SR = overall RPC success rate across all regional samples.",
           "fieldConfig": {
             "defaults": {
               "custom": {
@@ -1676,40 +1533,6 @@
                   {
                     "id": "custom.width",
                     "value": 108
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Region"
-                },
-                "properties": [
-                  {
-                    "id": "mappings",
-                    "value": [
-                      {
-                        "options": {
-                          "fra1": {
-                            "index": 0,
-                            "text": "EU"
-                          },
-                          "sfo1": {
-                            "index": 2,
-                            "text": "US"
-                          },
-                          "sin1": {
-                            "index": 1,
-                            "text": "SG"
-                          }
-                        },
-                        "type": "value"
-                      }
-                    ]
-                  },
-                  {
-                    "id": "custom.width",
-                    "value": 60
                   }
                 ]
               },
@@ -1811,7 +1634,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "100 * (1 - avg_over_time((clamp_min(-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Ethereum\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Ethereum\", response_status=\"success\"})), 0) > bool 2)[$__range:1m]))",
+              "expr": "100 * (1 - avg_over_time((avg by (provider) (clamp_min(-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Ethereum\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Ethereum\", response_status=\"success\"})), 0) > bool 2))[$__range:1m]))",
               "format": "table",
               "instant": true,
               "refId": "A"
@@ -1823,7 +1646,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n  or on(provider, source_region)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\"}[$__range])) by (provider, source_region))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\"}[$__range])) by (provider, source_region)",
+              "expr": "sum by (provider) (\r\n  count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\", response_status=\"success\"}[$__range])\r\n  or on(provider, source_region)\r\n  (0 * count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\"}[$__range]))\r\n)\r\n/\r\nsum by (provider) (count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Ethereum\"}[$__range]))",
               "format": "table",
               "instant": true,
               "refId": "B"
@@ -1842,16 +1665,14 @@
                   "Time": true
                 },
                 "indexByName": {
-                  "Value #A": 2,
-                  "Value #B": 3,
-                  "provider": 0,
-                  "source_region": 1
+                  "Value #A": 1,
+                  "Value #B": 2,
+                  "provider": 0
                 },
                 "renameByName": {
                   "Value #A": "% at Tip",
                   "Value #B": "SR",
-                  "provider": "Provider",
-                  "source_region": "Region"
+                  "provider": "Provider"
                 }
               }
             },
@@ -4608,6 +4429,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Ethereum",
   "uid": "fe3mtxna6483ke-global",
-  "version": 104,
+  "version": 106,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-hyperliquid-eu.json
+++ b/dashboards/dashboards/compare-dashboard-hyperliquid-eu.json
@@ -851,7 +851,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip.",
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip, grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -870,6 +870,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -4677,6 +4690,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Hyperliquid (EU)",
   "uid": "Hyperliquid-eu-1",
-  "version": 65,
+  "version": 66,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-hyperliquid-japan.json
+++ b/dashboards/dashboards/compare-dashboard-hyperliquid-japan.json
@@ -871,7 +871,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip.",
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip, grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -890,6 +890,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -4822,6 +4835,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Hyperliquid (Japan)",
   "uid": "Hyperliquid-jap-1",
-  "version": 50,
+  "version": 51,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-hyperliquid-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-hyperliquid-us-west.json
@@ -870,7 +870,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip.",
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip, grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -889,6 +889,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -4821,6 +4834,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Hyperliquid (US West)",
   "uid": "Hyperliquid-us-west-1",
-  "version": 57,
+  "version": 58,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-hyperliquid.json
+++ b/dashboards/dashboards/compare-dashboard-hyperliquid.json
@@ -1646,7 +1646,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider-region. Lag is relative to the best provider in the same region. Color shows severity: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20).",
+          "description": "Each row is a provider, aggregated across regions by worst region at each moment (most behind = shown). Lag is relative to the best provider in the same region. Color shows severity: green = at tip (\u22642 blocks), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20), grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1665,6 +1665,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -1691,180 +1704,24 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Alchemy-Growth - fra1"
+                  "options": "Chainstack"
                 },
                 "properties": [
                   {
                     "id": "displayName",
-                    "value": "Alchemy-Growth - EU"
+                    "value": "Chainstack-Growth"
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Alchemy-Growth - hnd1"
+                  "options": "dRPC"
                 },
                 "properties": [
                   {
                     "id": "displayName",
-                    "value": "Alchemy-Growth - JP"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Alchemy-Growth - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Alchemy-Growth - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack - hnd1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth - JP"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Helius-Developer - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Helius-Developer - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Helius-Developer - hnd1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Helius-Developer - JP"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Helius-Developer - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Helius-Developer - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Quicknode-Growth - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Quicknode-Growth - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Quicknode-Growth - hnd1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Quicknode-Growth - JP"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Quicknode-Growth - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Quicknode-Growth - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "dRPC - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "dRPC-Growth - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "dRPC - hnd1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "dRPC-Growth - JP"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "dRPC - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "dRPC-Growth - US"
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1905,8 +1762,8 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Hyperliquid\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Hyperliquid\", response_status=\"success\"}))",
-              "legendFormat": "{{provider}} - {{source_region}}",
+              "expr": "max by (provider) (-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Hyperliquid\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Hyperliquid\", response_status=\"success\"})))",
+              "legendFormat": "{{provider}}",
               "range": true,
               "refId": "A"
             }
@@ -1919,7 +1776,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Block lag tracking summary. % at Tip = percentage of time slot lag \u2264 2 (tip is best provider in same region). Success Rate = getLatestBlockhash reliability.",
+          "description": "Block lag tracking summary, aggregated across regions (weighted). % at Tip = share of region\u00d7minute samples where provider's lag \u2264 2 blocks vs best-in-region tip. SR = overall RPC success rate across all regional samples.",
           "fieldConfig": {
             "defaults": {
               "custom": {
@@ -1975,40 +1832,6 @@
                   {
                     "id": "custom.width",
                     "value": 108
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Region"
-                },
-                "properties": [
-                  {
-                    "id": "mappings",
-                    "value": [
-                      {
-                        "options": {
-                          "fra1": {
-                            "index": 0,
-                            "text": "EU"
-                          },
-                          "hnd1": {
-                            "index": 1,
-                            "text": "JP"
-                          },
-                          "sfo1": {
-                            "index": 2,
-                            "text": "US"
-                          }
-                        },
-                        "type": "value"
-                      }
-                    ]
-                  },
-                  {
-                    "id": "custom.width",
-                    "value": 60
                   }
                 ]
               },
@@ -2110,7 +1933,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "100 * (1 - avg_over_time((clamp_min(-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Hyperliquid\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Hyperliquid\", response_status=\"success\"})), 0) > bool 2)[$__range:1m]))",
+              "expr": "100 * (1 - avg_over_time((avg by (provider) (clamp_min(-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Hyperliquid\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Hyperliquid\", response_status=\"success\"})), 0) > bool 2))[$__range:1m]))",
               "format": "table",
               "instant": true,
               "refId": "A"
@@ -2122,7 +1945,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", api_method=~\"(eth_call|eth_getBalance|eth_getLogs|eth_getTransactionReceipt|eth_blockNumber)\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n  or on(provider, source_region)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", api_method=~\"(eth_call|eth_getBalance|eth_getLogs|eth_getTransactionReceipt|eth_blockNumber)\"}[$__range])) by (provider, source_region))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", api_method=~\"(eth_call|eth_getBalance|eth_getLogs|eth_getTransactionReceipt|eth_blockNumber)\"}[$__range])) by (provider, source_region)",
+              "expr": "sum by (provider) (\r\n  count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\", response_status=\"success\"}[$__range])\r\n  or on(provider, source_region)\r\n  (0 * count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\"}[$__range]))\r\n)\r\n/\r\nsum by (provider) (count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Hyperliquid\"}[$__range]))",
               "format": "table",
               "instant": true,
               "refId": "B"
@@ -2141,16 +1964,14 @@
                   "Time": true
                 },
                 "indexByName": {
-                  "Value #A": 2,
-                  "Value #B": 3,
-                  "provider": 0,
-                  "source_region": 1
+                  "Value #A": 1,
+                  "Value #B": 2,
+                  "provider": 0
                 },
                 "renameByName": {
                   "Value #A": "% at Tip",
                   "Value #B": "SR",
-                  "provider": "Provider",
-                  "source_region": "Region"
+                  "provider": "Provider"
                 }
               }
             },
@@ -4619,6 +4440,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Hyperliquid",
   "uid": "Hyperliquid-global-1",
-  "version": 80,
+  "version": 82,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-monad-eu.json
+++ b/dashboards/dashboards/compare-dashboard-monad-eu.json
@@ -870,7 +870,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip.",
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip, grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -889,6 +889,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7046,6 +7059,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Monad (EU)",
   "uid": "monad-eu-1",
-  "version": 26,
+  "version": 27,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-monad-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-monad-singapore.json
@@ -869,7 +869,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip.",
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip, grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -888,6 +888,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7021,6 +7034,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Monad (Singapore)",
   "uid": "monad-asia-1",
-  "version": 31,
+  "version": 32,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-monad-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-monad-us-west.json
@@ -867,7 +867,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip.",
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip, grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -886,6 +886,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7019,6 +7032,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Monad (US West)",
   "uid": "monad-us-west-1",
-  "version": 26,
+  "version": 27,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-monad.json
+++ b/dashboards/dashboards/compare-dashboard-monad.json
@@ -1413,7 +1413,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider-region. Lag is relative to the best provider in the same region. Color shows severity: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20).",
+          "description": "Each row is a provider, aggregated across regions by worst region at each moment (most behind = shown). Lag is relative to the best provider in the same region. Color shows severity: green = at tip (\u22642 blocks), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20), grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1432,6 +1432,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -1458,180 +1471,24 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Alchemy-Growth - fra1"
+                  "options": "Chainstack"
                 },
                 "properties": [
                   {
                     "id": "displayName",
-                    "value": "Alchemy-Growth - EU"
+                    "value": "Chainstack-Growth"
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Alchemy-Growth - sin1"
+                  "options": "dRPC"
                 },
                 "properties": [
                   {
                     "id": "displayName",
-                    "value": "Alchemy-Growth - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Alchemy-Growth - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Alchemy-Growth - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack - sin1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Helius-Developer - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Helius-Developer - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Helius-Developer - sin1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Helius-Developer - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Helius-Developer - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Helius-Developer - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Quicknode-Growth - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Quicknode-Growth - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Quicknode-Growth - sin1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Quicknode-Growth - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Quicknode-Growth - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Quicknode-Growth - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "dRPC - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "dRPC-Growth - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "dRPC - sin1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "dRPC-Growth - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "dRPC - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "dRPC-Growth - US"
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1672,8 +1529,8 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Monad\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Monad\", response_status=\"success\"}))",
-              "legendFormat": "{{provider}} - {{source_region}}",
+              "expr": "max by (provider) (-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Monad\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Monad\", response_status=\"success\"})))",
+              "legendFormat": "{{provider}}",
               "range": true,
               "refId": "A"
             }
@@ -1686,7 +1543,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Block lag tracking summary. % at Tip = percentage of time slot lag \u2264 2 (tip is best provider in same region). Success Rate = getLatestBlockhash reliability.",
+          "description": "Block lag tracking summary, aggregated across regions (weighted). % at Tip = share of region\u00d7minute samples where provider's lag \u2264 2 blocks vs best-in-region tip. SR = overall RPC success rate across all regional samples.",
           "fieldConfig": {
             "defaults": {
               "custom": {
@@ -1742,40 +1599,6 @@
                   {
                     "id": "custom.width",
                     "value": 108
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Region"
-                },
-                "properties": [
-                  {
-                    "id": "mappings",
-                    "value": [
-                      {
-                        "options": {
-                          "fra1": {
-                            "index": 0,
-                            "text": "EU"
-                          },
-                          "sfo1": {
-                            "index": 2,
-                            "text": "US"
-                          },
-                          "sin1": {
-                            "index": 1,
-                            "text": "SG"
-                          }
-                        },
-                        "type": "value"
-                      }
-                    ]
-                  },
-                  {
-                    "id": "custom.width",
-                    "value": 60
                   }
                 ]
               },
@@ -1877,7 +1700,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "100 * (1 - avg_over_time((clamp_min(-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Monad\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Monad\", response_status=\"success\"})), 0) > bool 2)[$__range:1m]))",
+              "expr": "100 * (1 - avg_over_time((avg by (provider) (clamp_min(-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Monad\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Monad\", response_status=\"success\"})), 0) > bool 2))[$__range:1m]))",
               "format": "table",
               "instant": true,
               "refId": "A"
@@ -1889,7 +1712,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n  or on(provider, source_region)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\"}[$__range])) by (provider, source_region))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\"}[$__range])) by (provider, source_region)",
+              "expr": "sum by (provider) (\r\n  count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\", response_status=\"success\"}[$__range])\r\n  or on(provider, source_region)\r\n  (0 * count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\"}[$__range]))\r\n)\r\n/\r\nsum by (provider) (count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Monad\"}[$__range]))",
               "format": "table",
               "instant": true,
               "refId": "B"
@@ -1908,16 +1731,14 @@
                   "Time": true
                 },
                 "indexByName": {
-                  "Value #A": 2,
-                  "Value #B": 3,
-                  "provider": 0,
-                  "source_region": 1
+                  "Value #A": 1,
+                  "Value #B": 2,
+                  "provider": 0
                 },
                 "renameByName": {
                   "Value #A": "% at Tip",
                   "Value #B": "SR",
-                  "provider": "Provider",
-                  "source_region": "Region"
+                  "provider": "Provider"
                 }
               }
             },
@@ -4794,6 +4615,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Monad",
   "uid": "monad-global-1",
-  "version": 30,
+  "version": 32,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-solana-eu.json
+++ b/dashboards/dashboards/compare-dashboard-solana-eu.json
@@ -731,7 +731,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip.",
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip, grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -750,6 +750,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -7801,6 +7814,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Solana (EU)",
   "uid": "be82wni0bhukgd",
-  "version": 107,
+  "version": 108,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-solana-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-solana-singapore.json
@@ -731,7 +731,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip.",
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip, grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -750,6 +750,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -6424,6 +6437,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Solana (Singapore)",
   "uid": "ae82yw1vzdfr4d",
-  "version": 85,
+  "version": 86,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-solana-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-solana-us-west.json
@@ -732,7 +732,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip.",
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Slot lag. 0 = at the tip, grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -751,6 +751,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -6425,6 +6438,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Solana (US West)",
   "uid": "de82ypwiibsowe",
-  "version": 88,
+  "version": 89,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-solana.json
+++ b/dashboards/dashboards/compare-dashboard-solana.json
@@ -1473,7 +1473,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider-region. Lag is relative to the best provider in the same region. Color shows severity: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20).",
+          "description": "Each row is a provider, aggregated across regions by worst region at each moment (most behind = shown). Lag is relative to the best provider in the same region. Color shows severity: green = at tip (\u22642 slots), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20), grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1492,6 +1492,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -1518,180 +1531,24 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Alchemy-Growth - fra1"
+                  "options": "Chainstack"
                 },
                 "properties": [
                   {
                     "id": "displayName",
-                    "value": "Alchemy-Growth - EU"
+                    "value": "Chainstack-Growth"
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Alchemy-Growth - sin1"
+                  "options": "dRPC"
                 },
                 "properties": [
                   {
                     "id": "displayName",
-                    "value": "Alchemy-Growth - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Alchemy-Growth - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Alchemy-Growth - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack - sin1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Chainstack - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Chainstack-Growth - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Helius-Developer - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Helius-Developer - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Helius-Developer - sin1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Helius-Developer - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Helius-Developer - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Helius-Developer - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Quicknode-Growth - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Quicknode-Growth - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Quicknode-Growth - sin1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Quicknode-Growth - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Quicknode-Growth - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Quicknode-Growth - US"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "dRPC - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "dRPC-Growth - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "dRPC - sin1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "dRPC-Growth - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "dRPC - sfo1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "dRPC-Growth - US"
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1732,8 +1589,8 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", response_status=\"success\"}))",
-              "legendFormat": "{{provider}} - {{source_region}}",
+              "expr": "max by (provider) (-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", response_status=\"success\"})))",
+              "legendFormat": "{{provider}}",
               "range": true,
               "refId": "A"
             }
@@ -1746,7 +1603,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Block lag tracking summary. % at Tip = percentage of time slot lag \u2264 2 (tip is best provider in same region). Success Rate = getLatestBlockhash reliability.",
+          "description": "Block lag tracking summary, aggregated across regions (weighted). % at Tip = share of region\u00d7minute samples where provider's lag \u2264 2 slots vs best-in-region tip. SR = overall getLatestBlockhash success rate across all regional samples.",
           "fieldConfig": {
             "defaults": {
               "custom": {
@@ -1802,40 +1659,6 @@
                   {
                     "id": "custom.width",
                     "value": 108
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Region"
-                },
-                "properties": [
-                  {
-                    "id": "mappings",
-                    "value": [
-                      {
-                        "options": {
-                          "fra1": {
-                            "index": 0,
-                            "text": "EU"
-                          },
-                          "sfo1": {
-                            "index": 2,
-                            "text": "US"
-                          },
-                          "sin1": {
-                            "index": 1,
-                            "text": "SG"
-                          }
-                        },
-                        "type": "value"
-                      }
-                    ]
-                  },
-                  {
-                    "id": "custom.width",
-                    "value": 60
                   }
                 ]
               },
@@ -1937,7 +1760,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "100 * (1 - avg_over_time((clamp_min(-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", response_status=\"success\"})), 0) > bool 2)[$__range:1m]))",
+              "expr": "100 * (1 - avg_over_time((avg by (provider) (clamp_min(-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"Solana\", response_status=\"success\"})), 0) > bool 2))[$__range:1m]))",
               "format": "table",
               "instant": true,
               "refId": "A"
@@ -1949,7 +1772,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n  or on(provider, source_region)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\"}[$__range])) by (provider, source_region))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\"}[$__range])) by (provider, source_region)",
+              "expr": "sum by (provider) (\r\n  count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\", response_status=\"success\"}[$__range])\r\n  or on(provider, source_region)\r\n  (0 * count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\"}[$__range]))\r\n)\r\n/\r\nsum by (provider) (count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"Solana\"}[$__range]))",
               "format": "table",
               "instant": true,
               "refId": "B"
@@ -1968,16 +1791,14 @@
                   "Time": true
                 },
                 "indexByName": {
-                  "Value #A": 2,
-                  "Value #B": 3,
-                  "provider": 0,
-                  "source_region": 1
+                  "Value #A": 1,
+                  "Value #B": 2,
+                  "provider": 0
                 },
                 "renameByName": {
                   "Value #A": "% at Tip",
                   "Value #B": "SR",
-                  "provider": "Provider",
-                  "source_region": "Region"
+                  "provider": "Provider"
                 }
               }
             },
@@ -5828,6 +5649,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Solana",
   "uid": "fe3mtxna6483ke-solana-global",
-  "version": 121,
+  "version": 124,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-ton-eu.json
+++ b/dashboards/dashboards/compare-dashboard-ton-eu.json
@@ -700,7 +700,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 blocks), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Masterchain seqno lag. 0 = at the tip.",
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 blocks), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Masterchain seqno lag. 0 = at the tip, grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -719,6 +719,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -4758,6 +4771,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: TON (EU)",
   "uid": "be82wni0bhukgd-ton-germ",
-  "version": 93,
+  "version": 94,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-ton-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-ton-singapore.json
@@ -700,7 +700,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 blocks), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Masterchain seqno lag. 0 = at the tip.",
+          "description": "Each row is a provider. Color shows lag severity over time: green = at tip (\u22642 blocks), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20). Masterchain seqno lag. 0 = at the tip, grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -719,6 +719,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -4758,6 +4771,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: TON (Singapore)",
   "uid": "be82wni0bhukgd-ton-sing",
-  "version": 88,
+  "version": 89,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-ton.json
+++ b/dashboards/dashboards/compare-dashboard-ton.json
@@ -1249,7 +1249,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Each row is a provider-region. Lag is relative to the best provider in the same region. Color shows severity: green = at tip (\u22642 blocks), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20).",
+          "description": "Each row is a provider, aggregated across regions by worst region at each moment (most behind = shown). Lag is relative to the best provider in the same region. Color shows severity: green = at tip (\u22642 blocks), yellow = slightly behind (3-10), orange = behind (10-20), red = significantly behind (>20), grey = no data.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1268,6 +1268,19 @@
                 "spanNulls": false
               },
               "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
@@ -1294,96 +1307,24 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack - fra1"
+                  "options": "Chainstack"
                 },
                 "properties": [
                   {
                     "id": "displayName",
-                    "value": "Chainstack-Growth - EU"
+                    "value": "Chainstack-Growth"
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack - sin1"
+                  "options": "dRPC"
                 },
                 "properties": [
                   {
                     "id": "displayName",
-                    "value": "Chainstack-Growth - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "dRPC - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "dRPC-Growth - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "dRPC - sin1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "dRPC-Growth - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Quicknode-Growth - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Quicknode-Growth - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Quicknode-Growth - sin1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "Quicknode-Growth - SG"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "TonCenter-WithAPIKey - fra1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "TonCenter-WithAPIKey - EU"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "TonCenter-WithAPIKey - sin1"
-                },
-                "properties": [
-                  {
-                    "id": "displayName",
-                    "value": "TonCenter-WithAPIKey - SG"
+                    "value": "dRPC-Growth"
                   }
                 ]
               }
@@ -1424,8 +1365,8 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", response_status=\"success\"}))",
-              "legendFormat": "{{provider}} - {{source_region}}",
+              "expr": "max by (provider) (-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", response_status=\"success\"})))",
+              "legendFormat": "{{provider}}",
               "range": true,
               "refId": "A"
             }
@@ -1438,7 +1379,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Block lag tracking summary. % at Tip = percentage of time seqno lag \u2264 2 (tip is best provider in same region). Success Rate = getMasterchainInfo reliability.",
+          "description": "Block lag tracking summary, aggregated across regions (weighted). % at Tip = share of region\u00d7minute samples where provider's lag \u2264 2 blocks vs best-in-region tip. SR = overall RPC success rate across all regional samples.",
           "fieldConfig": {
             "defaults": {
               "custom": {
@@ -1494,40 +1435,6 @@
                   {
                     "id": "custom.width",
                     "value": 108
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Region"
-                },
-                "properties": [
-                  {
-                    "id": "mappings",
-                    "value": [
-                      {
-                        "options": {
-                          "fra1": {
-                            "index": 0,
-                            "text": "EU"
-                          },
-                          "sfo1": {
-                            "index": 2,
-                            "text": "US"
-                          },
-                          "sin1": {
-                            "index": 1,
-                            "text": "SG"
-                          }
-                        },
-                        "type": "value"
-                      }
-                    ]
-                  },
-                  {
-                    "id": "custom.width",
-                    "value": 60
                   }
                 ]
               },
@@ -1629,7 +1536,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "100 * (1 - avg_over_time((clamp_min(-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", response_status=\"success\"})), 0) > bool 2)[$__range:1m]))",
+              "expr": "100 * (1 - avg_over_time((avg by (provider) (clamp_min(-1 * (max by (provider, source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", response_status=\"success\"}) - on(source_region) group_left max by (source_region) (response_latency_seconds{metric_type=\"block_number\", blockchain=\"TON\", response_status=\"success\"})), 0) > bool 2))[$__range:1m]))",
               "format": "table",
               "instant": true,
               "refId": "A"
@@ -1641,7 +1548,7 @@
               },
               "editorMode": "code",
               "exemplar": false,
-              "expr": "(\r\n  sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", response_status=\"success\"}[$__range])) by (provider, source_region)\r\n  or on(provider, source_region)\r\n  (0 * sum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\"}[$__range])) by (provider, source_region))\r\n)\r\n/\r\nsum(count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\"}[$__range])) by (provider, source_region)",
+              "expr": "sum by (provider) (\r\n  count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\", response_status=\"success\"}[$__range])\r\n  or on(provider, source_region)\r\n  (0 * count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\"}[$__range]))\r\n)\r\n/\r\nsum by (provider) (count_over_time(response_latency_seconds{metric_type=\"response_time\", blockchain=\"TON\"}[$__range]))",
               "format": "table",
               "instant": true,
               "refId": "B"
@@ -1660,16 +1567,14 @@
                   "Time": true
                 },
                 "indexByName": {
-                  "Value #A": 2,
-                  "Value #B": 3,
-                  "provider": 0,
-                  "source_region": 1
+                  "Value #A": 1,
+                  "Value #B": 2,
+                  "provider": 0
                 },
                 "renameByName": {
                   "Value #A": "% at Tip",
                   "Value #B": "SR",
-                  "provider": "Provider",
-                  "source_region": "Region"
+                  "provider": "Provider"
                 }
               }
             },
@@ -3452,6 +3357,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: TON",
   "uid": "fe3mtxna6483ke-TON-global",
-  "version": 114,
+  "version": 116,
   "weekStart": "monday"
 }


### PR DESCRIPTION
## Summary
- **Global dashboards** (arbitrum, base, bnb-smart-chain, ethereum, hyperliquid, monad, solana, ton): the "Block lag" row now collapses regions into per-provider views.
  - **Timeline** shows each provider's **worst-region lag** at every moment (`max by (provider)` over the existing per-region lag expression).
  - **Summary** columns are weighted across region×minute samples:
    - `% at Tip`: `avg by (provider)` over the per-region "at tip" flag, then time-averaged.
    - `SR`: `sum by (provider)` of success counts / total counts across all regions.
  - Legend renames restored to per-provider (`Chainstack → Chainstack-Growth`, `dRPC → dRPC-Growth`).
- **All dashboards** (global + regional): Block lag timeline now renders missing samples as grey via a `null → "No data"` value mapping, and each panel's description is updated to note **grey = no data**.
- Panel descriptions updated to reflect the new aggregation methodology.

## Test plan
- [x] Open each global dashboard, check Block lag timeline shows one row per provider (not per provider-region), with grey segments during known data gaps.
- [x] Verify summary table has columns `Provider`, `% at Tip`, `SR` only (no `Region`), one row per provider.
- [x] Sanity-check `% at Tip` and `SR` ranges look reasonable vs the pre-existing per-region breakdown.
- [x] Open one regional dashboard per chain and confirm grey = no data renders correctly on its Block lag timeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Block lag timeline panels now clearly display missing data as grey "No data" indicators instead of blank values.

* **Chores**
  * Updated dashboard visualizations across multiple chains to show provider-level aggregated metrics across regions rather than per-region breakdowns for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->