### PR TITLE
feat(dashboards): add Data agreement section to EVM v1 chains

### DIFF
--- a/dashboards/dashboards/compare-dashboard-arbitrum-eu.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum-eu.json
@@ -965,7 +965,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 18,
             "x": 0,
             "y": 30
@@ -1145,7 +1145,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 6,
             "x": 18,
             "y": 30
@@ -1232,12 +1232,326 @@
       "type": "row"
     },
     {
+      "id": 1300,
+      "type": "row",
+      "title": "Data agreement",
+      "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "panels": [
+        {
+          "id": 1301,
+          "type": "state-timeline",
+          "title": "Provider agreement",
+          "description": "Per provider in this region (EU), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"fra1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"fra1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"fra1\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 1302,
+          "type": "table",
+          "title": "Agreement summary",
+          "description": "For each provider in this region (EU), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "displayName": "Agreed %",
+                "desc": true
+              }
+            ],
+            "footer": {
+              "show": false,
+              "reducer": [
+                "sum"
+              ],
+              "countRows": false,
+              "fields": ""
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "Chainstack": {
+                            "text": "Chainstack-Growth",
+                            "index": 0
+                          },
+                          "dRPC": {
+                            "text": "dRPC-Growth",
+                            "index": 1
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"fra1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"fra1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"fra1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"fra1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "provider": 0,
+                  "Value": 1
+                },
+                "renameByName": {
+                  "provider": "Provider",
+                  "Value": "Agreed %"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 43
       },
       "id": 1008,
       "panels": [
@@ -3471,7 +3785,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 44
       },
       "id": 1009,
       "panels": [
@@ -4648,7 +4962,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 45
       },
       "id": 1010,
       "panels": [
@@ -5825,7 +6139,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 46
       },
       "id": 1011,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-arbitrum-japan.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum-japan.json
@@ -951,7 +951,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 18,
             "x": 0,
             "y": 30
@@ -1131,7 +1131,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 6,
             "x": 18,
             "y": 30
@@ -1218,12 +1218,326 @@
       "type": "row"
     },
     {
+      "id": 1300,
+      "type": "row",
+      "title": "Data agreement",
+      "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "panels": [
+        {
+          "id": 1301,
+          "type": "state-timeline",
+          "title": "Provider agreement",
+          "description": "Per provider in this region (JP), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"hnd1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"hnd1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"hnd1\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 1302,
+          "type": "table",
+          "title": "Agreement summary",
+          "description": "For each provider in this region (JP), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "displayName": "Agreed %",
+                "desc": true
+              }
+            ],
+            "footer": {
+              "show": false,
+              "reducer": [
+                "sum"
+              ],
+              "countRows": false,
+              "fields": ""
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "Chainstack": {
+                            "text": "Chainstack-Growth",
+                            "index": 0
+                          },
+                          "dRPC": {
+                            "text": "dRPC-Growth",
+                            "index": 1
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"hnd1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"hnd1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"hnd1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"hnd1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "provider": 0,
+                  "Value": 1
+                },
+                "renameByName": {
+                  "provider": "Provider",
+                  "Value": "Agreed %"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 43
       },
       "id": 7,
       "panels": [
@@ -3465,7 +3779,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 44
       },
       "id": 23,
       "panels": [
@@ -4647,7 +4961,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 45
       },
       "id": 999,
       "panels": [
@@ -5829,7 +6143,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 46
       },
       "id": 32,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-arbitrum-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum-us-west.json
@@ -949,7 +949,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 18,
             "x": 0,
             "y": 30
@@ -1129,7 +1129,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 6,
             "x": 18,
             "y": 30
@@ -1216,12 +1216,326 @@
       "type": "row"
     },
     {
+      "id": 1300,
+      "type": "row",
+      "title": "Data agreement",
+      "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "panels": [
+        {
+          "id": 1301,
+          "type": "state-timeline",
+          "title": "Provider agreement",
+          "description": "Per provider in this region (US West), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"sfo1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"sfo1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"sfo1\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 1302,
+          "type": "table",
+          "title": "Agreement summary",
+          "description": "For each provider in this region (US West), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "displayName": "Agreed %",
+                "desc": true
+              }
+            ],
+            "footer": {
+              "show": false,
+              "reducer": [
+                "sum"
+              ],
+              "countRows": false,
+              "fields": ""
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "Chainstack": {
+                            "text": "Chainstack-Growth",
+                            "index": 0
+                          },
+                          "dRPC": {
+                            "text": "dRPC-Growth",
+                            "index": 1
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"sfo1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"sfo1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"sfo1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"sfo1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "provider": 0,
+                  "Value": 1
+                },
+                "renameByName": {
+                  "provider": "Provider",
+                  "Value": "Agreed %"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 43
       },
       "id": 7,
       "panels": [
@@ -3463,7 +3777,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 44
       },
       "id": 23,
       "panels": [
@@ -4645,7 +4959,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 45
       },
       "id": 999,
       "panels": [
@@ -5827,7 +6141,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 46
       },
       "id": 32,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-arbitrum.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum.json
@@ -1475,7 +1475,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 18,
             "x": 0,
             "y": 36
@@ -1655,7 +1655,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 6,
             "x": 18,
             "y": 36
@@ -1742,12 +1742,362 @@
       "type": "row"
     },
     {
+      "id": 300,
+      "type": "row",
+      "title": "Data agreement",
       "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 35
+      },
+      "panels": [
+        {
+          "id": 301,
+          "type": "state-timeline",
+          "title": "Provider agreement",
+          "description": "Per provider, did this provider's answer match the majority answer in every region it participated in at this moment. Green - matched the majority everywhere. Red - was an outlier in at least one region. Grey - no data captured.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 37
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\"}\n    )\n    *\n    on(source_region, block_number, value) group_left()\n    count by (source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\"}\n    )\n  )\n  ==\n  bool on(source_region, block_number) group_left()\n  max by (source_region, block_number) (\n    count by (source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 302,
+          "type": "table",
+          "title": "Agreement summary",
+          "description": "For each provider in each region, the percentage of samples this provider returned that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 37
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "displayName": "Agreed %",
+                "desc": true
+              }
+            ],
+            "footer": {
+              "show": false,
+              "reducer": [
+                "sum"
+              ],
+              "countRows": false,
+              "fields": ""
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "Chainstack": {
+                            "text": "Chainstack-Growth",
+                            "index": 0
+                          },
+                          "dRPC": {
+                            "text": "dRPC-Growth",
+                            "index": 1
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Region"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 70
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "fra1": {
+                            "text": "EU",
+                            "index": 0
+                          },
+                          "hnd1": {
+                            "text": "JP",
+                            "index": 1
+                          },
+                          "sfo1": {
+                            "text": "US West",
+                            "index": 2
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider, source_region) (\n  max_over_time(\n    (\n      (\n        group by (provider, source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\"}\n        )\n        *\n        on(source_region, block_number, value) group_left()\n        count by (source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\"}\n        )\n      )\n      ==\n      bool on(source_region, block_number) group_left()\n      max by (source_region, block_number) (\n        count by (source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider, source_region) (\n  max_over_time(\n    (\n      group by (provider, source_region, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "provider": 0,
+                  "source_region": 1,
+                  "Value": 2
+                },
+                "renameByName": {
+                  "provider": "Provider",
+                  "source_region": "Region",
+                  "Value": "Agreed %"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 36
       },
       "id": 99,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-base-eu.json
+++ b/dashboards/dashboards/compare-dashboard-base-eu.json
@@ -949,7 +949,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 18,
             "x": 0,
             "y": 30
@@ -1129,7 +1129,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 6,
             "x": 18,
             "y": 30
@@ -1216,12 +1216,326 @@
       "type": "row"
     },
     {
+      "id": 1300,
+      "type": "row",
+      "title": "Data agreement",
+      "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "panels": [
+        {
+          "id": 1301,
+          "type": "state-timeline",
+          "title": "Provider agreement",
+          "description": "Per provider in this region (EU), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"fra1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"fra1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"fra1\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 1302,
+          "type": "table",
+          "title": "Agreement summary",
+          "description": "For each provider in this region (EU), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "displayName": "Agreed %",
+                "desc": true
+              }
+            ],
+            "footer": {
+              "show": false,
+              "reducer": [
+                "sum"
+              ],
+              "countRows": false,
+              "fields": ""
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "Chainstack": {
+                            "text": "Chainstack-Growth",
+                            "index": 0
+                          },
+                          "dRPC": {
+                            "text": "dRPC-Growth",
+                            "index": 1
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"fra1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"fra1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"fra1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"fra1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "provider": 0,
+                  "Value": 1
+                },
+                "renameByName": {
+                  "provider": "Provider",
+                  "Value": "Agreed %"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 43
       },
       "id": 7,
       "panels": [
@@ -3455,7 +3769,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 44
       },
       "id": 23,
       "panels": [
@@ -4637,7 +4951,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 45
       },
       "id": 999,
       "panels": [
@@ -5819,7 +6133,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 46
       },
       "id": 32,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-base-japan.json
+++ b/dashboards/dashboards/compare-dashboard-base-japan.json
@@ -948,7 +948,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 18,
             "x": 0,
             "y": 30
@@ -1128,7 +1128,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 6,
             "x": 18,
             "y": 30
@@ -1215,12 +1215,326 @@
       "type": "row"
     },
     {
+      "id": 1300,
+      "type": "row",
+      "title": "Data agreement",
+      "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "panels": [
+        {
+          "id": 1301,
+          "type": "state-timeline",
+          "title": "Provider agreement",
+          "description": "Per provider in this region (JP), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"hnd1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"hnd1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"hnd1\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 1302,
+          "type": "table",
+          "title": "Agreement summary",
+          "description": "For each provider in this region (JP), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "displayName": "Agreed %",
+                "desc": true
+              }
+            ],
+            "footer": {
+              "show": false,
+              "reducer": [
+                "sum"
+              ],
+              "countRows": false,
+              "fields": ""
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "Chainstack": {
+                            "text": "Chainstack-Growth",
+                            "index": 0
+                          },
+                          "dRPC": {
+                            "text": "dRPC-Growth",
+                            "index": 1
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"hnd1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"hnd1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"hnd1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"hnd1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "provider": 0,
+                  "Value": 1
+                },
+                "renameByName": {
+                  "provider": "Provider",
+                  "Value": "Agreed %"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 43
       },
       "id": 7,
       "panels": [
@@ -3454,7 +3768,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 44
       },
       "id": 23,
       "panels": [
@@ -4638,7 +4952,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 45
       },
       "id": 999,
       "panels": [
@@ -5822,7 +6136,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 46
       },
       "id": 32,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-base-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-base-us-west.json
@@ -948,7 +948,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 18,
             "x": 0,
             "y": 30
@@ -1128,7 +1128,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 6,
             "x": 18,
             "y": 30
@@ -1215,12 +1215,326 @@
       "type": "row"
     },
     {
+      "id": 1300,
+      "type": "row",
+      "title": "Data agreement",
+      "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "panels": [
+        {
+          "id": 1301,
+          "type": "state-timeline",
+          "title": "Provider agreement",
+          "description": "Per provider in this region (US West), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"sfo1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"sfo1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"sfo1\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 1302,
+          "type": "table",
+          "title": "Agreement summary",
+          "description": "For each provider in this region (US West), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "displayName": "Agreed %",
+                "desc": true
+              }
+            ],
+            "footer": {
+              "show": false,
+              "reducer": [
+                "sum"
+              ],
+              "countRows": false,
+              "fields": ""
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "Chainstack": {
+                            "text": "Chainstack-Growth",
+                            "index": 0
+                          },
+                          "dRPC": {
+                            "text": "dRPC-Growth",
+                            "index": 1
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"sfo1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"sfo1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"sfo1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"sfo1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "provider": 0,
+                  "Value": 1
+                },
+                "renameByName": {
+                  "provider": "Provider",
+                  "Value": "Agreed %"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 43
       },
       "id": 7,
       "panels": [
@@ -3454,7 +3768,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 44
       },
       "id": 23,
       "panels": [
@@ -4636,7 +4950,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 45
       },
       "id": 999,
       "panels": [
@@ -5818,7 +6132,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 46
       },
       "id": 32,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-base.json
+++ b/dashboards/dashboards/compare-dashboard-base.json
@@ -1463,7 +1463,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 18,
             "x": 0,
             "y": 36
@@ -1643,7 +1643,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 6,
             "x": 18,
             "y": 36
@@ -1730,12 +1730,362 @@
       "type": "row"
     },
     {
+      "id": 300,
+      "type": "row",
+      "title": "Data agreement",
       "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 34
+      },
+      "panels": [
+        {
+          "id": 301,
+          "type": "state-timeline",
+          "title": "Provider agreement",
+          "description": "Per provider, did this provider's answer match the majority answer in every region it participated in at this moment. Green - matched the majority everywhere. Red - was an outlier in at least one region. Grey - no data captured.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 36
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\"}\n    )\n    *\n    on(source_region, block_number, value) group_left()\n    count by (source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\"}\n    )\n  )\n  ==\n  bool on(source_region, block_number) group_left()\n  max by (source_region, block_number) (\n    count by (source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 302,
+          "type": "table",
+          "title": "Agreement summary",
+          "description": "For each provider in each region, the percentage of samples this provider returned that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 36
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "displayName": "Agreed %",
+                "desc": true
+              }
+            ],
+            "footer": {
+              "show": false,
+              "reducer": [
+                "sum"
+              ],
+              "countRows": false,
+              "fields": ""
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "Chainstack": {
+                            "text": "Chainstack-Growth",
+                            "index": 0
+                          },
+                          "dRPC": {
+                            "text": "dRPC-Growth",
+                            "index": 1
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Region"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 70
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "fra1": {
+                            "text": "EU",
+                            "index": 0
+                          },
+                          "hnd1": {
+                            "text": "JP",
+                            "index": 1
+                          },
+                          "sfo1": {
+                            "text": "US West",
+                            "index": 2
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider, source_region) (\n  max_over_time(\n    (\n      (\n        group by (provider, source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\"}\n        )\n        *\n        on(source_region, block_number, value) group_left()\n        count by (source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\"}\n        )\n      )\n      ==\n      bool on(source_region, block_number) group_left()\n      max by (source_region, block_number) (\n        count by (source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider, source_region) (\n  max_over_time(\n    (\n      group by (provider, source_region, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "provider": 0,
+                  "source_region": 1,
+                  "Value": 2
+                },
+                "renameByName": {
+                  "provider": "Provider",
+                  "source_region": "Region",
+                  "Value": "Agreed %"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 35
       },
       "id": 89,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain-eu.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain-eu.json
@@ -947,7 +947,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 18,
             "x": 0,
             "y": 30
@@ -1127,7 +1127,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 6,
             "x": 18,
             "y": 30
@@ -1214,12 +1214,326 @@
       "type": "row"
     },
     {
+      "id": 1300,
+      "type": "row",
+      "title": "Data agreement",
+      "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "panels": [
+        {
+          "id": 1301,
+          "type": "state-timeline",
+          "title": "Provider agreement",
+          "description": "Per provider in this region (EU), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"fra1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"fra1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"fra1\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 1302,
+          "type": "table",
+          "title": "Agreement summary",
+          "description": "For each provider in this region (EU), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "displayName": "Agreed %",
+                "desc": true
+              }
+            ],
+            "footer": {
+              "show": false,
+              "reducer": [
+                "sum"
+              ],
+              "countRows": false,
+              "fields": ""
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "Chainstack": {
+                            "text": "Chainstack-Growth",
+                            "index": 0
+                          },
+                          "dRPC": {
+                            "text": "dRPC-Growth",
+                            "index": 1
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"fra1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"fra1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"fra1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"fra1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "provider": 0,
+                  "Value": 1
+                },
+                "renameByName": {
+                  "provider": "Provider",
+                  "Value": "Agreed %"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 43
       },
       "id": 7,
       "panels": [
@@ -3450,7 +3764,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 44
       },
       "id": 23,
       "panels": [
@@ -4632,7 +4946,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 45
       },
       "id": 999,
       "panels": [
@@ -5814,7 +6128,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 46
       },
       "id": 32,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain-singapore.json
@@ -947,7 +947,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 18,
             "x": 0,
             "y": 30
@@ -1127,7 +1127,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 6,
             "x": 18,
             "y": 30
@@ -1214,12 +1214,326 @@
       "type": "row"
     },
     {
+      "id": 1300,
+      "type": "row",
+      "title": "Data agreement",
+      "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "panels": [
+        {
+          "id": 1301,
+          "type": "state-timeline",
+          "title": "Provider agreement",
+          "description": "Per provider in this region (SG), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"sin1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"sin1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"sin1\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 1302,
+          "type": "table",
+          "title": "Agreement summary",
+          "description": "For each provider in this region (SG), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "displayName": "Agreed %",
+                "desc": true
+              }
+            ],
+            "footer": {
+              "show": false,
+              "reducer": [
+                "sum"
+              ],
+              "countRows": false,
+              "fields": ""
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "Chainstack": {
+                            "text": "Chainstack-Growth",
+                            "index": 0
+                          },
+                          "dRPC": {
+                            "text": "dRPC-Growth",
+                            "index": 1
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"sin1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"sin1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"sin1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"sin1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "provider": 0,
+                  "Value": 1
+                },
+                "renameByName": {
+                  "provider": "Provider",
+                  "Value": "Agreed %"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 43
       },
       "id": 7,
       "panels": [
@@ -3449,7 +3763,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 44
       },
       "id": 23,
       "panels": [
@@ -4631,7 +4945,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 45
       },
       "id": 999,
       "panels": [
@@ -5813,7 +6127,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 46
       },
       "id": 32,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain-us-west.json
@@ -947,7 +947,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 18,
             "x": 0,
             "y": 30
@@ -1127,7 +1127,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 6,
             "x": 18,
             "y": 30
@@ -1214,12 +1214,326 @@
       "type": "row"
     },
     {
+      "id": 1300,
+      "type": "row",
+      "title": "Data agreement",
+      "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "panels": [
+        {
+          "id": 1301,
+          "type": "state-timeline",
+          "title": "Provider agreement",
+          "description": "Per provider in this region (US West), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"sfo1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"sfo1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"sfo1\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 1302,
+          "type": "table",
+          "title": "Agreement summary",
+          "description": "For each provider in this region (US West), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "displayName": "Agreed %",
+                "desc": true
+              }
+            ],
+            "footer": {
+              "show": false,
+              "reducer": [
+                "sum"
+              ],
+              "countRows": false,
+              "fields": ""
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "Chainstack": {
+                            "text": "Chainstack-Growth",
+                            "index": 0
+                          },
+                          "dRPC": {
+                            "text": "dRPC-Growth",
+                            "index": 1
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"sfo1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"sfo1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"sfo1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"sfo1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "provider": 0,
+                  "Value": 1
+                },
+                "renameByName": {
+                  "provider": "Provider",
+                  "Value": "Agreed %"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 43
       },
       "id": 7,
       "panels": [
@@ -3453,7 +3767,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 44
       },
       "id": 23,
       "panels": [
@@ -4635,7 +4949,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 45
       },
       "id": 999,
       "panels": [
@@ -5817,7 +6131,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 46
       },
       "id": 32,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain.json
@@ -1451,7 +1451,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 18,
             "x": 0,
             "y": 36
@@ -1631,7 +1631,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 6,
             "x": 18,
             "y": 36
@@ -1718,12 +1718,362 @@
       "type": "row"
     },
     {
+      "id": 300,
+      "type": "row",
+      "title": "Data agreement",
       "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 34
+      },
+      "panels": [
+        {
+          "id": 301,
+          "type": "state-timeline",
+          "title": "Provider agreement",
+          "description": "Per provider, did this provider's answer match the majority answer in every region it participated in at this moment. Green - matched the majority everywhere. Red - was an outlier in at least one region. Grey - no data captured.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 36
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\"}\n    )\n    *\n    on(source_region, block_number, value) group_left()\n    count by (source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\"}\n    )\n  )\n  ==\n  bool on(source_region, block_number) group_left()\n  max by (source_region, block_number) (\n    count by (source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 302,
+          "type": "table",
+          "title": "Agreement summary",
+          "description": "For each provider in each region, the percentage of samples this provider returned that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 36
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "displayName": "Agreed %",
+                "desc": true
+              }
+            ],
+            "footer": {
+              "show": false,
+              "reducer": [
+                "sum"
+              ],
+              "countRows": false,
+              "fields": ""
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "Chainstack": {
+                            "text": "Chainstack-Growth",
+                            "index": 0
+                          },
+                          "dRPC": {
+                            "text": "dRPC-Growth",
+                            "index": 1
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Region"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 70
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "fra1": {
+                            "text": "EU",
+                            "index": 0
+                          },
+                          "sin1": {
+                            "text": "SG",
+                            "index": 1
+                          },
+                          "sfo1": {
+                            "text": "US West",
+                            "index": 2
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider, source_region) (\n  max_over_time(\n    (\n      (\n        group by (provider, source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\"}\n        )\n        *\n        on(source_region, block_number, value) group_left()\n        count by (source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\"}\n        )\n      )\n      ==\n      bool on(source_region, block_number) group_left()\n      max by (source_region, block_number) (\n        count by (source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider, source_region) (\n  max_over_time(\n    (\n      group by (provider, source_region, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "provider": 0,
+                  "source_region": 1,
+                  "Value": 2
+                },
+                "renameByName": {
+                  "provider": "Provider",
+                  "source_region": "Region",
+                  "Value": "Agreed %"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 35
       },
       "id": 99,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-ethereum-eu.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum-eu.json
@@ -874,7 +874,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 18,
             "x": 0,
             "y": 30
@@ -1054,7 +1054,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 6,
             "x": 18,
             "y": 30
@@ -1141,12 +1141,326 @@
       "type": "row"
     },
     {
+      "id": 1300,
+      "type": "row",
+      "title": "Data agreement",
+      "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "panels": [
+        {
+          "id": 1301,
+          "type": "state-timeline",
+          "title": "Provider agreement",
+          "description": "Per provider in this region (EU), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"fra1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"fra1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"fra1\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 1302,
+          "type": "table",
+          "title": "Agreement summary",
+          "description": "For each provider in this region (EU), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "displayName": "Agreed %",
+                "desc": true
+              }
+            ],
+            "footer": {
+              "show": false,
+              "reducer": [
+                "sum"
+              ],
+              "countRows": false,
+              "fields": ""
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "Chainstack": {
+                            "text": "Chainstack-Growth",
+                            "index": 0
+                          },
+                          "dRPC": {
+                            "text": "dRPC-Growth",
+                            "index": 1
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"fra1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"fra1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"fra1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"fra1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "provider": 0,
+                  "Value": 1
+                },
+                "renameByName": {
+                  "provider": "Provider",
+                  "Value": "Agreed %"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 43
       },
       "id": 7,
       "panels": [
@@ -3377,7 +3691,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 44
       },
       "id": 23,
       "panels": [
@@ -4559,7 +4873,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 45
       },
       "id": 999,
       "panels": [
@@ -5741,7 +6055,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 46
       },
       "id": 32,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-ethereum-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum-singapore.json
@@ -948,7 +948,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 18,
             "x": 0,
             "y": 30
@@ -1128,7 +1128,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 6,
             "x": 18,
             "y": 30
@@ -1215,12 +1215,326 @@
       "type": "row"
     },
     {
+      "id": 1300,
+      "type": "row",
+      "title": "Data agreement",
+      "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "panels": [
+        {
+          "id": 1301,
+          "type": "state-timeline",
+          "title": "Provider agreement",
+          "description": "Per provider in this region (SG), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"sin1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"sin1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"sin1\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 1302,
+          "type": "table",
+          "title": "Agreement summary",
+          "description": "For each provider in this region (SG), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "displayName": "Agreed %",
+                "desc": true
+              }
+            ],
+            "footer": {
+              "show": false,
+              "reducer": [
+                "sum"
+              ],
+              "countRows": false,
+              "fields": ""
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "Chainstack": {
+                            "text": "Chainstack-Growth",
+                            "index": 0
+                          },
+                          "dRPC": {
+                            "text": "dRPC-Growth",
+                            "index": 1
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"sin1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"sin1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"sin1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"sin1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "provider": 0,
+                  "Value": 1
+                },
+                "renameByName": {
+                  "provider": "Provider",
+                  "Value": "Agreed %"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 43
       },
       "id": 7,
       "panels": [
@@ -3450,7 +3764,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 44
       },
       "id": 23,
       "panels": [
@@ -4632,7 +4946,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 45
       },
       "id": 999,
       "panels": [
@@ -5814,7 +6128,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 46
       },
       "id": 32,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-ethereum-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum-us-west.json
@@ -948,7 +948,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 18,
             "x": 0,
             "y": 30
@@ -1128,7 +1128,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 6,
             "x": 18,
             "y": 30
@@ -1215,12 +1215,326 @@
       "type": "row"
     },
     {
+      "id": 1300,
+      "type": "row",
+      "title": "Data agreement",
+      "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "panels": [
+        {
+          "id": 1301,
+          "type": "state-timeline",
+          "title": "Provider agreement",
+          "description": "Per provider in this region (US West), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"sfo1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"sfo1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"sfo1\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 1302,
+          "type": "table",
+          "title": "Agreement summary",
+          "description": "For each provider in this region (US West), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "displayName": "Agreed %",
+                "desc": true
+              }
+            ],
+            "footer": {
+              "show": false,
+              "reducer": [
+                "sum"
+              ],
+              "countRows": false,
+              "fields": ""
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "Chainstack": {
+                            "text": "Chainstack-Growth",
+                            "index": 0
+                          },
+                          "dRPC": {
+                            "text": "dRPC-Growth",
+                            "index": 1
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"sfo1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"sfo1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"sfo1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"sfo1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "provider": 0,
+                  "Value": 1
+                },
+                "renameByName": {
+                  "provider": "Provider",
+                  "Value": "Agreed %"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 43
       },
       "id": 7,
       "panels": [
@@ -3450,7 +3764,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 44
       },
       "id": 23,
       "panels": [
@@ -4632,7 +4946,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 45
       },
       "id": 999,
       "panels": [
@@ -5814,7 +6128,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 46
       },
       "id": 32,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-ethereum.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum.json
@@ -1429,7 +1429,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 18,
             "x": 0,
             "y": 36
@@ -1609,7 +1609,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 6,
             "x": 18,
             "y": 36
@@ -1696,12 +1696,362 @@
       "type": "row"
     },
     {
+      "id": 300,
+      "type": "row",
+      "title": "Data agreement",
       "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 35
+      },
+      "panels": [
+        {
+          "id": 301,
+          "type": "state-timeline",
+          "title": "Provider agreement",
+          "description": "Per provider, did this provider's answer match the majority answer in every region it participated in at this moment. Green - matched the majority everywhere. Red - was an outlier in at least one region. Grey - no data captured.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 37
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\"}\n    )\n    *\n    on(source_region, block_number, value) group_left()\n    count by (source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\"}\n    )\n  )\n  ==\n  bool on(source_region, block_number) group_left()\n  max by (source_region, block_number) (\n    count by (source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 302,
+          "type": "table",
+          "title": "Agreement summary",
+          "description": "For each provider in each region, the percentage of samples this provider returned that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 37
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "displayName": "Agreed %",
+                "desc": true
+              }
+            ],
+            "footer": {
+              "show": false,
+              "reducer": [
+                "sum"
+              ],
+              "countRows": false,
+              "fields": ""
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "Chainstack": {
+                            "text": "Chainstack-Growth",
+                            "index": 0
+                          },
+                          "dRPC": {
+                            "text": "dRPC-Growth",
+                            "index": 1
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Region"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 70
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "fra1": {
+                            "text": "EU",
+                            "index": 0
+                          },
+                          "sin1": {
+                            "text": "SG",
+                            "index": 1
+                          },
+                          "sfo1": {
+                            "text": "US West",
+                            "index": 2
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider, source_region) (\n  max_over_time(\n    (\n      (\n        group by (provider, source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\"}\n        )\n        *\n        on(source_region, block_number, value) group_left()\n        count by (source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\"}\n        )\n      )\n      ==\n      bool on(source_region, block_number) group_left()\n      max by (source_region, block_number) (\n        count by (source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider, source_region) (\n  max_over_time(\n    (\n      group by (provider, source_region, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "provider": 0,
+                  "source_region": 1,
+                  "Value": 2
+                },
+                "renameByName": {
+                  "provider": "Provider",
+                  "source_region": "Region",
+                  "Value": "Agreed %"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 36
       },
       "id": 100,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-monad-eu.json
+++ b/dashboards/dashboards/compare-dashboard-monad-eu.json
@@ -952,7 +952,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 18,
             "x": 0,
             "y": 30
@@ -1132,7 +1132,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 6,
             "x": 18,
             "y": 30
@@ -1219,12 +1219,326 @@
       "type": "row"
     },
     {
+      "id": 1300,
+      "type": "row",
+      "title": "Data agreement",
+      "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "panels": [
+        {
+          "id": 1301,
+          "type": "state-timeline",
+          "title": "Provider agreement",
+          "description": "Per provider in this region (EU), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Monad\", source_region=\"fra1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Monad\", source_region=\"fra1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Monad\", source_region=\"fra1\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 1302,
+          "type": "table",
+          "title": "Agreement summary",
+          "description": "For each provider in this region (EU), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "displayName": "Agreed %",
+                "desc": true
+              }
+            ],
+            "footer": {
+              "show": false,
+              "reducer": [
+                "sum"
+              ],
+              "countRows": false,
+              "fields": ""
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "Chainstack": {
+                            "text": "Chainstack-Growth",
+                            "index": 0
+                          },
+                          "dRPC": {
+                            "text": "dRPC-Growth",
+                            "index": 1
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Monad\", source_region=\"fra1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Monad\", source_region=\"fra1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Monad\", source_region=\"fra1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Monad\", source_region=\"fra1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "provider": 0,
+                  "Value": 1
+                },
+                "renameByName": {
+                  "provider": "Provider",
+                  "Value": "Agreed %"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 43
       },
       "id": 7,
       "panels": [
@@ -3466,7 +3780,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 44
       },
       "id": 23,
       "panels": [
@@ -4656,7 +4970,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 45
       },
       "id": 999,
       "panels": [
@@ -5846,7 +6160,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 46
       },
       "id": 32,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-monad-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-monad-singapore.json
@@ -951,7 +951,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 18,
             "x": 0,
             "y": 30
@@ -1131,7 +1131,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 6,
             "x": 18,
             "y": 30
@@ -1218,12 +1218,326 @@
       "type": "row"
     },
     {
+      "id": 1300,
+      "type": "row",
+      "title": "Data agreement",
+      "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "panels": [
+        {
+          "id": 1301,
+          "type": "state-timeline",
+          "title": "Provider agreement",
+          "description": "Per provider in this region (SG), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Monad\", source_region=\"sin1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Monad\", source_region=\"sin1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Monad\", source_region=\"sin1\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 1302,
+          "type": "table",
+          "title": "Agreement summary",
+          "description": "For each provider in this region (SG), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "displayName": "Agreed %",
+                "desc": true
+              }
+            ],
+            "footer": {
+              "show": false,
+              "reducer": [
+                "sum"
+              ],
+              "countRows": false,
+              "fields": ""
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "Chainstack": {
+                            "text": "Chainstack-Growth",
+                            "index": 0
+                          },
+                          "dRPC": {
+                            "text": "dRPC-Growth",
+                            "index": 1
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Monad\", source_region=\"sin1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Monad\", source_region=\"sin1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Monad\", source_region=\"sin1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Monad\", source_region=\"sin1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "provider": 0,
+                  "Value": 1
+                },
+                "renameByName": {
+                  "provider": "Provider",
+                  "Value": "Agreed %"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 43
       },
       "id": 7,
       "panels": [
@@ -3465,7 +3779,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 44
       },
       "id": 23,
       "panels": [
@@ -4647,7 +4961,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 45
       },
       "id": 999,
       "panels": [
@@ -5829,7 +6143,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 46
       },
       "id": 32,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-monad-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-monad-us-west.json
@@ -949,7 +949,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 18,
             "x": 0,
             "y": 30
@@ -1129,7 +1129,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 6,
             "x": 18,
             "y": 30
@@ -1216,12 +1216,326 @@
       "type": "row"
     },
     {
+      "id": 1300,
+      "type": "row",
+      "title": "Data agreement",
+      "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "panels": [
+        {
+          "id": 1301,
+          "type": "state-timeline",
+          "title": "Provider agreement",
+          "description": "Per provider in this region (US West), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Monad\", source_region=\"sfo1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Monad\", source_region=\"sfo1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Monad\", source_region=\"sfo1\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 1302,
+          "type": "table",
+          "title": "Agreement summary",
+          "description": "For each provider in this region (US West), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "displayName": "Agreed %",
+                "desc": true
+              }
+            ],
+            "footer": {
+              "show": false,
+              "reducer": [
+                "sum"
+              ],
+              "countRows": false,
+              "fields": ""
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "Chainstack": {
+                            "text": "Chainstack-Growth",
+                            "index": 0
+                          },
+                          "dRPC": {
+                            "text": "dRPC-Growth",
+                            "index": 1
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Monad\", source_region=\"sfo1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Monad\", source_region=\"sfo1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Monad\", source_region=\"sfo1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Monad\", source_region=\"sfo1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "provider": 0,
+                  "Value": 1
+                },
+                "renameByName": {
+                  "provider": "Provider",
+                  "Value": "Agreed %"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
       "collapsed": true,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 43
       },
       "id": 7,
       "panels": [
@@ -3463,7 +3777,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 44
       },
       "id": 23,
       "panels": [
@@ -4645,7 +4959,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 45
       },
       "id": 999,
       "panels": [
@@ -5827,7 +6141,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 46
       },
       "id": 32,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-monad.json
+++ b/dashboards/dashboards/compare-dashboard-monad.json
@@ -1495,7 +1495,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 18,
             "x": 0,
             "y": 36
@@ -1675,7 +1675,7 @@
             ]
           },
           "gridPos": {
-            "h": 14,
+            "h": 8,
             "w": 6,
             "x": 18,
             "y": 36
@@ -1762,12 +1762,362 @@
       "type": "row"
     },
     {
+      "id": 300,
+      "type": "row",
+      "title": "Data agreement",
       "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 36
+      },
+      "panels": [
+        {
+          "id": 301,
+          "type": "state-timeline",
+          "title": "Provider agreement",
+          "description": "Per provider, did this provider's answer match the majority answer in every region it participated in at this moment. Green - matched the majority everywhere. Red - was an outlier in at least one region. Grey - no data captured.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 38
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "type": "special",
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  }
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Monad\"}\n    )\n    *\n    on(source_region, block_number, value) group_left()\n    count by (source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Monad\"}\n    )\n  )\n  ==\n  bool on(source_region, block_number) group_left()\n  max by (source_region, block_number) (\n    count by (source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Monad\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ]
+        },
+        {
+          "id": 302,
+          "type": "table",
+          "title": "Agreement summary",
+          "description": "For each provider in each region, the percentage of samples this provider returned that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 38
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "options": {
+            "cellHeight": "sm",
+            "showHeader": true,
+            "sortBy": [
+              {
+                "displayName": "Agreed %",
+                "desc": true
+              }
+            ],
+            "footer": {
+              "show": false,
+              "reducer": [
+                "sum"
+              ],
+              "countRows": false,
+              "fields": ""
+            }
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "Chainstack": {
+                            "text": "Chainstack-Growth",
+                            "index": 0
+                          },
+                          "dRPC": {
+                            "text": "dRPC-Growth",
+                            "index": 1
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Region"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 70
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "type": "value",
+                        "options": {
+                          "fra1": {
+                            "text": "EU",
+                            "index": 0
+                          },
+                          "sin1": {
+                            "text": "SG",
+                            "index": 1
+                          },
+                          "sfo1": {
+                            "text": "US West",
+                            "index": 2
+                          }
+                        }
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider, source_region) (\n  max_over_time(\n    (\n      (\n        group by (provider, source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Monad\"}\n        )\n        *\n        on(source_region, block_number, value) group_left()\n        count by (source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Monad\"}\n        )\n      )\n      ==\n      bool on(source_region, block_number) group_left()\n      max by (source_region, block_number) (\n        count by (source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Monad\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider, source_region) (\n  max_over_time(\n    (\n      group by (provider, source_region, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Monad\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "provider": 0,
+                  "source_region": 1,
+                  "Value": 2
+                },
+                "renameByName": {
+                  "provider": "Provider",
+                  "source_region": "Region",
+                  "Value": "Agreed %"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 37
       },
       "id": 99,
       "panels": [


### PR DESCRIPTION
## Summary
New "Data agreement" collapsed row between Block lag and Historical data on the global + regional dashboards for the 5 EVM chains that emit `balance_observed`: **Ethereum, Base, Arbitrum, BNB Smart Chain, Monad** (20 dashboards total).

Hyperliquid is intentionally excluded — that chain only supports `latest` for `eth_getBalance` and does not emit `balance_observed`.

## Panels
**Panel 1 — Provider agreement** (state-timeline, `h=8 w=18`)
- One row per provider.
- Cell at moment t = green if this provider's value matched the majority answer in every active (region, block) bucket; red if outlier in at least one region; grey if no data.
- `showValue: never`, matching the Block lag timeline style.

**Panel 2 — Agreement summary** (table, `h=8 w=6`)
- Per (Provider × Region) for global; per Provider for regional.
- `Agreed %` = fraction of (block, value) tuples this provider had that were ever the majority value during the panel time range.
- Sort descending; thresholds red <95%, yellow 95–99%, green ≥99%.

**Block lag panels resized** `h=14 → h=8` on every touched dashboard to keep the layout uniform.

## Forward-compatible with v2
The "majority answer" is v1's stand-in for an independent check — whichever value the most providers reported in a (region, block) bucket. When v2's `stateRoot`-anchor verifier ships and emits `balance_verified`, the right-hand side of the modal `==` in each query swaps to that series. **Layout, descriptions, thresholds, transformations all stay.**

v1's known limitation: 2-2 splits show as "agreement" (tied modal counts) and won't surface until v2 has authoritative ground truth.

## Per-chain region renames
| Chain | Singapore region | Display |
|---|---|---|
| Ethereum, BNB, Monad | `sin1` | SG |
| Base, Arbitrum | `hnd1` | JP |

Plus the standard `fra1 → EU`, `sfo1 → US West`, and provider renames `Chainstack → Chainstack-Growth`, `dRPC → dRPC-Growth`.

## Safety
The existing-panel audit done as part of the original v1 PR confirmed every dashboard query that touches `response_latency_seconds` filters explicitly by `metric_type=` — the new `metric_type=balance_observed` series cannot leak into any existing aggregation.

## Test plan
- [x] Pulled latest from Grafana before editing (no drift)
- [x] Pushed and reviewed in Grafana Cloud during iteration; current state approved by Anton across global + regionals for Ethereum, then mirrored to the other 4 chains
- [x] Verified row order on each global: Block lag → Data agreement → Historical data
- [x] Verified row order on each regional: Block lag → Data agreement → Historical data → Chainstack-vs-X comparison rows
- [x] Live data: dashboard should populate from existing `balance_observed` ingestion (already flowing for all 5 chains)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added "Data agreement" dashboard section to all comparison dashboards showing provider consensus metrics
  * Displays per-provider agreement percentage against majority consensus with state-timeline visualization for real-time tracking

* **Style**
  * Optimized "Block lag" panel layout to improve dashboard space utilization across all blockchain networks and regional variants

<!-- end of auto-generated comment: release notes by coderabbit.ai -->