### PR TITLE
feat(verifier): self-contained v2.1 — fix proof-window failures, add per-provider observation

### DIFF
--- a/api/support/verify_state.py
+++ b/api/support/verify_state.py
@@ -1,12 +1,21 @@
 """Verifier function: emits balance_verified + verifier_status for EVM chains.
 
-Per cron round (fra1-only, every 15 min, offset 5 min from update_state):
-- Read OLD_BLOCK from shared blob storage (set by update_state).
-- For each chain in [Ethereum, Base, Arbitrum, BNB]:
-  - Multi-provider stateRoot quorum at OLD_BLOCK.
+Per cron round (fra1-only, every 15 min). For each chain in
+[Ethereum, Base, Arbitrum, BNB]:
+  - Compute VERIFY_BLOCK = latest_head - random(VERIFY_BLOCK_OFFSET_RANGES[chain]).
+    Self-contained: no blob coordination with update_state.
+  - Multi-provider stateRoot quorum at VERIFY_BLOCK.
   - eth_getProof from Chainstack for the chain's probe address.
   - Local MPT verification against the agreed stateRoot.
-  - Emit balance_verified (hashed) on success, verifier_status code on any failure.
+  - Probe each provider's eth_getBalance at VERIFY_BLOCK (per-provider
+    balance_observed_verified emission, hashed identically to balance_verified
+    so dashboards can join the two on block_number and compare per-provider
+    reporting against the proof-anchored truth).
+
+The per-chain offsets are sized to fit Chainstack's empirically-measured
+proof-retention window — proofs are MPT trie nodes, pruned ~128 blocks deep
+on geth-family clients, much shallower than the snapshot-served balance
+window. See ``config/defaults.py:VERIFY_BLOCK_OFFSET_RANGES``.
 
 See ``spec-verified-correctness-v2.md`` (local design doc).
 """
@@ -15,33 +24,33 @@ import asyncio
 import hmac
 import logging
 import os
+import random
 import time
 from http.server import BaseHTTPRequestHandler
-from typing import Any
+from typing import Optional
 
 import aiohttp
 
 from common.balance_hash import hash_balance_to_float
-from common.state.blockchain_state import BlockchainState
 from common.verify import (
     AnchorDisagreementError,
     AnchorPartialResponseError,
     ProofError,
-    all_providers_for,
+    all_provider_entries_for,
     chainstack_endpoint_for,
     fetch_account_proof,
     fetch_agreed_anchor,
+    fetch_balance_at,
+    fetch_latest_block,
     verify_account_proof,
 )
 from config.defaults import MetricsServiceConfig
 
 ALLOWED_REGIONS: set[str] = {"fra1"}
 
