### PR TITLE
feat: add P2P-Syncro provider to Solana tx landing metrics

### DIFF
--- a/api/write/solana_p2p_syncro.py
+++ b/api/write/solana_p2p_syncro.py
@@ -1,0 +1,92 @@
+"""Vercel cron entry point for the P2P Syncro Sender landing-rate metric.
+
+Standalone from ``api/write/solana.py``: uses a custom ``MetricsHandler``
+subclass that emits exactly one probe (not one per Solana provider in
+``endpoints.json``). Reads the first Solana provider's ``http_endpoint``
+from the ``ENDPOINTS`` env var to back the read RPC (``getLatestBlockhash``
+/ ``getSlot`` / ``getSignatureStatuses``); the send endpoint is hardcoded
+inside ``P2PSyncroLandingMetric``.
+"""
+
+import json
+import logging
+import os
+from typing import Optional
+
+from common.metric_config import EndpointConfig, MetricConfig, MetricLabels
+from common.metrics_handler import BaseVercelHandler, MetricsHandler
+from config.defaults import MetricsServiceConfig
+from metrics.p2p_syncro_landing_rate import P2PSyncroLandingMetric
+
+METRIC_NAME = f"{MetricsServiceConfig.METRIC_PREFIX}transaction_landing_latency"
+ALLOWED_REGIONS = ["fra1"]
+PROVIDER_LABEL = "P2P-Syncro"
+BLOCKCHAIN = "Solana"
+
+
+def _resolve_read_endpoint() -> Optional[str]:
+    """Return the first Solana provider's http_endpoint from ENDPOINTS, or None."""
+    raw = os.getenv("ENDPOINTS")
+    if not raw:
+        return None
+    try:
+        config = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    for provider in config.get("providers", []):
+        if provider.get("blockchain") == BLOCKCHAIN and provider.get("http_endpoint"):
+            return str(provider["http_endpoint"])
+    return None
+
+
+class SyncroMetricsHandler(MetricsHandler):
+    """Custom handler that emits a single Syncro probe per invocation."""
+
+    def __init__(self) -> None:
+        """Initialise with empty metric registry; metric is built in handle()."""
+        super().__init__(BLOCKCHAIN, [])
+
+    async def handle(self) -> tuple[str, str]:
+        """Build one Syncro probe, collect it, push to Grafana."""
+        self._instances = []
+        region = self.grafana_config["current_region"] or "default"
+        if region not in ALLOWED_REGIONS:
+            return "skipped", ""
+
+        read_endpoint = _resolve_read_endpoint()
+        if not read_endpoint:
+            raise RuntimeError("No Solana http_endpoint found in ENDPOINTS env var")
+
+        metric_config = MetricConfig(
+            timeout=MetricsServiceConfig.METRIC_REQUEST_TIMEOUT,
+            max_latency=MetricsServiceConfig.METRIC_MAX_LATENCY,
+            endpoints=EndpointConfig(main_endpoint=read_endpoint),
+        )
+        labels = MetricLabels(
+            source_region=region,
+            target_region="default",
+            blockchain=BLOCKCHAIN,
+            provider=PROVIDER_LABEL,
+        )
+        metric = P2PSyncroLandingMetric(
+            handler=self,
+            metric_name=METRIC_NAME,
+            labels=labels,
+            config=metric_config,
+            http_endpoint=read_endpoint,
+        )
+
+        await metric.collect_metric()
+
+        metrics_text = self.get_metrics_text()
+        if metrics_text:
+            await self.push_to_grafana(metrics_text)
+        else:
+            logging.warning("Nothing to push to Grafana.")
+        return "done", metrics_text
+
+
+class handler(BaseVercelHandler):
+    """Vercel HTTP handler for the Syncro landing-rate metric."""
+
+    metrics_handler = SyncroMetricsHandler()

