### PR TITLE
fix: get_influx_format emits per-value MetricValue.labels

### DIFF
--- a/common/base_metric.py
+++ b/common/base_metric.py
@@ -55,7 +55,14 @@ class BaseMetric(ABC):
         """Processes raw data into metric value."""
 
     def get_influx_format(self) -> list[str]:
-        """Returns metrics in Influx line protocol format."""
+        """Returns metrics in Influx line protocol format.
+
+        Per-value labels passed via ``update_metric_value(labels=...)`` are
+        appended to the tag line for that ``value_type`` only. Keys that
+        collide with an instance-label key or with the reserved
+        ``metric_type`` tag are silently dropped — the instance value wins,
+        avoiding duplicate tags on the output line.
+        """
         if not self.values:
             raise ValueError("No metric values set")
 
@@ -63,6 +70,9 @@ class BaseMetric(ABC):
         base_tags: str = ",".join(
             [f"{label.key.value}={label.value}" for label in self.labels.labels]
         )
+        reserved_keys = {label.key.value for label in self.labels.labels} | {
+            "metric_type"
+        }
 
         for value_type, metric_value in self.values.items():
             tags: str = base_tags
@@ -70,6 +80,15 @@ class BaseMetric(ABC):
                 tags = f"{base_tags},metric_type={value_type}"
             else:
                 tags = f"metric_type={value_type}"
+
+            if metric_value.labels:
+                extra = ",".join(
+                    f"{k}={v}"
+                    for k, v in metric_value.labels.items()
+                    if k not in reserved_keys
+                )
+                if extra:
+                    tags = f"{tags},{extra}"
 
             metric_line: str = f"{self.metric_name}"
             if tags:
@@ -87,6 +106,13 @@ class BaseMetric(ABC):
         labels: Optional[dict[str, str]] = None,
     ) -> None:
         """Updates metric value, preserving existing labels if present.
+
+        ``labels`` attaches per-value tags that ``get_influx_format`` appends
+        to the output line for this ``value_type`` only. Keys that collide
+        with an instance label (``source_region``, ``target_region``,
+        ``blockchain``, ``provider``, ``api_method``, ``response_status``)
+        or with the reserved ``metric_type`` tag are silently dropped at emit
+        time — the instance value wins.
 
         Raises:
             ValueError: If value is negative.


### PR DESCRIPTION
## Summary
- Wire `MetricValue.labels` through `get_influx_format` so per-value labels actually appear on the output line.
- Per-value labels apply to the matching `value_type` only — the rest of the metric instance's value_types emit unchanged.
- Collision protection: keys that match an instance label (`source_region`, `target_region`, `blockchain`, `provider`, `api_method`, `response_status`) or the reserved `metric_type` tag are dropped; instance value wins.

## Why
`MetricValue.labels` has been a stored-but-never-emitted dataclass field since the start. `update_metric_value(labels=...)` accepted and stored the kwarg; `get_influx_format()` only ever read instance labels and silently discarded per-value labels. Latent half-implemented feature.

The upcoming verified-correctness work needs per-value tagging — `block_number` must ride on the `balance_observed` value_type only. Putting it on instance labels would fragment every existing `response_time` series and break every existing latency dashboard.

## Behavior preservation
**Byte-identical** for all current call sites. None of the 9 existing `update_metric_value` callers pass `labels=`, so `metric_value.labels` is `None` and the new branch is skipped:

```
metrics/solana_landing_rate.py:162,163,194
common/base_metric.py:138,161
common/metric_types.py:81,135
common/metrics_handler.py:55
```

The new code path is dead until a future caller starts passing `labels=`.

## Test plan
- [x] `uvx black .` / `uvx ruff check .` clean
- [x] `uvx mypy .` no new errors (full-repo count unchanged from master baseline at 238)
- [x] Smoke test covers four cases:
  - No labels → byte-identical output
  - Labels on one value_type → appended to that line, other lines untouched
  - Instance-key collision (`blockchain=Hijack`) → dropped, instance value wins
  - Reserved `metric_type=fake` collision → dropped
  - Empty dict (`labels={}`) → no-op, identical to no-labels
- [x] Local cron run on a single chain (not run — needs `endpoints.json` + Grafana credentials; defers to v1 PR which actually exercises the new path)

## Followup
This unblocks v1 (verified-correctness for `eth_getBalance`). v1 will be the first caller to pass `labels=` (specifically `{"block_number": "0x..."}` on the `balance_observed` value_type).

🤖 Generated with [Claude Code](https://claude.com/claude-code)