-# Probe addresses must stay in sync with v1's HTTPAccBalanceLatencyMetric.probe_address
-# per chain so balance_observed (v1) and balance_verified (v2) measure the same
-# account and can be joined by block_number in Grafana. Each is the canonical
-# wrap contract (WETH / WBNB) — high-volume, well-known, balance changes
-# frequently so successive rounds exercise the proof system on different values.
+# Probe addresses: canonical wrap contracts on each chain (WETH / WBNB).
+# Held balances are high and change on every wrap/unwrap, so successive
+# rounds sample meaningfully different values at VERIFY_BLOCK.
 PROBE_ADDRESSES: dict[str, str] = {
     "Ethereum": "0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2",  # WETH9
     "Base": "0x4200000000000000000000000000000000000006",  # WETH (OP Stack predeploy)
@@ -72,6 +81,30 @@ def _format_balance_verified_line(
     )
 
 
+def _format_balance_observed_verified_line(
+    chain: str,
+    provider_name: str,
+    block_hex: str,
+    hash_value: float,
+    ts_ns: int,
+) -> str:
+    """Format an Influx line for per-provider ``balance_observed_verified``.
+
+    Distinct from v1's ``balance_observed`` (which is emitted at v1's deep
+    OLD_BLOCK alongside the latency cron) so dashboards can pair each
+    provider's report at VERIFY_BLOCK with the proof-anchored truth at the
+    same block without colliding on the legacy v1 series.
+    """
+    return (
+        f"{METRIC_NAME},"
+        f"source_region=fra1,target_region=default,blockchain={chain},"
+        f"provider={provider_name},api_method=eth_getBalance,"
+        f"response_status=success,metric_type=balance_observed_verified,"
+        f"block_number={block_hex} "
+        f"value={hash_value} {ts_ns}"
+    )
+
+
 def _format_verifier_status_line(chain: str, code: int, ts_ns: int) -> str:
     """Format an Influx line for ``metric_type=verifier_status``."""
     return (
@@ -82,10 +115,54 @@ def _format_verifier_status_line(chain: str, code: int, ts_ns: int) -> str:
     )
 
 
+def _pick_verify_block(chain: str, head: int) -> Optional[int]:
+    """Compute VERIFY_BLOCK for a chain, or None if no offset configured."""
+    offset_range = MetricsServiceConfig.VERIFY_BLOCK_OFFSET_RANGES.get(chain.lower())
+    if not offset_range:
+        return None
+    lo, hi = offset_range
+    return head - random.randint(lo, hi)
+
+
+async def _probe_observed_balances(
+    session: aiohttp.ClientSession,
+    chain: str,
+    provider_entries: list[tuple[str, str]],
+    addr_hex: str,
+    block_hex: str,
+    ts_ns: int,
+) -> list[str]:
+    """Probe each provider's eth_getBalance at VERIFY_BLOCK in parallel.
+
+    Returns Influx lines for providers that responded successfully. Failures
+    (timeout, RPC error, malformed) are silently skipped — dashboards show
+    a clean gap, which is the right shape for a transient provider blip.
+    Quorum/proof emission has already happened by the time this runs, so a
+    per-provider balance failure is informational, not a verifier failure.
+    """
+    tasks = [
+        fetch_balance_at(session, url, addr_hex, block_hex)
+        for _, url in provider_entries
+    ]
+    balances = await asyncio.gather(*tasks, return_exceptions=True)
+
+    lines: list[str] = []
+    for (name, _url), balance in zip(provider_entries, balances):
+        if isinstance(balance, BaseException) or balance is None:
+            continue
+        if not isinstance(balance, int) or balance < 0:
+            continue
+        lines.append(
+            _format_balance_observed_verified_line(
+                chain, name, block_hex, hash_balance_to_float(balance), ts_ns
+            )
+        )
+    return lines
+
+
 async def _verify_chain(
     session: aiohttp.ClientSession,
     chain: str,
-    state_data: dict[str, Any],
 ) -> list[str]:
     """Run one verifier round for a chain. Returns Influx-format lines to emit.
 
@@ -93,19 +170,11 @@ async def _verify_chain(
     "verifier round happened" from "no sample" — never returns an empty list.
     """
     ts_ns = time.time_ns()
-    chain_lower = chain.lower()
-    chain_state = state_data.get(chain_lower)
-    if not chain_state or not chain_state.get("old_block"):
-        # Missing OLD_BLOCK — could be update_state outage, blob read failure, etc.
-        # Treat as anchor unavailable so the failure is visible, not silent.
-        logging.warning(f"verify_state: no old_block for {chain}")
-        return [_format_verifier_status_line(chain, STATUS_ANCHOR_UNAVAILABLE, ts_ns)]
-
-    block_hex = chain_state["old_block"]
     addr_hex = PROBE_ADDRESSES[chain]
     addr_bytes = bytes.fromhex(addr_hex.removeprefix("0x"))
 
-    providers = all_providers_for(chain)
+    provider_entries = all_provider_entries_for(chain)
+    providers = [url for _, url in provider_entries]
     chainstack_url = chainstack_endpoint_for(chain)
 
     if not providers:
@@ -115,7 +184,23 @@ async def _verify_chain(
         logging.warning(f"verify_state: no Chainstack endpoint configured for {chain}")
         return [_format_verifier_status_line(chain, STATUS_PROOF_UNAVAILABLE, ts_ns)]
 
-    # 1. Anchor — multi-provider stateRoot quorum.
+    # 0. Compute VERIFY_BLOCK from current head. We sample head from Chainstack
+    #    because Chainstack also serves the proof — its head determines whether
+    #    the chosen block falls inside the proof window. Other providers can be
+    #    a few blocks behind without breaking anything (offsets are large enough
+    #    to absorb normal cross-provider lag).
+    head = await fetch_latest_block(session, chainstack_url)
+    if head is None:
+        logging.warning(f"verify_state: failed to fetch latest block for {chain}")
+        return [_format_verifier_status_line(chain, STATUS_ANCHOR_UNAVAILABLE, ts_ns)]
+
+    verify_block = _pick_verify_block(chain, head)
+    if verify_block is None:
+        logging.warning(f"verify_state: no VERIFY_BLOCK_OFFSET_RANGES for {chain}")
+        return [_format_verifier_status_line(chain, STATUS_ANCHOR_UNAVAILABLE, ts_ns)]
+    block_hex = hex(verify_block)
+
+    # 1. Anchor — multi-provider stateRoot quorum at VERIFY_BLOCK.
     try:
         anchor = await fetch_agreed_anchor(session, block_hex, providers)
     except AnchorDisagreementError:
@@ -131,7 +216,12 @@ async def _verify_chain(
     try:
         proof = await fetch_account_proof(session, chainstack_url, addr_hex, block_hex)
     except Exception as e:
-        logging.warning(f"verify_state: proof fetch failed for {chain}: {e}")
+        # Use type(e).__name__ + repr so silent failures like
+        # asyncio.TimeoutError (which has an empty str()) are visible.
+        logging.warning(
+            f"verify_state: proof fetch failed for {chain}: "
+            f"{type(e).__name__}: {e!r}"
+        )
         return [_format_verifier_status_line(chain, STATUS_PROOF_UNAVAILABLE, ts_ns)]
 
     # 3. Local MPT verification.
@@ -143,51 +233,43 @@ async def _verify_chain(
 
     if balance is None:
         # Cryptographically valid exclusion proof for our funded probe address —
-        # not a math failure. Most likely root causes: wrong probe address in
-        # config, stale OLD_BLOCK from blob, or chain reorg deeper than our
-        # offset. Mapped to STATUS_PROOF_UNAVAILABLE because the proof yielded
-        # nothing to verify against, not because the math was invalid.
+        # not a math failure. Most likely root causes: wrong probe address, or
+        # chain reorg deeper than VERIFY_BLOCK_OFFSET_RANGES (very unlikely on
+        # post-finality blocks; possible at L2 sequencer-settle depth).
         logging.error(
             f"verify_state: unexpected exclusion proof for {chain} "
             f"address={addr_hex} block={block_hex}"
         )
         return [_format_verifier_status_line(chain, STATUS_PROOF_UNAVAILABLE, ts_ns)]
 
-    # 4. Emit balance_verified + verifier_status=0.
+    # 4. Probe per-provider balances at VERIFY_BLOCK in parallel. Failures
+    #    here don't change verifier_status — proof+quorum already succeeded.
+    observed_lines = await _probe_observed_balances(
+        session, chain, provider_entries, addr_hex, block_hex, ts_ns
+    )
+
+    # 5. Emit balance_verified + verifier_status=0 + per-provider observations.
     return [
         _format_balance_verified_line(
             chain, block_hex, hash_balance_to_float(balance), ts_ns
         ),
         _format_verifier_status_line(chain, STATUS_OK, ts_ns),
+        *observed_lines,
     ]
-
-
-async def _gather_state_data() -> dict[str, dict[str, Any]]:
-    """Read OLD_BLOCK + other state for each in-scope chain from blob storage."""
-    out: dict[str, dict[str, Any]] = {}
-    for chain in PROBE_ADDRESSES:
-        try:
-            chain_state = await BlockchainState.get_data(chain.lower())
-            if chain_state:
-                out[chain.lower()] = chain_state
-        except Exception:
-            logging.exception(f"verify_state: failed to read state for {chain}")
-    return out
 
 
 async def _verify_all() -> str:
     """Run the verifier across all in-scope chains. Returns Influx text.
 
     If a per-chain task raises an unexpected exception (i.e. something not
-    handled inside ``_verify_chain``), emit ``verifier_status=2`` for that
+    handled inside ``_verify_chain``), emit ``verifier_status=4`` for that
     chain so the failure is visible in dashboards rather than silently dropped.
     """
-    state_data = await _gather_state_data()
     chains = list(PROBE_ADDRESSES)
 
     async with aiohttp.ClientSession() as session:
         results = await asyncio.gather(
-            *[_verify_chain(session, chain, state_data) for chain in chains],
+            *[_verify_chain(session, chain) for chain in chains],
             return_exceptions=True,
         )
 

--- a/common/verify/__init__.py
+++ b/common/verify/__init__.py
@@ -9,18 +9,27 @@ from common.verify.anchor import (
     AnchorPartialResponseError,
     fetch_account_proof,
     fetch_agreed_anchor,
+    fetch_balance_at,
+    fetch_latest_block,
 )
 from common.verify.proof import ProofError, verify_account_proof
-from common.verify.providers import all_providers_for, chainstack_endpoint_for
+from common.verify.providers import (
+    all_provider_entries_for,
+    all_providers_for,
+    chainstack_endpoint_for,
+)
 
 __all__ = [
     "AnchorDisagreementError",
     "AnchorError",
     "AnchorPartialResponseError",
     "ProofError",
+    "all_provider_entries_for",
     "all_providers_for",
     "chainstack_endpoint_for",
     "fetch_account_proof",
     "fetch_agreed_anchor",
+    "fetch_balance_at",
+    "fetch_latest_block",
     "verify_account_proof",
 ]

--- a/common/verify/anchor.py
+++ b/common/verify/anchor.py
@@ -14,7 +14,11 @@ from typing import Any, Optional
 import aiohttp
 
 _RPC_TIMEOUT = aiohttp.ClientTimeout(total=15)
-_PROOF_TIMEOUT = aiohttp.ClientTimeout(total=25)
+# Ethereum eth_getProof at ~8000-block depth on Chainstack mainstream nodes
+# takes ~45-50s empirically (large MPT walk on the server). The previous 25s
+# limit was the silent reason production Ethereum verifier rounds were
+# timing out and reporting empty errors.
+_PROOF_TIMEOUT = aiohttp.ClientTimeout(total=55)
 
 
 class AnchorError(Exception):
@@ -113,6 +117,73 @@ async def _fetch_state_root(
         # Reject non-32-byte stateRoots so a malformed-but-unanimous response
         # fails as anchor-unavailable instead of surfacing later as proof-math-invalid.
         return state_root if len(state_root) == 32 else None
+
+
+async def fetch_latest_block(session: aiohttp.ClientSession, url: str) -> Optional[int]:
+    """Return latest block height (eth_blockNumber) as an int, or None on failure."""
+    payload: dict[str, Any] = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "eth_blockNumber",
+        "params": [],
+    }
+    try:
+        async with session.post(
+            url,
+            headers={"Content-Type": "application/json"},
+            data=json.dumps(payload),
+            timeout=_RPC_TIMEOUT,
+        ) as response:
+            if response.status != 200:
+                return None
+            body = await response.json()
+            if not isinstance(body, dict) or "error" in body:
+                return None
+            result = body.get("result")
+            if not isinstance(result, str):
+                return None
+            return int(result, 16)
+    except (aiohttp.ClientError, asyncio.TimeoutError, ValueError):
+        return None
+
+
+async def fetch_balance_at(
+    session: aiohttp.ClientSession,
+    url: str,
+    address_hex: str,
+    block_hex: str,
+) -> Optional[int]:
+    """Call ``eth_getBalance`` for an address at a specific block.
+
+    Returns the balance as an int on success, ``None`` on any failure
+    (HTTP error, RPC error, malformed response, timeout). Callers
+    skip emission for ``None`` results so the dashboard shows a clean
+    gap for provider blips instead of a fake zero.
+    """
+    payload: dict[str, Any] = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "eth_getBalance",
+        "params": [address_hex, block_hex],
+    }
+    try:
+        async with session.post(
+            url,
+            headers={"Content-Type": "application/json"},
+            data=json.dumps(payload),
+            timeout=_RPC_TIMEOUT,
+        ) as response:
+            if response.status != 200:
+                return None
+            body = await response.json()
+            if not isinstance(body, dict) or "error" in body:
+                return None
+            result = body.get("result")
+            if not isinstance(result, str):
+                return None
+            return int(result, 16)
+    except (aiohttp.ClientError, asyncio.TimeoutError, ValueError):
+        return None
 
 
 async def fetch_account_proof(

--- a/common/verify/providers.py
+++ b/common/verify/providers.py
@@ -38,17 +38,28 @@ def all_providers_for(chain: str) -> list[str]:
     Returns:
         List of HTTP endpoint URLs. Empty if no providers are configured.
     """
+    return [url for _, url in all_provider_entries_for(chain)]
+
+
+def all_provider_entries_for(chain: str) -> list[tuple[str, str]]:
+    """Return (name, http_endpoint) pairs for every provider on the chain.
+
+    Used by v2.1's per-provider balance probe step, which needs the provider
+    name as a Grafana tag — ``all_providers_for`` drops the name. Order
+    matches the ENDPOINTS config so the per-round emission order is stable.
+    """
     config = _load_endpoints_config()
     target = chain.lower()
-    out: list[str] = []
+    out: list[tuple[str, str]] = []
     for provider in config.get("providers", []):
         if not isinstance(provider, dict):
             continue
         if provider.get("blockchain", "").lower() != target:
             continue
+        name = provider.get("name")
         endpoint = provider.get("http_endpoint")
-        if isinstance(endpoint, str) and endpoint:
-            out.append(endpoint)
+        if isinstance(name, str) and name and isinstance(endpoint, str) and endpoint:
+            out.append((name, endpoint))
     return out
 
 

--- a/config/defaults.py
+++ b/config/defaults.py
@@ -44,6 +44,30 @@ class MetricsServiceConfig:
         "monad": (216000, 256000),
     }
 
+    # Per-chain offset for the v2 verifier (eth_getProof at VERIFY_BLOCK).
+    # Sized to fit Chainstack's empirically-measured proof-retention window
+    # per chain — proofs are MPT trie nodes which prune ~128 blocks deep on
+    # geth-family clients, much shallower than the snapshot-served balance
+    # window that BLOCK_OFFSET_RANGES targets. Verified ranges as of 2026-05:
+    #   Ethereum max retention ≈ 10,000 blocks, but proof latency scales
+    #                            linearly with depth on Chainstack (~6 ms
+    #                            per block, ~48 s at 8000-block depth).
+    #                            Tightened to (200, 500) for proof times
+    #                            of ~4-7s, well within Vercel's 59 s budget.
+    #                            200 blocks (~40 min) is way past finality
+    #                            (~64 blocks).
+    #   Base     max retention ≈   121 blocks (~4 min)
+    #   BNB      max retention ≈   117 blocks (~5.8 min)
+    #   Arbitrum max retention ≈   107 blocks (~27 s) — tightest; arb head
+    #                            moves fast so we keep extra headroom for
+    #                            in-cron drift.
+    VERIFY_BLOCK_OFFSET_RANGES: ClassVar[dict[str, tuple[int, int]]] = {
+        "ethereum": (200, 500),
+        "base": (60, 100),
+        "arbitrum": (50, 70),
+        "bnb": (30, 100),
+    }
+
 
 class BlobStorageConfig:
     """Default configuration for blob storage."""

--- a/tests/test_verify_state_e2e.py
+++ b/tests/test_verify_state_e2e.py
@@ -1,0 +1,25 @@
+"""End-to-end smoke test for v2.1 verify_state.
+
+Runs `_verify_all` locally against the live endpoints in endpoints.json
+and prints the resulting Influx lines. Does NOT push to Grafana.
+"""
+
+import asyncio
+import os
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+os.environ["ENDPOINTS"] = (ROOT / "endpoints.json").read_text()
+sys.path.insert(0, str(ROOT))
+
+from api.support.verify_state import _verify_all  # noqa: E402
+
+
+async def main() -> None:
+    out = await _verify_all()
+    print(out)
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary

Fixes production v2 verifier (PR #76), which has been emitting `verifier_status=4` on every cron round across all four chains. Adds per-provider balance observation at the verified block so dashboards can compare each provider's reporting against the proof-anchored truth (replacing modal-vote eventually).

## Root cause

v2 reused v1's `OLD_BLOCK` offset (7200–10000 blocks). v1 was tuned for **latency cleanliness** — `eth_getBalance` is served from the flat snapshot layer that retains a wide window. But v2 needs `eth_getProof`, which requires the actual Merkle-Patricia trie nodes; those are pruned ~128 blocks deep on geth-family clients. 7200+ blocks is far outside the proof window on every chain.

Additionally, the Ethereum case was timing out silently — `eth_getProof` at depth 8000 takes ~48s on Chainstack (proof latency scales ~6ms/block), exceeding the 25s aiohttp timeout. The `asyncio.TimeoutError` has an empty `str()`, so the warning log line showed nothing after the colon, masking the root cause.

## Empirically measured Chainstack proof retention (2026-05)

| Chain | Max offset | Wall time | Notes |
|---|---|---|---|
| Ethereum | ~10,000 blocks | ~33h | Latency scales linearly with depth |
| Base | 121 blocks | ~4 min | op-geth default |
| BNB | 117 blocks | ~5.8 min | geth fork default |
| Arbitrum | 107 blocks | ~27s | nitro, 250ms blocks |

## Changes

1. **`config/defaults.py`** — new `VERIFY_BLOCK_OFFSET_RANGES`, separate from v1's `BLOCK_OFFSET_RANGES`:
   - Ethereum: `(200, 500)` — past finality (~64 blocks), proof times ~4–7s
   - Base: `(60, 100)` — inside 121-block window
   - BNB: `(30, 100)` — past PoSA finality (~21 blocks)
   - Arbitrum: `(50, 70)` — inside 107-block window with headroom for in-cron head movement

2. **`common/verify/anchor.py`** — bump proof timeout 25s → 55s, plus new helpers `fetch_latest_block` and `fetch_balance_at` for the per-provider probe.

3. **`common/verify/providers.py`** — add `all_provider_entries_for(chain)` returning `(name, url)` pairs for the per-provider balance emit step.

4. **`api/support/verify_state.py`** — major refactor:
   - Drops blob coordination with `update_state` (no more `BlockchainState.get_data`); v2 is now self-contained.
   - Computes `VERIFY_BLOCK = latest_head - random(offset_range_for_chain)` itself.
   - Per cron round: quorum stateRoot → fetch proof → walk MPT → **probe each provider's `eth_getBalance` at VERIFY_BLOCK** → emit.
   - Emits new `metric_type=balance_observed_verified` tagged with `provider` and `block_number`, alongside existing `balance_verified` and `verifier_status`.
   - Better error logging (`type(e).__name__`) so silent timeouts surface.

5. **`tests/test_verify_state_e2e.py`** — new local smoke test that runs the full verifier against live endpoints.

## Trust model

Unchanged. Multi-provider stateRoot quorum still required for the anchor; MPT math still catches forged proofs from Chainstack. The new per-provider balance probe is an **observation step** — its emissions are compared against the proof-anchored `balance_verified`, not used to determine truth.

## What's NOT in this PR (intentional)

- Dashboard panel swap to `balance_observed_verified` — separate PR after soak window.
- v1's `balance_observed` deprecation — keep the legacy series live for backward-compat until panel swap settles.
- `update_state` is unchanged. Even though v2 no longer reads its blob output for OLD_BLOCK, v1 still does — keeping it.
- `spec-verified-correctness-v2.md` not updated in this PR. v2.1 notes belong in a doc PR with the panel swap.

## Test plan

- [x] `uvx ruff check` — clean
- [x] `uvx black --check` — clean
- [x] `uvx mypy` — clean (env warning about Python 3.9 is pre-existing)
- [x] Local e2e — 5 consecutive runs against live `endpoints.json`, all four chains emit `verifier_status=0`, every configured provider's `balance_observed_verified` hash equals the corresponding `balance_verified` hash (no quorum failures, no proof failures, no provider lag failures)
- [ ] Post-merge soak: watch `verifier_status` series in fra1. Expect steady `=0`. Occasional `=1` (stateRoot disagreement at shallow L2 offsets) is *signal* — flag if rate is >a few percent.
- [ ] Post-soak: dashboard panel swap PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved verification resilience with independent block selection per cycle
  * Increased timeout handling for large proof retrievals
  * Enhanced error logging for better visibility into network issues
  * Strengthened error handling for unexpected account state scenarios

* **New Features**
  * Added per-provider balance observation metrics to supplement existing verification metrics

* **Tests**
  * Added end-to-end verification test suite

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chainstacklabs/compare-dashboard-functions/pull/77?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->