--- a/metrics/p2p_syncro_landing_rate.py
+++ b/metrics/p2p_syncro_landing_rate.py
@@ -1,0 +1,126 @@
+"""P2P Syncro Sender landing rate metric.
+
+Reuses the memo-probe flow from ``SolanaLandingMetric`` but routes
+``sendTransaction`` to the public Syncro Sender endpoint while keeping
+reads on a normal Solana RPC. Adds the mandatory tip transfer (>=100k
+lamports) to a Syncro tip account so the public endpoint accepts the tx.
+
+Public endpoint is rate-limited to 1 RPS — do not increase send cadence.
+"""
+
+import random
+import time
+from typing import Optional
+
+from solana.rpc.async_api import AsyncClient
+from solana.rpc.types import TxOpts
+from solders.compute_budget import set_compute_unit_limit, set_compute_unit_price
+from solders.instruction import Instruction
+from solders.pubkey import Pubkey
+from solders.rpc.responses import SendTransactionResp
+from solders.system_program import TransferParams, transfer
+from solders.transaction import Transaction
+
+from common.metric_config import MetricLabelKey
+from config.defaults import MetricsServiceConfig
+from metrics.solana_landing_rate import SolanaLandingMetric, generate_fixed_memo
+
+
+class P2PSyncroLandingMetric(SolanaLandingMetric):
+    """Solana landing-rate probe through P2P.org Syncro Sender public endpoint."""
+
+    SYNCRO_TX_ENDPOINT = "https://sfls-geo-fra.l2.p2p.org/public"
+    TIP_LAMPORTS = 100_000
+    TIP_ACCOUNTS: tuple[Pubkey, ...] = tuple(
+        Pubkey.from_string(addr)
+        for addr in (
+            "BPZrtYhdoAhiHWV5EgGLoV7bZFbMamBZurGDq4DmST8v",
+            "7D5pdbkV75Sr73M1YFNZwXMed6DenwkdfbJwVWrX6drQ",
+            "ELpn2NryEW4B3psG36eSjF45YcGMQpGGuu9J2AgAccbV",
+            "FnckAPC9PitnRpGZM2M4WLwb3w9odRLJ7EDRZDngjvd6",
+            "3ZnDTgvVfwzqwWoqAUmDkgVtXvXqjmeb5t9zxD5pMbmv",
+            "3SLDFcdCzMbcFNguZhzmV4zqEAUvcPoKY13akpE4Tq1p",
+            "48tT6LJqrsoFrLpzZSHkjGdGTWtsJ1PvjgWZjh8qF1RK",
+            "7GM9fpVMHHcrK4cgzfVdzJvjiy1bSyfwSYzhxvgbfVLg",
+            "CBd8GE3ffMJKf3iCCcNNBEifMxH1WpgtTzRnXPxxbjGE",
+        )
+    )
+
+    async def _prepare_memo_transaction(self, client: AsyncClient) -> Transaction:
+        """Build the memo transaction with a Syncro tip transfer prepended."""
+        memo_text: str = generate_fixed_memo(
+            self.labels.get_label(MetricLabelKey.SOURCE_REGION)  # type: ignore[arg-type]
+        )
+
+        tip_ix = transfer(
+            TransferParams(
+                from_pubkey=self.keypair.pubkey(),
+                to_pubkey=random.choice(self.TIP_ACCOUNTS),
+                lamports=self.TIP_LAMPORTS,
+            )
+        )
+        compute_limit_ix: Instruction = set_compute_unit_limit(
+            MetricsServiceConfig.COMPUTE_LIMIT
+        )
+        compute_price_ix: Instruction = set_compute_unit_price(
+            MetricsServiceConfig.PRIORITY_FEE_MICROLAMPORTS
+        )
+        memo_ix = Instruction(
+            program_id=Pubkey.from_string(self.MEMO_PROGRAM_ID),
+            accounts=[],
+            data=memo_text.encode(),
+        )
+
+        blockhash = await client.get_latest_blockhash()
+        if not blockhash or not blockhash.value:
+            raise ValueError("Failed to get latest blockhash")
+
+        return Transaction.new_signed_with_payer(
+            [tip_ix, compute_limit_ix, compute_price_ix, memo_ix],
+            self.keypair.pubkey(),
+            [self.keypair],
+            blockhash.value.blockhash,
+        )
+
+    async def fetch_data(self) -> Optional[float]:
+        """Send a tipped memo tx via Syncro; read state via the inherited endpoint."""
+        self.update_metric_value(0, "response_time")
+        self.update_metric_value(0, "slot_latency")
+
+        read_client: Optional[AsyncClient] = None
+        tx_client: Optional[AsyncClient] = None
+        try:
+            read_client = await self._create_client()
+            tx_client = AsyncClient(self.SYNCRO_TX_ENDPOINT)
+
+            tx: Transaction = await self._prepare_memo_transaction(read_client)
+            start_slot: int = await self._get_slot(read_client)
+            start_time: float = time.monotonic()
+
+            signature_response: SendTransactionResp = await tx_client.send_transaction(
+                tx, TxOpts(skip_preflight=True, max_retries=0)
+            )
+            if not signature_response or not signature_response.value:
+                raise ValueError("Failed to send transaction")
+
+            confirmation_slot: int = await self._wait_for_confirmation(
+                read_client,
+                str(signature_response.value),
+                self.config.timeout,
+            )
+
+            response_time: float = time.monotonic() - start_time
+            self._slot_diff = confirmation_slot - start_slot
+            if self._slot_diff < 0:
+                raise ValueError(
+                    f"Negative slot difference: {self._slot_diff} "
+                    f"(confirmation_slot={confirmation_slot}, start_slot={start_slot})"
+                )
+            self.update_metric_value(self._slot_diff, "slot_latency")
+            return response_time
+
+        finally:
+            if read_client:
+                await read_client.close()
+            if tx_client:
+                await tx_client.close()

--- a/vercel.fra1.json
+++ b/vercel.fra1.json
@@ -43,6 +43,10 @@
       "memory": 160,
       "maxDuration": 65
     },
+    "api/write/solana_p2p_syncro.py": {
+      "memory": 160,
+      "maxDuration": 65
+    },
     "api/support/update_state.py": {
       "memory": 128,
       "maxDuration": 59
@@ -91,6 +95,10 @@
     },
     {
       "path": "/api/write/solana",
+      "schedule": "*/15 * * * *"
+    },
+    {
+      "path": "/api/write/solana_p2p_syncro",
       "schedule": "*/15 * * * *"
     },
     {


### PR DESCRIPTION
## Summary

Adds the P2P.org Syncro Sender public endpoint as a new provider on the Solana transaction landing dashboard.

- New Vercel function `api/write/solana_p2p_syncro.py`, runs every 15 min from fra1.
- Sends a memo transaction through `https://sfls-geo-fra.l2.p2p.org/public`. Includes a 100,000-lamport tip transfer to a randomly picked Syncro tip account, which the public endpoint requires.
- Reads (`getLatestBlockhash`, `getSlot`, `getSignatureStatuses`) go through the first Solana provider in `endpoints.json`, since Syncro's public endpoint only supports `sendTransaction`.
- Emits `transaction_landing_latency` with `provider=P2P-Syncro` and the same label set as existing tx providers, so the metric lives alongside them in storage.
- Uses the existing `SOLANA_PRIVATE_KEY`. No new environment variables.
- Hardcoded constants in `metrics/p2p_syncro_landing_rate.py`: send endpoint, tip amount, and the 9 public tip accounts from the Syncro docs.

The base `SolanaLandingMetric` class and the existing `api/write/solana.py` cron are not modified.

Dashboard panel updates to surface `provider=P2P-Syncro` will be a separate PR — current panels hardcode each provider name in their queries.

## Test plan

- [x] `uvx black .` clean
- [x] `uvx ruff check .` clean
- [x] `uvx mypy` shows no new errors on the two added files
- [x] Local run with real `SOLANA_PRIVATE_KEY` and `VERCEL_REGION=fra1` produces one influx line with `provider=P2P-Syncro`, `api_method=sendTransaction`, `metric_type=slot_latency`, `response_status=success`
- [x] After deploy, verify the metric stream appears in Grafana with the expected label set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added P2P Syncro landing rate metric collection for Solana transactions
  * Automated metric collection scheduled every 15 minutes, reporting transaction confirmation latency data to the monitoring system

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chainstacklabs/compare-dashboard-functions/pull/78?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->