### PR TITLE
feat(dashboards): surface P2P-Syncro on Solana landing panels

### DIFF
--- a/dashboards/dashboards/compare-dashboard-arbitrum-eu.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum-eu.json
@@ -1232,9 +1232,6 @@
       "type": "row"
     },
     {
-      "id": 1300,
-      "type": "row",
-      "title": "Data agreement",
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
@@ -1246,43 +1243,14 @@
         "x": 0,
         "y": 26
       },
+      "id": 1300,
       "panels": [
         {
-          "id": 1301,
-          "type": "state-timeline",
-          "title": "Provider agreement",
-          "description": "Per provider in this region (EU), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 18,
-            "x": 0,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "alignValue": "left",
-            "annotations": {
-              "clustering": -1,
-              "multiLane": false
-            },
-            "legend": {
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "mergeValues": true,
-            "rowHeight": 0.8,
-            "showValue": "never",
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
+          "description": "Per provider in this region (EU), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1303,7 +1271,6 @@
               "decimals": 0,
               "mappings": [
                 {
-                  "type": "special",
                   "options": {
                     "match": "null",
                     "result": {
@@ -1311,7 +1278,8 @@
                       "index": 0,
                       "text": "No data"
                     }
-                  }
+                  },
+                  "type": "special"
                 }
               ],
               "thresholds": {
@@ -1355,6 +1323,34 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "id": 1301,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1367,42 +1363,16 @@
               "range": true,
               "refId": "A"
             }
-          ]
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
         },
         {
-          "id": 1302,
-          "type": "table",
-          "title": "Agreement summary",
-          "description": "For each provider in this region (EU), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 18,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "cellHeight": "sm",
-            "showHeader": true,
-            "sortBy": [
-              {
-                "displayName": "Agreed %",
-                "desc": true
-              }
-            ],
-            "footer": {
-              "show": false,
-              "reducer": [
-                "sum"
-              ],
-              "countRows": false,
-              "fields": ""
-            }
-          },
+          "description": "For each provider in this region (EU), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1442,17 +1412,17 @@
                     "id": "mappings",
                     "value": [
                       {
-                        "type": "value",
                         "options": {
                           "Chainstack": {
-                            "text": "Chainstack-Growth",
-                            "index": 0
+                            "index": 0,
+                            "text": "Chainstack-Growth"
                           },
                           "dRPC": {
-                            "text": "dRPC-Growth",
-                            "index": 1
+                            "index": 1,
+                            "text": "dRPC-Growth"
                           }
-                        }
+                        },
+                        "type": "value"
                       }
                     ]
                   }
@@ -1510,6 +1480,32 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "id": 1302,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1524,6 +1520,7 @@
               "refId": "A"
             }
           ],
+          "title": "Agreement summary",
           "transformations": [
             {
               "id": "organize",
@@ -1532,18 +1529,21 @@
                   "Time": true
                 },
                 "indexByName": {
-                  "provider": 0,
-                  "Value": 1
+                  "Value": 1,
+                  "provider": 0
                 },
                 "renameByName": {
-                  "provider": "Provider",
-                  "Value": "Agreed %"
+                  "Value": "Agreed %",
+                  "provider": "Provider"
                 }
               }
             }
-          ]
+          ],
+          "type": "table"
         }
-      ]
+      ],
+      "title": "Data agreement",
+      "type": "row"
     },
     {
       "collapsed": true,
@@ -7352,6 +7352,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Arbitrum (EU)",
   "uid": "arbitrum-eu-1",
-  "version": 54,
+  "version": 55,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-arbitrum-japan.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum-japan.json
@@ -1218,9 +1218,6 @@
       "type": "row"
     },
     {
-      "id": 1300,
-      "type": "row",
-      "title": "Data agreement",
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
@@ -1232,43 +1229,14 @@
         "x": 0,
         "y": 26
       },
+      "id": 1300,
       "panels": [
         {
-          "id": 1301,
-          "type": "state-timeline",
-          "title": "Provider agreement",
-          "description": "Per provider in this region (JP), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 18,
-            "x": 0,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "alignValue": "left",
-            "annotations": {
-              "clustering": -1,
-              "multiLane": false
-            },
-            "legend": {
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "mergeValues": true,
-            "rowHeight": 0.8,
-            "showValue": "never",
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
+          "description": "Per provider in this region (JP), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1289,7 +1257,6 @@
               "decimals": 0,
               "mappings": [
                 {
-                  "type": "special",
                   "options": {
                     "match": "null",
                     "result": {
@@ -1297,7 +1264,8 @@
                       "index": 0,
                       "text": "No data"
                     }
-                  }
+                  },
+                  "type": "special"
                 }
               ],
               "thresholds": {
@@ -1341,6 +1309,34 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "id": 1301,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1353,42 +1349,16 @@
               "range": true,
               "refId": "A"
             }
-          ]
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
         },
         {
-          "id": 1302,
-          "type": "table",
-          "title": "Agreement summary",
-          "description": "For each provider in this region (JP), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 18,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "cellHeight": "sm",
-            "showHeader": true,
-            "sortBy": [
-              {
-                "displayName": "Agreed %",
-                "desc": true
-              }
-            ],
-            "footer": {
-              "show": false,
-              "reducer": [
-                "sum"
-              ],
-              "countRows": false,
-              "fields": ""
-            }
-          },
+          "description": "For each provider in this region (JP), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1428,17 +1398,17 @@
                     "id": "mappings",
                     "value": [
                       {
-                        "type": "value",
                         "options": {
                           "Chainstack": {
-                            "text": "Chainstack-Growth",
-                            "index": 0
+                            "index": 0,
+                            "text": "Chainstack-Growth"
                           },
                           "dRPC": {
-                            "text": "dRPC-Growth",
-                            "index": 1
+                            "index": 1,
+                            "text": "dRPC-Growth"
                           }
-                        }
+                        },
+                        "type": "value"
                       }
                     ]
                   }
@@ -1496,6 +1466,32 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "id": 1302,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1510,6 +1506,7 @@
               "refId": "A"
             }
           ],
+          "title": "Agreement summary",
           "transformations": [
             {
               "id": "organize",
@@ -1518,18 +1515,21 @@
                   "Time": true
                 },
                 "indexByName": {
-                  "provider": 0,
-                  "Value": 1
+                  "Value": 1,
+                  "provider": 0
                 },
                 "renameByName": {
-                  "provider": "Provider",
-                  "Value": "Agreed %"
+                  "Value": "Agreed %",
+                  "provider": "Provider"
                 }
               }
             }
-          ]
+          ],
+          "type": "table"
         }
-      ]
+      ],
+      "title": "Data agreement",
+      "type": "row"
     },
     {
       "collapsed": true,
@@ -7348,6 +7348,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Arbitrum (Japan)",
   "uid": "arbitrum-sing-1",
-  "version": 55,
+  "version": 56,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-arbitrum-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum-us-west.json
@@ -1216,9 +1216,6 @@
       "type": "row"
     },
     {
-      "id": 1300,
-      "type": "row",
-      "title": "Data agreement",
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
@@ -1230,43 +1227,14 @@
         "x": 0,
         "y": 26
       },
+      "id": 1300,
       "panels": [
         {
-          "id": 1301,
-          "type": "state-timeline",
-          "title": "Provider agreement",
-          "description": "Per provider in this region (US West), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 18,
-            "x": 0,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "alignValue": "left",
-            "annotations": {
-              "clustering": -1,
-              "multiLane": false
-            },
-            "legend": {
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "mergeValues": true,
-            "rowHeight": 0.8,
-            "showValue": "never",
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
+          "description": "Per provider in this region (US West), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1287,7 +1255,6 @@
               "decimals": 0,
               "mappings": [
                 {
-                  "type": "special",
                   "options": {
                     "match": "null",
                     "result": {
@@ -1295,7 +1262,8 @@
                       "index": 0,
                       "text": "No data"
                     }
-                  }
+                  },
+                  "type": "special"
                 }
               ],
               "thresholds": {
@@ -1339,6 +1307,34 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "id": 1301,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1351,42 +1347,16 @@
               "range": true,
               "refId": "A"
             }
-          ]
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
         },
         {
-          "id": 1302,
-          "type": "table",
-          "title": "Agreement summary",
-          "description": "For each provider in this region (US West), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 18,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "cellHeight": "sm",
-            "showHeader": true,
-            "sortBy": [
-              {
-                "displayName": "Agreed %",
-                "desc": true
-              }
-            ],
-            "footer": {
-              "show": false,
-              "reducer": [
-                "sum"
-              ],
-              "countRows": false,
-              "fields": ""
-            }
-          },
+          "description": "For each provider in this region (US West), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1426,17 +1396,17 @@
                     "id": "mappings",
                     "value": [
                       {
-                        "type": "value",
                         "options": {
                           "Chainstack": {
-                            "text": "Chainstack-Growth",
-                            "index": 0
+                            "index": 0,
+                            "text": "Chainstack-Growth"
                           },
                           "dRPC": {
-                            "text": "dRPC-Growth",
-                            "index": 1
+                            "index": 1,
+                            "text": "dRPC-Growth"
                           }
-                        }
+                        },
+                        "type": "value"
                       }
                     ]
                   }
@@ -1494,6 +1464,32 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "id": 1302,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1508,6 +1504,7 @@
               "refId": "A"
             }
           ],
+          "title": "Agreement summary",
           "transformations": [
             {
               "id": "organize",
@@ -1516,18 +1513,21 @@
                   "Time": true
                 },
                 "indexByName": {
-                  "provider": 0,
-                  "Value": 1
+                  "Value": 1,
+                  "provider": 0
                 },
                 "renameByName": {
-                  "provider": "Provider",
-                  "Value": "Agreed %"
+                  "Value": "Agreed %",
+                  "provider": "Provider"
                 }
               }
             }
-          ]
+          ],
+          "type": "table"
         }
-      ]
+      ],
+      "title": "Data agreement",
+      "type": "row"
     },
     {
       "collapsed": true,
@@ -7346,6 +7346,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Arbitrum (US West)",
   "uid": "arbitrum-us-west-1",
-  "version": 53,
+  "version": 54,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-arbitrum.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum.json
@@ -1742,9 +1742,6 @@
       "type": "row"
     },
     {
-      "id": 300,
-      "type": "row",
-      "title": "Data agreement",
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
@@ -1756,43 +1753,14 @@
         "x": 0,
         "y": 35
       },
+      "id": 300,
       "panels": [
         {
-          "id": 301,
-          "type": "state-timeline",
-          "title": "Provider agreement",
-          "description": "Per provider, did this provider's answer match the majority answer in every region it participated in at this moment. Green - matched the majority everywhere. Red - was an outlier in at least one region. Grey - no data captured.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 18,
-            "x": 0,
-            "y": 37
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "alignValue": "left",
-            "annotations": {
-              "clustering": -1,
-              "multiLane": false
-            },
-            "legend": {
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "mergeValues": true,
-            "rowHeight": 0.8,
-            "showValue": "never",
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
+          "description": "Per provider, did this provider's answer match the majority answer in every region it participated in at this moment. Green - matched the majority everywhere. Red - was an outlier in at least one region. Grey - no data captured.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1813,7 +1781,6 @@
               "decimals": 0,
               "mappings": [
                 {
-                  "type": "special",
                   "options": {
                     "match": "null",
                     "result": {
@@ -1821,7 +1788,8 @@
                       "index": 0,
                       "text": "No data"
                     }
-                  }
+                  },
+                  "type": "special"
                 }
               ],
               "thresholds": {
@@ -1865,6 +1833,34 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 37
+          },
+          "id": 301,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1877,42 +1873,16 @@
               "range": true,
               "refId": "A"
             }
-          ]
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
         },
         {
-          "id": 302,
-          "type": "table",
-          "title": "Agreement summary",
-          "description": "For each provider in each region, the percentage of samples this provider returned that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 18,
-            "y": 37
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "cellHeight": "sm",
-            "showHeader": true,
-            "sortBy": [
-              {
-                "displayName": "Agreed %",
-                "desc": true
-              }
-            ],
-            "footer": {
-              "show": false,
-              "reducer": [
-                "sum"
-              ],
-              "countRows": false,
-              "fields": ""
-            }
-          },
+          "description": "For each provider in each region, the percentage of samples this provider returned that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1952,17 +1922,17 @@
                     "id": "mappings",
                     "value": [
                       {
-                        "type": "value",
                         "options": {
                           "Chainstack": {
-                            "text": "Chainstack-Growth",
-                            "index": 0
+                            "index": 0,
+                            "text": "Chainstack-Growth"
                           },
                           "dRPC": {
-                            "text": "dRPC-Growth",
-                            "index": 1
+                            "index": 1,
+                            "text": "dRPC-Growth"
                           }
-                        }
+                        },
+                        "type": "value"
                       }
                     ]
                   }
@@ -1982,21 +1952,21 @@
                     "id": "mappings",
                     "value": [
                       {
-                        "type": "value",
                         "options": {
                           "fra1": {
-                            "text": "EU",
-                            "index": 0
+                            "index": 0,
+                            "text": "EU"
                           },
                           "hnd1": {
-                            "text": "JP",
-                            "index": 1
+                            "index": 1,
+                            "text": "JP"
                           },
                           "sfo1": {
-                            "text": "US West",
-                            "index": 2
+                            "index": 2,
+                            "text": "US West"
                           }
-                        }
+                        },
+                        "type": "value"
                       }
                     ]
                   }
@@ -2054,6 +2024,32 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 37
+          },
+          "id": 302,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -2068,6 +2064,7 @@
               "refId": "A"
             }
           ],
+          "title": "Agreement summary",
           "transformations": [
             {
               "id": "organize",
@@ -2076,20 +2073,23 @@
                   "Time": true
                 },
                 "indexByName": {
+                  "Value": 2,
                   "provider": 0,
-                  "source_region": 1,
-                  "Value": 2
+                  "source_region": 1
                 },
                 "renameByName": {
+                  "Value": "Agreed %",
                   "provider": "Provider",
-                  "source_region": "Region",
-                  "Value": "Agreed %"
+                  "source_region": "Region"
                 }
               }
             }
-          ]
+          ],
+          "type": "table"
         }
-      ]
+      ],
+      "title": "Data agreement",
+      "type": "row"
     },
     {
       "collapsed": true,
@@ -4864,6 +4864,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Arbitrum",
   "uid": "arbitrum-global-1",
-  "version": 96,
+  "version": 97,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-base-eu.json
+++ b/dashboards/dashboards/compare-dashboard-base-eu.json
@@ -1216,9 +1216,6 @@
       "type": "row"
     },
     {
-      "id": 1300,
-      "type": "row",
-      "title": "Data agreement",
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
@@ -1230,43 +1227,14 @@
         "x": 0,
         "y": 26
       },
+      "id": 1300,
       "panels": [
         {
-          "id": 1301,
-          "type": "state-timeline",
-          "title": "Provider agreement",
-          "description": "Per provider in this region (EU), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 18,
-            "x": 0,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "alignValue": "left",
-            "annotations": {
-              "clustering": -1,
-              "multiLane": false
-            },
-            "legend": {
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "mergeValues": true,
-            "rowHeight": 0.8,
-            "showValue": "never",
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
+          "description": "Per provider in this region (EU), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1287,7 +1255,6 @@
               "decimals": 0,
               "mappings": [
                 {
-                  "type": "special",
                   "options": {
                     "match": "null",
                     "result": {
@@ -1295,7 +1262,8 @@
                       "index": 0,
                       "text": "No data"
                     }
-                  }
+                  },
+                  "type": "special"
                 }
               ],
               "thresholds": {
@@ -1339,6 +1307,34 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "id": 1301,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1351,42 +1347,16 @@
               "range": true,
               "refId": "A"
             }
-          ]
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
         },
         {
-          "id": 1302,
-          "type": "table",
-          "title": "Agreement summary",
-          "description": "For each provider in this region (EU), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 18,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "cellHeight": "sm",
-            "showHeader": true,
-            "sortBy": [
-              {
-                "displayName": "Agreed %",
-                "desc": true
-              }
-            ],
-            "footer": {
-              "show": false,
-              "reducer": [
-                "sum"
-              ],
-              "countRows": false,
-              "fields": ""
-            }
-          },
+          "description": "For each provider in this region (EU), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1426,17 +1396,17 @@
                     "id": "mappings",
                     "value": [
                       {
-                        "type": "value",
                         "options": {
                           "Chainstack": {
-                            "text": "Chainstack-Growth",
-                            "index": 0
+                            "index": 0,
+                            "text": "Chainstack-Growth"
                           },
                           "dRPC": {
-                            "text": "dRPC-Growth",
-                            "index": 1
+                            "index": 1,
+                            "text": "dRPC-Growth"
                           }
-                        }
+                        },
+                        "type": "value"
                       }
                     ]
                   }
@@ -1494,6 +1464,32 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "id": 1302,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1508,6 +1504,7 @@
               "refId": "A"
             }
           ],
+          "title": "Agreement summary",
           "transformations": [
             {
               "id": "organize",
@@ -1516,18 +1513,21 @@
                   "Time": true
                 },
                 "indexByName": {
-                  "provider": 0,
-                  "Value": 1
+                  "Value": 1,
+                  "provider": 0
                 },
                 "renameByName": {
-                  "provider": "Provider",
-                  "Value": "Agreed %"
+                  "Value": "Agreed %",
+                  "provider": "Provider"
                 }
               }
             }
-          ]
+          ],
+          "type": "table"
         }
-      ]
+      ],
+      "title": "Data agreement",
+      "type": "row"
     },
     {
       "collapsed": true,
@@ -7338,6 +7338,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Base (EU)",
   "uid": "fe3mtxna6483ke-base-germ",
-  "version": 98,
+  "version": 99,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-base-japan.json
+++ b/dashboards/dashboards/compare-dashboard-base-japan.json
@@ -1215,9 +1215,6 @@
       "type": "row"
     },
     {
-      "id": 1300,
-      "type": "row",
-      "title": "Data agreement",
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
@@ -1229,43 +1226,14 @@
         "x": 0,
         "y": 26
       },
+      "id": 1300,
       "panels": [
         {
-          "id": 1301,
-          "type": "state-timeline",
-          "title": "Provider agreement",
-          "description": "Per provider in this region (JP), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 18,
-            "x": 0,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "alignValue": "left",
-            "annotations": {
-              "clustering": -1,
-              "multiLane": false
-            },
-            "legend": {
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "mergeValues": true,
-            "rowHeight": 0.8,
-            "showValue": "never",
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
+          "description": "Per provider in this region (JP), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1286,7 +1254,6 @@
               "decimals": 0,
               "mappings": [
                 {
-                  "type": "special",
                   "options": {
                     "match": "null",
                     "result": {
@@ -1294,7 +1261,8 @@
                       "index": 0,
                       "text": "No data"
                     }
-                  }
+                  },
+                  "type": "special"
                 }
               ],
               "thresholds": {
@@ -1338,6 +1306,34 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "id": 1301,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1350,42 +1346,16 @@
               "range": true,
               "refId": "A"
             }
-          ]
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
         },
         {
-          "id": 1302,
-          "type": "table",
-          "title": "Agreement summary",
-          "description": "For each provider in this region (JP), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 18,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "cellHeight": "sm",
-            "showHeader": true,
-            "sortBy": [
-              {
-                "displayName": "Agreed %",
-                "desc": true
-              }
-            ],
-            "footer": {
-              "show": false,
-              "reducer": [
-                "sum"
-              ],
-              "countRows": false,
-              "fields": ""
-            }
-          },
+          "description": "For each provider in this region (JP), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1425,17 +1395,17 @@
                     "id": "mappings",
                     "value": [
                       {
-                        "type": "value",
                         "options": {
                           "Chainstack": {
-                            "text": "Chainstack-Growth",
-                            "index": 0
+                            "index": 0,
+                            "text": "Chainstack-Growth"
                           },
                           "dRPC": {
-                            "text": "dRPC-Growth",
-                            "index": 1
+                            "index": 1,
+                            "text": "dRPC-Growth"
                           }
-                        }
+                        },
+                        "type": "value"
                       }
                     ]
                   }
@@ -1493,6 +1463,32 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "id": 1302,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1507,6 +1503,7 @@
               "refId": "A"
             }
           ],
+          "title": "Agreement summary",
           "transformations": [
             {
               "id": "organize",
@@ -1515,18 +1512,21 @@
                   "Time": true
                 },
                 "indexByName": {
-                  "provider": 0,
-                  "Value": 1
+                  "Value": 1,
+                  "provider": 0
                 },
                 "renameByName": {
-                  "provider": "Provider",
-                  "Value": "Agreed %"
+                  "Value": "Agreed %",
+                  "provider": "Provider"
                 }
               }
             }
-          ]
+          ],
+          "type": "table"
         }
-      ]
+      ],
+      "title": "Data agreement",
+      "type": "row"
     },
     {
       "collapsed": true,
@@ -7341,6 +7341,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Base (Japan)",
   "uid": "fe3mtxna6483ke-base-sing",
-  "version": 97,
+  "version": 98,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-base-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-base-us-west.json
@@ -1215,9 +1215,6 @@
       "type": "row"
     },
     {
-      "id": 1300,
-      "type": "row",
-      "title": "Data agreement",
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
@@ -1229,43 +1226,14 @@
         "x": 0,
         "y": 26
       },
+      "id": 1300,
       "panels": [
         {
-          "id": 1301,
-          "type": "state-timeline",
-          "title": "Provider agreement",
-          "description": "Per provider in this region (US West), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 18,
-            "x": 0,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "alignValue": "left",
-            "annotations": {
-              "clustering": -1,
-              "multiLane": false
-            },
-            "legend": {
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "mergeValues": true,
-            "rowHeight": 0.8,
-            "showValue": "never",
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
+          "description": "Per provider in this region (US West), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1286,7 +1254,6 @@
               "decimals": 0,
               "mappings": [
                 {
-                  "type": "special",
                   "options": {
                     "match": "null",
                     "result": {
@@ -1294,7 +1261,8 @@
                       "index": 0,
                       "text": "No data"
                     }
-                  }
+                  },
+                  "type": "special"
                 }
               ],
               "thresholds": {
@@ -1338,6 +1306,34 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "id": 1301,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1350,42 +1346,16 @@
               "range": true,
               "refId": "A"
             }
-          ]
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
         },
         {
-          "id": 1302,
-          "type": "table",
-          "title": "Agreement summary",
-          "description": "For each provider in this region (US West), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 18,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "cellHeight": "sm",
-            "showHeader": true,
-            "sortBy": [
-              {
-                "displayName": "Agreed %",
-                "desc": true
-              }
-            ],
-            "footer": {
-              "show": false,
-              "reducer": [
-                "sum"
-              ],
-              "countRows": false,
-              "fields": ""
-            }
-          },
+          "description": "For each provider in this region (US West), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1425,17 +1395,17 @@
                     "id": "mappings",
                     "value": [
                       {
-                        "type": "value",
                         "options": {
                           "Chainstack": {
-                            "text": "Chainstack-Growth",
-                            "index": 0
+                            "index": 0,
+                            "text": "Chainstack-Growth"
                           },
                           "dRPC": {
-                            "text": "dRPC-Growth",
-                            "index": 1
+                            "index": 1,
+                            "text": "dRPC-Growth"
                           }
-                        }
+                        },
+                        "type": "value"
                       }
                     ]
                   }
@@ -1493,6 +1463,32 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "id": 1302,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1507,6 +1503,7 @@
               "refId": "A"
             }
           ],
+          "title": "Agreement summary",
           "transformations": [
             {
               "id": "organize",
@@ -1515,18 +1512,21 @@
                   "Time": true
                 },
                 "indexByName": {
-                  "provider": 0,
-                  "Value": 1
+                  "Value": 1,
+                  "provider": 0
                 },
                 "renameByName": {
-                  "provider": "Provider",
-                  "Value": "Agreed %"
+                  "Value": "Agreed %",
+                  "provider": "Provider"
                 }
               }
             }
-          ]
+          ],
+          "type": "table"
         }
-      ]
+      ],
+      "title": "Data agreement",
+      "type": "row"
     },
     {
       "collapsed": true,
@@ -7337,6 +7337,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Base (US West)",
   "uid": "fe3mtxna6483ke-base-us-west",
-  "version": 94,
+  "version": 95,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-base.json
+++ b/dashboards/dashboards/compare-dashboard-base.json
@@ -1730,9 +1730,6 @@
       "type": "row"
     },
     {
-      "id": 300,
-      "type": "row",
-      "title": "Data agreement",
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
@@ -1744,43 +1741,14 @@
         "x": 0,
         "y": 34
       },
+      "id": 300,
       "panels": [
         {
-          "id": 301,
-          "type": "state-timeline",
-          "title": "Provider agreement",
-          "description": "Per provider, did this provider's answer match the majority answer in every region it participated in at this moment. Green - matched the majority everywhere. Red - was an outlier in at least one region. Grey - no data captured.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 18,
-            "x": 0,
-            "y": 36
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "alignValue": "left",
-            "annotations": {
-              "clustering": -1,
-              "multiLane": false
-            },
-            "legend": {
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "mergeValues": true,
-            "rowHeight": 0.8,
-            "showValue": "never",
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
+          "description": "Per provider, did this provider's answer match the majority answer in every region it participated in at this moment. Green - matched the majority everywhere. Red - was an outlier in at least one region. Grey - no data captured.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1801,7 +1769,6 @@
               "decimals": 0,
               "mappings": [
                 {
-                  "type": "special",
                   "options": {
                     "match": "null",
                     "result": {
@@ -1809,7 +1776,8 @@
                       "index": 0,
                       "text": "No data"
                     }
-                  }
+                  },
+                  "type": "special"
                 }
               ],
               "thresholds": {
@@ -1853,6 +1821,34 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 36
+          },
+          "id": 301,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1865,42 +1861,16 @@
               "range": true,
               "refId": "A"
             }
-          ]
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
         },
         {
-          "id": 302,
-          "type": "table",
-          "title": "Agreement summary",
-          "description": "For each provider in each region, the percentage of samples this provider returned that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 18,
-            "y": 36
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "cellHeight": "sm",
-            "showHeader": true,
-            "sortBy": [
-              {
-                "displayName": "Agreed %",
-                "desc": true
-              }
-            ],
-            "footer": {
-              "show": false,
-              "reducer": [
-                "sum"
-              ],
-              "countRows": false,
-              "fields": ""
-            }
-          },
+          "description": "For each provider in each region, the percentage of samples this provider returned that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1940,17 +1910,17 @@
                     "id": "mappings",
                     "value": [
                       {
-                        "type": "value",
                         "options": {
                           "Chainstack": {
-                            "text": "Chainstack-Growth",
-                            "index": 0
+                            "index": 0,
+                            "text": "Chainstack-Growth"
                           },
                           "dRPC": {
-                            "text": "dRPC-Growth",
-                            "index": 1
+                            "index": 1,
+                            "text": "dRPC-Growth"
                           }
-                        }
+                        },
+                        "type": "value"
                       }
                     ]
                   }
@@ -1970,21 +1940,21 @@
                     "id": "mappings",
                     "value": [
                       {
-                        "type": "value",
                         "options": {
                           "fra1": {
-                            "text": "EU",
-                            "index": 0
+                            "index": 0,
+                            "text": "EU"
                           },
                           "hnd1": {
-                            "text": "JP",
-                            "index": 1
+                            "index": 1,
+                            "text": "JP"
                           },
                           "sfo1": {
-                            "text": "US West",
-                            "index": 2
+                            "index": 2,
+                            "text": "US West"
                           }
-                        }
+                        },
+                        "type": "value"
                       }
                     ]
                   }
@@ -2042,6 +2012,32 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 36
+          },
+          "id": 302,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -2056,6 +2052,7 @@
               "refId": "A"
             }
           ],
+          "title": "Agreement summary",
           "transformations": [
             {
               "id": "organize",
@@ -2064,20 +2061,23 @@
                   "Time": true
                 },
                 "indexByName": {
+                  "Value": 2,
                   "provider": 0,
-                  "source_region": 1,
-                  "Value": 2
+                  "source_region": 1
                 },
                 "renameByName": {
+                  "Value": "Agreed %",
                   "provider": "Provider",
-                  "source_region": "Region",
-                  "Value": "Agreed %"
+                  "source_region": "Region"
                 }
               }
             }
-          ]
+          ],
+          "type": "table"
         }
-      ]
+      ],
+      "title": "Data agreement",
+      "type": "row"
     },
     {
       "collapsed": true,
@@ -4866,6 +4866,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Base",
   "uid": "fe3mtxna6483ke-base-global",
-  "version": 181,
+  "version": 182,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain-eu.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain-eu.json
@@ -1214,9 +1214,6 @@
       "type": "row"
     },
     {
-      "id": 1300,
-      "type": "row",
-      "title": "Data agreement",
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
@@ -1228,43 +1225,14 @@
         "x": 0,
         "y": 26
       },
+      "id": 1300,
       "panels": [
         {
-          "id": 1301,
-          "type": "state-timeline",
-          "title": "Provider agreement",
-          "description": "Per provider in this region (EU), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 18,
-            "x": 0,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "alignValue": "left",
-            "annotations": {
-              "clustering": -1,
-              "multiLane": false
-            },
-            "legend": {
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "mergeValues": true,
-            "rowHeight": 0.8,
-            "showValue": "never",
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
+          "description": "Per provider in this region (EU), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1285,7 +1253,6 @@
               "decimals": 0,
               "mappings": [
                 {
-                  "type": "special",
                   "options": {
                     "match": "null",
                     "result": {
@@ -1293,7 +1260,8 @@
                       "index": 0,
                       "text": "No data"
                     }
-                  }
+                  },
+                  "type": "special"
                 }
               ],
               "thresholds": {
@@ -1337,6 +1305,34 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "id": 1301,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1349,42 +1345,16 @@
               "range": true,
               "refId": "A"
             }
-          ]
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
         },
         {
-          "id": 1302,
-          "type": "table",
-          "title": "Agreement summary",
-          "description": "For each provider in this region (EU), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 18,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "cellHeight": "sm",
-            "showHeader": true,
-            "sortBy": [
-              {
-                "displayName": "Agreed %",
-                "desc": true
-              }
-            ],
-            "footer": {
-              "show": false,
-              "reducer": [
-                "sum"
-              ],
-              "countRows": false,
-              "fields": ""
-            }
-          },
+          "description": "For each provider in this region (EU), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1424,17 +1394,17 @@
                     "id": "mappings",
                     "value": [
                       {
-                        "type": "value",
                         "options": {
                           "Chainstack": {
-                            "text": "Chainstack-Growth",
-                            "index": 0
+                            "index": 0,
+                            "text": "Chainstack-Growth"
                           },
                           "dRPC": {
-                            "text": "dRPC-Growth",
-                            "index": 1
+                            "index": 1,
+                            "text": "dRPC-Growth"
                           }
-                        }
+                        },
+                        "type": "value"
                       }
                     ]
                   }
@@ -1492,6 +1462,32 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "id": 1302,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1506,6 +1502,7 @@
               "refId": "A"
             }
           ],
+          "title": "Agreement summary",
           "transformations": [
             {
               "id": "organize",
@@ -1514,18 +1511,21 @@
                   "Time": true
                 },
                 "indexByName": {
-                  "provider": 0,
-                  "Value": 1
+                  "Value": 1,
+                  "provider": 0
                 },
                 "renameByName": {
-                  "provider": "Provider",
-                  "Value": "Agreed %"
+                  "Value": "Agreed %",
+                  "provider": "Provider"
                 }
               }
             }
-          ]
+          ],
+          "type": "table"
         }
-      ]
+      ],
+      "title": "Data agreement",
+      "type": "row"
     },
     {
       "collapsed": true,
@@ -7333,6 +7333,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: BNB Smart Chain (EU)",
   "uid": "bnbsc-eu-1",
-  "version": 41,
+  "version": 42,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain-singapore.json
@@ -1214,9 +1214,6 @@
       "type": "row"
     },
     {
-      "id": 1300,
-      "type": "row",
-      "title": "Data agreement",
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
@@ -1228,43 +1225,14 @@
         "x": 0,
         "y": 26
       },
+      "id": 1300,
       "panels": [
         {
-          "id": 1301,
-          "type": "state-timeline",
-          "title": "Provider agreement",
-          "description": "Per provider in this region (SG), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 18,
-            "x": 0,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "alignValue": "left",
-            "annotations": {
-              "clustering": -1,
-              "multiLane": false
-            },
-            "legend": {
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "mergeValues": true,
-            "rowHeight": 0.8,
-            "showValue": "never",
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
+          "description": "Per provider in this region (SG), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1285,7 +1253,6 @@
               "decimals": 0,
               "mappings": [
                 {
-                  "type": "special",
                   "options": {
                     "match": "null",
                     "result": {
@@ -1293,7 +1260,8 @@
                       "index": 0,
                       "text": "No data"
                     }
-                  }
+                  },
+                  "type": "special"
                 }
               ],
               "thresholds": {
@@ -1337,6 +1305,34 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "id": 1301,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1349,42 +1345,16 @@
               "range": true,
               "refId": "A"
             }
-          ]
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
         },
         {
-          "id": 1302,
-          "type": "table",
-          "title": "Agreement summary",
-          "description": "For each provider in this region (SG), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 18,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "cellHeight": "sm",
-            "showHeader": true,
-            "sortBy": [
-              {
-                "displayName": "Agreed %",
-                "desc": true
-              }
-            ],
-            "footer": {
-              "show": false,
-              "reducer": [
-                "sum"
-              ],
-              "countRows": false,
-              "fields": ""
-            }
-          },
+          "description": "For each provider in this region (SG), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1424,17 +1394,17 @@
                     "id": "mappings",
                     "value": [
                       {
-                        "type": "value",
                         "options": {
                           "Chainstack": {
-                            "text": "Chainstack-Growth",
-                            "index": 0
+                            "index": 0,
+                            "text": "Chainstack-Growth"
                           },
                           "dRPC": {
-                            "text": "dRPC-Growth",
-                            "index": 1
+                            "index": 1,
+                            "text": "dRPC-Growth"
                           }
-                        }
+                        },
+                        "type": "value"
                       }
                     ]
                   }
@@ -1492,6 +1462,32 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "id": 1302,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1506,6 +1502,7 @@
               "refId": "A"
             }
           ],
+          "title": "Agreement summary",
           "transformations": [
             {
               "id": "organize",
@@ -1514,18 +1511,21 @@
                   "Time": true
                 },
                 "indexByName": {
-                  "provider": 0,
-                  "Value": 1
+                  "Value": 1,
+                  "provider": 0
                 },
                 "renameByName": {
-                  "provider": "Provider",
-                  "Value": "Agreed %"
+                  "Value": "Agreed %",
+                  "provider": "Provider"
                 }
               }
             }
-          ]
+          ],
+          "type": "table"
         }
-      ]
+      ],
+      "title": "Data agreement",
+      "type": "row"
     },
     {
       "collapsed": true,
@@ -7332,6 +7332,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: BNB Smart Chain (Singapore)",
   "uid": "bnbsc-sing-1",
-  "version": 39,
+  "version": 40,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain-us-west.json
@@ -1214,9 +1214,6 @@
       "type": "row"
     },
     {
-      "id": 1300,
-      "type": "row",
-      "title": "Data agreement",
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
@@ -1228,43 +1225,14 @@
         "x": 0,
         "y": 26
       },
+      "id": 1300,
       "panels": [
         {
-          "id": 1301,
-          "type": "state-timeline",
-          "title": "Provider agreement",
-          "description": "Per provider in this region (US West), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 18,
-            "x": 0,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "alignValue": "left",
-            "annotations": {
-              "clustering": -1,
-              "multiLane": false
-            },
-            "legend": {
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "mergeValues": true,
-            "rowHeight": 0.8,
-            "showValue": "never",
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
+          "description": "Per provider in this region (US West), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1285,7 +1253,6 @@
               "decimals": 0,
               "mappings": [
                 {
-                  "type": "special",
                   "options": {
                     "match": "null",
                     "result": {
@@ -1293,7 +1260,8 @@
                       "index": 0,
                       "text": "No data"
                     }
-                  }
+                  },
+                  "type": "special"
                 }
               ],
               "thresholds": {
@@ -1337,6 +1305,34 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "id": 1301,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1349,42 +1345,16 @@
               "range": true,
               "refId": "A"
             }
-          ]
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
         },
         {
-          "id": 1302,
-          "type": "table",
-          "title": "Agreement summary",
-          "description": "For each provider in this region (US West), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 18,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "cellHeight": "sm",
-            "showHeader": true,
-            "sortBy": [
-              {
-                "displayName": "Agreed %",
-                "desc": true
-              }
-            ],
-            "footer": {
-              "show": false,
-              "reducer": [
-                "sum"
-              ],
-              "countRows": false,
-              "fields": ""
-            }
-          },
+          "description": "For each provider in this region (US West), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1424,17 +1394,17 @@
                     "id": "mappings",
                     "value": [
                       {
-                        "type": "value",
                         "options": {
                           "Chainstack": {
-                            "text": "Chainstack-Growth",
-                            "index": 0
+                            "index": 0,
+                            "text": "Chainstack-Growth"
                           },
                           "dRPC": {
-                            "text": "dRPC-Growth",
-                            "index": 1
+                            "index": 1,
+                            "text": "dRPC-Growth"
                           }
-                        }
+                        },
+                        "type": "value"
                       }
                     ]
                   }
@@ -1492,6 +1462,32 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "id": 1302,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1506,6 +1502,7 @@
               "refId": "A"
             }
           ],
+          "title": "Agreement summary",
           "transformations": [
             {
               "id": "organize",
@@ -1514,18 +1511,21 @@
                   "Time": true
                 },
                 "indexByName": {
-                  "provider": 0,
-                  "Value": 1
+                  "Value": 1,
+                  "provider": 0
                 },
                 "renameByName": {
-                  "provider": "Provider",
-                  "Value": "Agreed %"
+                  "Value": "Agreed %",
+                  "provider": "Provider"
                 }
               }
             }
-          ]
+          ],
+          "type": "table"
         }
-      ]
+      ],
+      "title": "Data agreement",
+      "type": "row"
     },
     {
       "collapsed": true,
@@ -7336,6 +7336,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: BNB Smart Chain (US West)",
   "uid": "bnbsc-us-west-1",
-  "version": 40,
+  "version": 41,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain.json
@@ -1718,9 +1718,6 @@
       "type": "row"
     },
     {
-      "id": 300,
-      "type": "row",
-      "title": "Data agreement",
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
@@ -1732,43 +1729,14 @@
         "x": 0,
         "y": 34
       },
+      "id": 300,
       "panels": [
         {
-          "id": 301,
-          "type": "state-timeline",
-          "title": "Provider agreement",
-          "description": "Per provider, did this provider's answer match the majority answer in every region it participated in at this moment. Green - matched the majority everywhere. Red - was an outlier in at least one region. Grey - no data captured.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 18,
-            "x": 0,
-            "y": 36
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "alignValue": "left",
-            "annotations": {
-              "clustering": -1,
-              "multiLane": false
-            },
-            "legend": {
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "mergeValues": true,
-            "rowHeight": 0.8,
-            "showValue": "never",
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
+          "description": "Per provider, did this provider's answer match the majority answer in every region it participated in at this moment. Green - matched the majority everywhere. Red - was an outlier in at least one region. Grey - no data captured.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1789,7 +1757,6 @@
               "decimals": 0,
               "mappings": [
                 {
-                  "type": "special",
                   "options": {
                     "match": "null",
                     "result": {
@@ -1797,7 +1764,8 @@
                       "index": 0,
                       "text": "No data"
                     }
-                  }
+                  },
+                  "type": "special"
                 }
               ],
               "thresholds": {
@@ -1841,6 +1809,34 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 36
+          },
+          "id": 301,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1853,42 +1849,16 @@
               "range": true,
               "refId": "A"
             }
-          ]
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
         },
         {
-          "id": 302,
-          "type": "table",
-          "title": "Agreement summary",
-          "description": "For each provider in each region, the percentage of samples this provider returned that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 18,
-            "y": 36
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "cellHeight": "sm",
-            "showHeader": true,
-            "sortBy": [
-              {
-                "displayName": "Agreed %",
-                "desc": true
-              }
-            ],
-            "footer": {
-              "show": false,
-              "reducer": [
-                "sum"
-              ],
-              "countRows": false,
-              "fields": ""
-            }
-          },
+          "description": "For each provider in each region, the percentage of samples this provider returned that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1928,17 +1898,17 @@
                     "id": "mappings",
                     "value": [
                       {
-                        "type": "value",
                         "options": {
                           "Chainstack": {
-                            "text": "Chainstack-Growth",
-                            "index": 0
+                            "index": 0,
+                            "text": "Chainstack-Growth"
                           },
                           "dRPC": {
-                            "text": "dRPC-Growth",
-                            "index": 1
+                            "index": 1,
+                            "text": "dRPC-Growth"
                           }
-                        }
+                        },
+                        "type": "value"
                       }
                     ]
                   }
@@ -1958,21 +1928,21 @@
                     "id": "mappings",
                     "value": [
                       {
-                        "type": "value",
                         "options": {
                           "fra1": {
-                            "text": "EU",
-                            "index": 0
-                          },
-                          "sin1": {
-                            "text": "SG",
-                            "index": 1
+                            "index": 0,
+                            "text": "EU"
                           },
                           "sfo1": {
-                            "text": "US West",
-                            "index": 2
+                            "index": 2,
+                            "text": "US West"
+                          },
+                          "sin1": {
+                            "index": 1,
+                            "text": "SG"
                           }
-                        }
+                        },
+                        "type": "value"
                       }
                     ]
                   }
@@ -2030,6 +2000,32 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 36
+          },
+          "id": 302,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -2044,6 +2040,7 @@
               "refId": "A"
             }
           ],
+          "title": "Agreement summary",
           "transformations": [
             {
               "id": "organize",
@@ -2052,20 +2049,23 @@
                   "Time": true
                 },
                 "indexByName": {
+                  "Value": 2,
                   "provider": 0,
-                  "source_region": 1,
-                  "Value": 2
+                  "source_region": 1
                 },
                 "renameByName": {
+                  "Value": "Agreed %",
                   "provider": "Provider",
-                  "source_region": "Region",
-                  "Value": "Agreed %"
+                  "source_region": "Region"
                 }
               }
             }
-          ]
+          ],
+          "type": "table"
         }
-      ]
+      ],
+      "title": "Data agreement",
+      "type": "row"
     },
     {
       "collapsed": true,
@@ -4790,6 +4790,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: BNB Smart Chain",
   "uid": "bnbsc-global-1",
-  "version": 55,
+  "version": 56,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-ethereum-eu.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum-eu.json
@@ -1141,9 +1141,6 @@
       "type": "row"
     },
     {
-      "id": 1300,
-      "type": "row",
-      "title": "Data agreement",
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
@@ -1155,43 +1152,14 @@
         "x": 0,
         "y": 26
       },
+      "id": 1300,
       "panels": [
         {
-          "id": 1301,
-          "type": "state-timeline",
-          "title": "Provider agreement",
-          "description": "Per provider in this region (EU), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 18,
-            "x": 0,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "alignValue": "left",
-            "annotations": {
-              "clustering": -1,
-              "multiLane": false
-            },
-            "legend": {
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "mergeValues": true,
-            "rowHeight": 0.8,
-            "showValue": "never",
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
+          "description": "Per provider in this region (EU), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1212,7 +1180,6 @@
               "decimals": 0,
               "mappings": [
                 {
-                  "type": "special",
                   "options": {
                     "match": "null",
                     "result": {
@@ -1220,7 +1187,8 @@
                       "index": 0,
                       "text": "No data"
                     }
-                  }
+                  },
+                  "type": "special"
                 }
               ],
               "thresholds": {
@@ -1264,6 +1232,34 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "id": 1301,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1276,42 +1272,16 @@
               "range": true,
               "refId": "A"
             }
-          ]
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
         },
         {
-          "id": 1302,
-          "type": "table",
-          "title": "Agreement summary",
-          "description": "For each provider in this region (EU), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 18,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "cellHeight": "sm",
-            "showHeader": true,
-            "sortBy": [
-              {
-                "displayName": "Agreed %",
-                "desc": true
-              }
-            ],
-            "footer": {
-              "show": false,
-              "reducer": [
-                "sum"
-              ],
-              "countRows": false,
-              "fields": ""
-            }
-          },
+          "description": "For each provider in this region (EU), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1351,17 +1321,17 @@
                     "id": "mappings",
                     "value": [
                       {
-                        "type": "value",
                         "options": {
                           "Chainstack": {
-                            "text": "Chainstack-Growth",
-                            "index": 0
+                            "index": 0,
+                            "text": "Chainstack-Growth"
                           },
                           "dRPC": {
-                            "text": "dRPC-Growth",
-                            "index": 1
+                            "index": 1,
+                            "text": "dRPC-Growth"
                           }
-                        }
+                        },
+                        "type": "value"
                       }
                     ]
                   }
@@ -1419,6 +1389,32 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "id": 1302,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1433,6 +1429,7 @@
               "refId": "A"
             }
           ],
+          "title": "Agreement summary",
           "transformations": [
             {
               "id": "organize",
@@ -1441,18 +1438,21 @@
                   "Time": true
                 },
                 "indexByName": {
-                  "provider": 0,
-                  "Value": 1
+                  "Value": 1,
+                  "provider": 0
                 },
                 "renameByName": {
-                  "provider": "Provider",
-                  "Value": "Agreed %"
+                  "Value": "Agreed %",
+                  "provider": "Provider"
                 }
               }
             }
-          ]
+          ],
+          "type": "table"
         }
-      ]
+      ],
+      "title": "Data agreement",
+      "type": "row"
     },
     {
       "collapsed": true,
@@ -7260,6 +7260,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Ethereum (EU)",
   "uid": "fe3mtxna6483ke-eu",
-  "version": 89,
+  "version": 92,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-ethereum-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum-singapore.json
@@ -1215,9 +1215,6 @@
       "type": "row"
     },
     {
-      "id": 1300,
-      "type": "row",
-      "title": "Data agreement",
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
@@ -1229,43 +1226,14 @@
         "x": 0,
         "y": 26
       },
+      "id": 1300,
       "panels": [
         {
-          "id": 1301,
-          "type": "state-timeline",
-          "title": "Provider agreement",
-          "description": "Per provider in this region (SG), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 18,
-            "x": 0,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "alignValue": "left",
-            "annotations": {
-              "clustering": -1,
-              "multiLane": false
-            },
-            "legend": {
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "mergeValues": true,
-            "rowHeight": 0.8,
-            "showValue": "never",
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
+          "description": "Per provider in this region (SG), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1286,7 +1254,6 @@
               "decimals": 0,
               "mappings": [
                 {
-                  "type": "special",
                   "options": {
                     "match": "null",
                     "result": {
@@ -1294,7 +1261,8 @@
                       "index": 0,
                       "text": "No data"
                     }
-                  }
+                  },
+                  "type": "special"
                 }
               ],
               "thresholds": {
@@ -1338,6 +1306,34 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "id": 1301,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1350,42 +1346,16 @@
               "range": true,
               "refId": "A"
             }
-          ]
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
         },
         {
-          "id": 1302,
-          "type": "table",
-          "title": "Agreement summary",
-          "description": "For each provider in this region (SG), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 18,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "cellHeight": "sm",
-            "showHeader": true,
-            "sortBy": [
-              {
-                "displayName": "Agreed %",
-                "desc": true
-              }
-            ],
-            "footer": {
-              "show": false,
-              "reducer": [
-                "sum"
-              ],
-              "countRows": false,
-              "fields": ""
-            }
-          },
+          "description": "For each provider in this region (SG), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1425,17 +1395,17 @@
                     "id": "mappings",
                     "value": [
                       {
-                        "type": "value",
                         "options": {
                           "Chainstack": {
-                            "text": "Chainstack-Growth",
-                            "index": 0
+                            "index": 0,
+                            "text": "Chainstack-Growth"
                           },
                           "dRPC": {
-                            "text": "dRPC-Growth",
-                            "index": 1
+                            "index": 1,
+                            "text": "dRPC-Growth"
                           }
-                        }
+                        },
+                        "type": "value"
                       }
                     ]
                   }
@@ -1493,6 +1463,32 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "id": 1302,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1507,6 +1503,7 @@
               "refId": "A"
             }
           ],
+          "title": "Agreement summary",
           "transformations": [
             {
               "id": "organize",
@@ -1515,18 +1512,21 @@
                   "Time": true
                 },
                 "indexByName": {
-                  "provider": 0,
-                  "Value": 1
+                  "Value": 1,
+                  "provider": 0
                 },
                 "renameByName": {
-                  "provider": "Provider",
-                  "Value": "Agreed %"
+                  "Value": "Agreed %",
+                  "provider": "Provider"
                 }
               }
             }
-          ]
+          ],
+          "type": "table"
         }
-      ]
+      ],
+      "title": "Data agreement",
+      "type": "row"
     },
     {
       "collapsed": true,
@@ -7333,6 +7333,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Ethereum (Singapore)",
   "uid": "ssss-sing",
-  "version": 61,
+  "version": 64,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-ethereum-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum-us-west.json
@@ -1215,9 +1215,6 @@
       "type": "row"
     },
     {
-      "id": 1300,
-      "type": "row",
-      "title": "Data agreement",
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
@@ -1229,43 +1226,14 @@
         "x": 0,
         "y": 26
       },
+      "id": 1300,
       "panels": [
         {
-          "id": 1301,
-          "type": "state-timeline",
-          "title": "Provider agreement",
-          "description": "Per provider in this region (US West), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 18,
-            "x": 0,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "alignValue": "left",
-            "annotations": {
-              "clustering": -1,
-              "multiLane": false
-            },
-            "legend": {
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "mergeValues": true,
-            "rowHeight": 0.8,
-            "showValue": "never",
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
+          "description": "Per provider in this region (US West), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1286,7 +1254,6 @@
               "decimals": 0,
               "mappings": [
                 {
-                  "type": "special",
                   "options": {
                     "match": "null",
                     "result": {
@@ -1294,7 +1261,8 @@
                       "index": 0,
                       "text": "No data"
                     }
-                  }
+                  },
+                  "type": "special"
                 }
               ],
               "thresholds": {
@@ -1338,6 +1306,34 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "id": 1301,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1350,42 +1346,16 @@
               "range": true,
               "refId": "A"
             }
-          ]
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
         },
         {
-          "id": 1302,
-          "type": "table",
-          "title": "Agreement summary",
-          "description": "For each provider in this region (US West), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 18,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "cellHeight": "sm",
-            "showHeader": true,
-            "sortBy": [
-              {
-                "displayName": "Agreed %",
-                "desc": true
-              }
-            ],
-            "footer": {
-              "show": false,
-              "reducer": [
-                "sum"
-              ],
-              "countRows": false,
-              "fields": ""
-            }
-          },
+          "description": "For each provider in this region (US West), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1425,17 +1395,17 @@
                     "id": "mappings",
                     "value": [
                       {
-                        "type": "value",
                         "options": {
                           "Chainstack": {
-                            "text": "Chainstack-Growth",
-                            "index": 0
+                            "index": 0,
+                            "text": "Chainstack-Growth"
                           },
                           "dRPC": {
-                            "text": "dRPC-Growth",
-                            "index": 1
+                            "index": 1,
+                            "text": "dRPC-Growth"
                           }
-                        }
+                        },
+                        "type": "value"
                       }
                     ]
                   }
@@ -1493,6 +1463,32 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "id": 1302,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1507,6 +1503,7 @@
               "refId": "A"
             }
           ],
+          "title": "Agreement summary",
           "transformations": [
             {
               "id": "organize",
@@ -1515,18 +1512,21 @@
                   "Time": true
                 },
                 "indexByName": {
-                  "provider": 0,
-                  "Value": 1
+                  "Value": 1,
+                  "provider": 0
                 },
                 "renameByName": {
-                  "provider": "Provider",
-                  "Value": "Agreed %"
+                  "Value": "Agreed %",
+                  "provider": "Provider"
                 }
               }
             }
-          ]
+          ],
+          "type": "table"
         }
-      ]
+      ],
+      "title": "Data agreement",
+      "type": "row"
     },
     {
       "collapsed": true,
@@ -7333,6 +7333,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Ethereum (US West)",
   "uid": "fe3mtxna6483ke",
-  "version": 276,
+  "version": 279,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-ethereum.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum.json
@@ -1696,9 +1696,6 @@
       "type": "row"
     },
     {
-      "id": 300,
-      "type": "row",
-      "title": "Data agreement",
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
@@ -1710,43 +1707,14 @@
         "x": 0,
         "y": 35
       },
+      "id": 300,
       "panels": [
         {
-          "id": 301,
-          "type": "state-timeline",
-          "title": "Provider agreement",
-          "description": "Per provider, did this provider's answer match the majority answer in every region it participated in at this moment. Green - matched the majority everywhere. Red - was an outlier in at least one region. Grey - no data captured.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 18,
-            "x": 0,
-            "y": 37
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "alignValue": "left",
-            "annotations": {
-              "clustering": -1,
-              "multiLane": false
-            },
-            "legend": {
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "mergeValues": true,
-            "rowHeight": 0.8,
-            "showValue": "never",
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
+          "description": "Per provider, did this provider's answer match the majority answer in every region it participated in at this moment. Green - matched the majority everywhere. Red - was an outlier in at least one region. Grey - no data captured.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1767,7 +1735,6 @@
               "decimals": 0,
               "mappings": [
                 {
-                  "type": "special",
                   "options": {
                     "match": "null",
                     "result": {
@@ -1775,7 +1742,8 @@
                       "index": 0,
                       "text": "No data"
                     }
-                  }
+                  },
+                  "type": "special"
                 }
               ],
               "thresholds": {
@@ -1819,6 +1787,34 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 37
+          },
+          "id": 301,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1831,42 +1827,16 @@
               "range": true,
               "refId": "A"
             }
-          ]
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
         },
         {
-          "id": 302,
-          "type": "table",
-          "title": "Agreement summary",
-          "description": "For each provider in each region, the percentage of samples this provider returned that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 18,
-            "y": 37
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "cellHeight": "sm",
-            "showHeader": true,
-            "sortBy": [
-              {
-                "displayName": "Agreed %",
-                "desc": true
-              }
-            ],
-            "footer": {
-              "show": false,
-              "reducer": [
-                "sum"
-              ],
-              "countRows": false,
-              "fields": ""
-            }
-          },
+          "description": "For each provider in each region, the percentage of samples this provider returned that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1906,17 +1876,17 @@
                     "id": "mappings",
                     "value": [
                       {
-                        "type": "value",
                         "options": {
                           "Chainstack": {
-                            "text": "Chainstack-Growth",
-                            "index": 0
+                            "index": 0,
+                            "text": "Chainstack-Growth"
                           },
                           "dRPC": {
-                            "text": "dRPC-Growth",
-                            "index": 1
+                            "index": 1,
+                            "text": "dRPC-Growth"
                           }
-                        }
+                        },
+                        "type": "value"
                       }
                     ]
                   }
@@ -1936,21 +1906,21 @@
                     "id": "mappings",
                     "value": [
                       {
-                        "type": "value",
                         "options": {
                           "fra1": {
-                            "text": "EU",
-                            "index": 0
-                          },
-                          "sin1": {
-                            "text": "SG",
-                            "index": 1
+                            "index": 0,
+                            "text": "EU"
                           },
                           "sfo1": {
-                            "text": "US West",
-                            "index": 2
+                            "index": 2,
+                            "text": "US West"
+                          },
+                          "sin1": {
+                            "index": 1,
+                            "text": "SG"
                           }
-                        }
+                        },
+                        "type": "value"
                       }
                     ]
                   }
@@ -2008,6 +1978,32 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 37
+          },
+          "id": 302,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -2022,6 +2018,7 @@
               "refId": "A"
             }
           ],
+          "title": "Agreement summary",
           "transformations": [
             {
               "id": "organize",
@@ -2030,20 +2027,23 @@
                   "Time": true
                 },
                 "indexByName": {
+                  "Value": 2,
                   "provider": 0,
-                  "source_region": 1,
-                  "Value": 2
+                  "source_region": 1
                 },
                 "renameByName": {
+                  "Value": "Agreed %",
                   "provider": "Provider",
-                  "source_region": "Region",
-                  "Value": "Agreed %"
+                  "source_region": "Region"
                 }
               }
             }
-          ]
+          ],
+          "type": "table"
         }
-      ]
+      ],
+      "title": "Data agreement",
+      "type": "row"
     },
     {
       "collapsed": true,
@@ -4779,6 +4779,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Ethereum",
   "uid": "fe3mtxna6483ke-global",
-  "version": 106,
+  "version": 114,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-monad-eu.json
+++ b/dashboards/dashboards/compare-dashboard-monad-eu.json
@@ -1219,9 +1219,6 @@
       "type": "row"
     },
     {
-      "id": 1300,
-      "type": "row",
-      "title": "Data agreement",
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
@@ -1233,43 +1230,14 @@
         "x": 0,
         "y": 26
       },
+      "id": 1300,
       "panels": [
         {
-          "id": 1301,
-          "type": "state-timeline",
-          "title": "Provider agreement",
-          "description": "Per provider in this region (EU), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 18,
-            "x": 0,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "alignValue": "left",
-            "annotations": {
-              "clustering": -1,
-              "multiLane": false
-            },
-            "legend": {
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "mergeValues": true,
-            "rowHeight": 0.8,
-            "showValue": "never",
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
+          "description": "Per provider in this region (EU), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1290,7 +1258,6 @@
               "decimals": 0,
               "mappings": [
                 {
-                  "type": "special",
                   "options": {
                     "match": "null",
                     "result": {
@@ -1298,7 +1265,8 @@
                       "index": 0,
                       "text": "No data"
                     }
-                  }
+                  },
+                  "type": "special"
                 }
               ],
               "thresholds": {
@@ -1342,6 +1310,34 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "id": 1301,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1354,42 +1350,16 @@
               "range": true,
               "refId": "A"
             }
-          ]
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
         },
         {
-          "id": 1302,
-          "type": "table",
-          "title": "Agreement summary",
-          "description": "For each provider in this region (EU), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 18,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "cellHeight": "sm",
-            "showHeader": true,
-            "sortBy": [
-              {
-                "displayName": "Agreed %",
-                "desc": true
-              }
-            ],
-            "footer": {
-              "show": false,
-              "reducer": [
-                "sum"
-              ],
-              "countRows": false,
-              "fields": ""
-            }
-          },
+          "description": "For each provider in this region (EU), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1429,17 +1399,17 @@
                     "id": "mappings",
                     "value": [
                       {
-                        "type": "value",
                         "options": {
                           "Chainstack": {
-                            "text": "Chainstack-Growth",
-                            "index": 0
+                            "index": 0,
+                            "text": "Chainstack-Growth"
                           },
                           "dRPC": {
-                            "text": "dRPC-Growth",
-                            "index": 1
+                            "index": 1,
+                            "text": "dRPC-Growth"
                           }
-                        }
+                        },
+                        "type": "value"
                       }
                     ]
                   }
@@ -1497,6 +1467,32 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "id": 1302,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1511,6 +1507,7 @@
               "refId": "A"
             }
           ],
+          "title": "Agreement summary",
           "transformations": [
             {
               "id": "organize",
@@ -1519,18 +1516,21 @@
                   "Time": true
                 },
                 "indexByName": {
-                  "provider": 0,
-                  "Value": 1
+                  "Value": 1,
+                  "provider": 0
                 },
                 "renameByName": {
-                  "provider": "Provider",
-                  "Value": "Agreed %"
+                  "Value": "Agreed %",
+                  "provider": "Provider"
                 }
               }
             }
-          ]
+          ],
+          "type": "table"
         }
-      ]
+      ],
+      "title": "Data agreement",
+      "type": "row"
     },
     {
       "collapsed": true,
@@ -7373,6 +7373,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Monad (EU)",
   "uid": "monad-eu-1",
-  "version": 27,
+  "version": 28,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-monad-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-monad-singapore.json
@@ -1218,9 +1218,6 @@
       "type": "row"
     },
     {
-      "id": 1300,
-      "type": "row",
-      "title": "Data agreement",
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
@@ -1232,43 +1229,14 @@
         "x": 0,
         "y": 26
       },
+      "id": 1300,
       "panels": [
         {
-          "id": 1301,
-          "type": "state-timeline",
-          "title": "Provider agreement",
-          "description": "Per provider in this region (SG), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 18,
-            "x": 0,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "alignValue": "left",
-            "annotations": {
-              "clustering": -1,
-              "multiLane": false
-            },
-            "legend": {
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "mergeValues": true,
-            "rowHeight": 0.8,
-            "showValue": "never",
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
+          "description": "Per provider in this region (SG), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1289,7 +1257,6 @@
               "decimals": 0,
               "mappings": [
                 {
-                  "type": "special",
                   "options": {
                     "match": "null",
                     "result": {
@@ -1297,7 +1264,8 @@
                       "index": 0,
                       "text": "No data"
                     }
-                  }
+                  },
+                  "type": "special"
                 }
               ],
               "thresholds": {
@@ -1341,6 +1309,34 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "id": 1301,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1353,42 +1349,16 @@
               "range": true,
               "refId": "A"
             }
-          ]
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
         },
         {
-          "id": 1302,
-          "type": "table",
-          "title": "Agreement summary",
-          "description": "For each provider in this region (SG), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 18,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "cellHeight": "sm",
-            "showHeader": true,
-            "sortBy": [
-              {
-                "displayName": "Agreed %",
-                "desc": true
-              }
-            ],
-            "footer": {
-              "show": false,
-              "reducer": [
-                "sum"
-              ],
-              "countRows": false,
-              "fields": ""
-            }
-          },
+          "description": "For each provider in this region (SG), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1428,17 +1398,17 @@
                     "id": "mappings",
                     "value": [
                       {
-                        "type": "value",
                         "options": {
                           "Chainstack": {
-                            "text": "Chainstack-Growth",
-                            "index": 0
+                            "index": 0,
+                            "text": "Chainstack-Growth"
                           },
                           "dRPC": {
-                            "text": "dRPC-Growth",
-                            "index": 1
+                            "index": 1,
+                            "text": "dRPC-Growth"
                           }
-                        }
+                        },
+                        "type": "value"
                       }
                     ]
                   }
@@ -1496,6 +1466,32 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "id": 1302,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1510,6 +1506,7 @@
               "refId": "A"
             }
           ],
+          "title": "Agreement summary",
           "transformations": [
             {
               "id": "organize",
@@ -1518,18 +1515,21 @@
                   "Time": true
                 },
                 "indexByName": {
-                  "provider": 0,
-                  "Value": 1
+                  "Value": 1,
+                  "provider": 0
                 },
                 "renameByName": {
-                  "provider": "Provider",
-                  "Value": "Agreed %"
+                  "Value": "Agreed %",
+                  "provider": "Provider"
                 }
               }
             }
-          ]
+          ],
+          "type": "table"
         }
-      ]
+      ],
+      "title": "Data agreement",
+      "type": "row"
     },
     {
       "collapsed": true,
@@ -7348,6 +7348,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Monad (Singapore)",
   "uid": "monad-asia-1",
-  "version": 32,
+  "version": 33,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-monad-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-monad-us-west.json
@@ -1216,9 +1216,6 @@
       "type": "row"
     },
     {
-      "id": 1300,
-      "type": "row",
-      "title": "Data agreement",
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
@@ -1230,43 +1227,14 @@
         "x": 0,
         "y": 26
       },
+      "id": 1300,
       "panels": [
         {
-          "id": 1301,
-          "type": "state-timeline",
-          "title": "Provider agreement",
-          "description": "Per provider in this region (US West), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 18,
-            "x": 0,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "alignValue": "left",
-            "annotations": {
-              "clustering": -1,
-              "multiLane": false
-            },
-            "legend": {
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "mergeValues": true,
-            "rowHeight": 0.8,
-            "showValue": "never",
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
+          "description": "Per provider in this region (US West), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1287,7 +1255,6 @@
               "decimals": 0,
               "mappings": [
                 {
-                  "type": "special",
                   "options": {
                     "match": "null",
                     "result": {
@@ -1295,7 +1262,8 @@
                       "index": 0,
                       "text": "No data"
                     }
-                  }
+                  },
+                  "type": "special"
                 }
               ],
               "thresholds": {
@@ -1339,6 +1307,34 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 39
+          },
+          "id": 1301,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1351,42 +1347,16 @@
               "range": true,
               "refId": "A"
             }
-          ]
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
         },
         {
-          "id": 1302,
-          "type": "table",
-          "title": "Agreement summary",
-          "description": "For each provider in this region (US West), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 18,
-            "y": 39
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "cellHeight": "sm",
-            "showHeader": true,
-            "sortBy": [
-              {
-                "displayName": "Agreed %",
-                "desc": true
-              }
-            ],
-            "footer": {
-              "show": false,
-              "reducer": [
-                "sum"
-              ],
-              "countRows": false,
-              "fields": ""
-            }
-          },
+          "description": "For each provider in this region (US West), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1426,17 +1396,17 @@
                     "id": "mappings",
                     "value": [
                       {
-                        "type": "value",
                         "options": {
                           "Chainstack": {
-                            "text": "Chainstack-Growth",
-                            "index": 0
+                            "index": 0,
+                            "text": "Chainstack-Growth"
                           },
                           "dRPC": {
-                            "text": "dRPC-Growth",
-                            "index": 1
+                            "index": 1,
+                            "text": "dRPC-Growth"
                           }
-                        }
+                        },
+                        "type": "value"
                       }
                     ]
                   }
@@ -1494,6 +1464,32 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 39
+          },
+          "id": 1302,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1508,6 +1504,7 @@
               "refId": "A"
             }
           ],
+          "title": "Agreement summary",
           "transformations": [
             {
               "id": "organize",
@@ -1516,18 +1513,21 @@
                   "Time": true
                 },
                 "indexByName": {
-                  "provider": 0,
-                  "Value": 1
+                  "Value": 1,
+                  "provider": 0
                 },
                 "renameByName": {
-                  "provider": "Provider",
-                  "Value": "Agreed %"
+                  "Value": "Agreed %",
+                  "provider": "Provider"
                 }
               }
             }
-          ]
+          ],
+          "type": "table"
         }
-      ]
+      ],
+      "title": "Data agreement",
+      "type": "row"
     },
     {
       "collapsed": true,
@@ -7346,6 +7346,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Monad (US West)",
   "uid": "monad-us-west-1",
-  "version": 27,
+  "version": 28,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-monad.json
+++ b/dashboards/dashboards/compare-dashboard-monad.json
@@ -1762,9 +1762,6 @@
       "type": "row"
     },
     {
-      "id": 300,
-      "type": "row",
-      "title": "Data agreement",
       "collapsed": true,
       "datasource": {
         "type": "prometheus",
@@ -1776,43 +1773,14 @@
         "x": 0,
         "y": 36
       },
+      "id": 300,
       "panels": [
         {
-          "id": 301,
-          "type": "state-timeline",
-          "title": "Provider agreement",
-          "description": "Per provider, did this provider's answer match the majority answer in every region it participated in at this moment. Green - matched the majority everywhere. Red - was an outlier in at least one region. Grey - no data captured.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 18,
-            "x": 0,
-            "y": 38
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "alignValue": "left",
-            "annotations": {
-              "clustering": -1,
-              "multiLane": false
-            },
-            "legend": {
-              "displayMode": "list",
-              "placement": "bottom",
-              "showLegend": true
-            },
-            "mergeValues": true,
-            "rowHeight": 0.8,
-            "showValue": "never",
-            "tooltip": {
-              "hideZeros": false,
-              "mode": "single",
-              "sort": "none"
-            }
-          },
+          "description": "Per provider, did this provider's answer match the majority answer in every region it participated in at this moment. Green - matched the majority everywhere. Red - was an outlier in at least one region. Grey - no data captured.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1833,7 +1801,6 @@
               "decimals": 0,
               "mappings": [
                 {
-                  "type": "special",
                   "options": {
                     "match": "null",
                     "result": {
@@ -1841,7 +1808,8 @@
                       "index": 0,
                       "text": "No data"
                     }
-                  }
+                  },
+                  "type": "special"
                 }
               ],
               "thresholds": {
@@ -1885,6 +1853,34 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 38
+          },
+          "id": 301,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -1897,42 +1893,16 @@
               "range": true,
               "refId": "A"
             }
-          ]
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
         },
         {
-          "id": 302,
-          "type": "table",
-          "title": "Agreement summary",
-          "description": "For each provider in each region, the percentage of samples this provider returned that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "datasource": {
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "gridPos": {
-            "h": 8,
-            "w": 6,
-            "x": 18,
-            "y": 38
-          },
-          "pluginVersion": "13.1.0-24455754975",
-          "options": {
-            "cellHeight": "sm",
-            "showHeader": true,
-            "sortBy": [
-              {
-                "displayName": "Agreed %",
-                "desc": true
-              }
-            ],
-            "footer": {
-              "show": false,
-              "reducer": [
-                "sum"
-              ],
-              "countRows": false,
-              "fields": ""
-            }
-          },
+          "description": "For each provider in each region, the percentage of samples this provider returned that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1972,17 +1942,17 @@
                     "id": "mappings",
                     "value": [
                       {
-                        "type": "value",
                         "options": {
                           "Chainstack": {
-                            "text": "Chainstack-Growth",
-                            "index": 0
+                            "index": 0,
+                            "text": "Chainstack-Growth"
                           },
                           "dRPC": {
-                            "text": "dRPC-Growth",
-                            "index": 1
+                            "index": 1,
+                            "text": "dRPC-Growth"
                           }
-                        }
+                        },
+                        "type": "value"
                       }
                     ]
                   }
@@ -2002,21 +1972,21 @@
                     "id": "mappings",
                     "value": [
                       {
-                        "type": "value",
                         "options": {
                           "fra1": {
-                            "text": "EU",
-                            "index": 0
-                          },
-                          "sin1": {
-                            "text": "SG",
-                            "index": 1
+                            "index": 0,
+                            "text": "EU"
                           },
                           "sfo1": {
-                            "text": "US West",
-                            "index": 2
+                            "index": 2,
+                            "text": "US West"
+                          },
+                          "sin1": {
+                            "index": 1,
+                            "text": "SG"
                           }
-                        }
+                        },
+                        "type": "value"
                       }
                     ]
                   }
@@ -2074,6 +2044,32 @@
               }
             ]
           },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 38
+          },
+          "id": 302,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -2088,6 +2084,7 @@
               "refId": "A"
             }
           ],
+          "title": "Agreement summary",
           "transformations": [
             {
               "id": "organize",
@@ -2096,20 +2093,23 @@
                   "Time": true
                 },
                 "indexByName": {
+                  "Value": 2,
                   "provider": 0,
-                  "source_region": 1,
-                  "Value": 2
+                  "source_region": 1
                 },
                 "renameByName": {
+                  "Value": "Agreed %",
                   "provider": "Provider",
-                  "source_region": "Region",
-                  "Value": "Agreed %"
+                  "source_region": "Region"
                 }
               }
             }
-          ]
+          ],
+          "type": "table"
         }
-      ]
+      ],
+      "title": "Data agreement",
+      "type": "row"
     },
     {
       "collapsed": true,
@@ -4965,6 +4965,6 @@
   "timezone": "browser",
   "title": "Compare Dashboard: Monad",
   "uid": "monad-global-1",
-  "version": 32,
+  "version": 33,
   "weekStart": "monday"
 }

--- a/dashboards/dashboards/compare-dashboard-solana-eu.json
+++ b/dashboards/dashboards/compare-dashboard-solana-eu.json
@@ -2788,7 +2788,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Number of slots between transaction submission and confirmation, both using confirmed commitment level. Lower values indicate faster transaction landing on chain.\n\nTransactions are sent every 15 minutes. Compute unit price (priority fee) fixed at 200,000 microlamports per compute unit.\n\nChainstack-Default means a default Solana RPC endpoint (not bloXroute) under Growth plan.\n\nChainstack-Warp means a Solana Trader Node (bloXroute) under Growth plan.\n\nHelius-Default means a default Solana RPC endpoint (staked) under Developer plan.",
+          "description": "Number of slots between transaction submission and confirmation, both using confirmed commitment level. Lower values indicate faster transaction landing on chain.\n\nTransactions are sent every 15 minutes. Compute unit price (priority fee) fixed at 200,000 microlamports per compute unit.\n\nChainstack-Default means a default Solana RPC endpoint (not bloXroute) under Growth plan.\n\nChainstack-Warp means a Solana Trader Node (bloXroute) under Growth plan.\n\nHelius-Default means a default Solana RPC endpoint (staked) under Developer plan.\n\nP2P-Syncro means P2P.org Syncro Sender (public endpoint) with a 100,000 lamport tip per tx.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -2956,99 +2956,105 @@
           "description": "The success rate of transaction landing, calculated by dividing successful confirmations by total attempts over the selected time range. Data grouped by provider and displayed as a percentage.\n\nChainstack-Default means a default Solana RPC endpoint (not bloXroute) under Growth plan.\n\nChainstack-Warp means a Solana Trader Node (bloXroute) under Growth plan.\n\nHelius-Default means a default Solana RPC endpoint (staked) under Developer plan.",
           "fieldConfig": {
             "defaults": {
-              "color": {
-                "fixedColor": "super-light-blue",
-                "mode": "continuous-YlBl"
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "footer": {
+                  "reducers": []
+                },
+                "inspect": false,
+                "minWidth": 110
               },
-              "mappings": [],
-              "max": 1,
-              "min": 0,
               "thresholds": {
                 "mode": "absolute",
                 "steps": [
                   {
-                    "color": "green"
+                    "color": "green",
+                    "value": 0
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
                   }
                 ]
-              },
-              "unit": "percentunit"
+              }
             },
             "overrides": [
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack"
+                  "options": "Provider"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Default"
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Default"
+                          },
+                          "Chainstack_tx": {
+                            "index": 1,
+                            "text": "Chainstack-Warp"
+                          },
+                          "Helius-Developer": {
+                            "index": 2,
+                            "text": "Helius-Default"
+                          },
+                          "dRPC": {
+                            "index": 3,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  },
+                  {
+                    "id": "custom.width",
+                    "value": 150
                   }
                 ]
               },
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Chainstack_tx"
+                  "options": "Success Rate"
                 },
                 "properties": [
                   {
-                    "id": "displayName",
-                    "value": "Chainstack-Warp"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Helius-Developer"
-                },
-                "properties": [
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
                   {
-                    "id": "displayName",
-                    "value": "Helius-Default"
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Helius-Developer_tx"
-                },
-                "properties": [
+                    "id": "decimals",
+                    "value": 2
+                  },
                   {
-                    "id": "displayName",
-                    "value": "Helius-Staked"
+                    "id": "custom.width",
+                    "value": 90
                   }
                 ]
               }
             ]
           },
           "gridPos": {
-            "h": 8,
-            "w": 4,
-            "x": 20,
-            "y": 42
+            "h": 12,
+            "w": 6,
+            "x": 18,
+            "y": 38
           },
           "id": 72,
           "options": {
-            "colorMode": "value",
-            "graphMode": "none",
-            "justifyMode": "auto",
-            "orientation": "horizontal",
-            "percentChangeColorMode": "standard",
-            "reduceOptions": {
-              "calcs": [
-                "lastNotNull"
-              ],
-              "fields": "",
-              "values": false
-            },
-            "showPercentChange": false,
-            "textMode": "auto",
-            "wideLayout": true
+            "cellHeight": "sm",
+            "showHeader": false,
+            "sortBy": []
           },
-          "pluginVersion": "12.1.0-88106",
+          "pluginVersion": "13.1.0-24455754975",
           "targets": [
             {
               "datasource": {
@@ -3058,18 +3064,47 @@
               "disableTextWrap": false,
               "editorMode": "code",
               "expr": "sum(count_over_time(transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", metric_type=\"slot_latency\", api_method=\"sendTransaction\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", metric_type=\"slot_latency\", api_method=\"sendTransaction\"}[$__range])) by (provider)",
+              "format": "table",
               "fullMetaSearch": false,
               "includeNullMetadata": true,
-              "instant": false,
+              "instant": true,
               "interval": "",
-              "legendFormat": "{{provider}}",
-              "range": true,
               "refId": "A",
               "useBackend": false
             }
           ],
           "title": "Landing rate",
-          "type": "stat"
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Success Rate",
+                  "provider": "Provider"
+                }
+              }
+            },
+            {
+              "id": "sortBy",
+              "options": {
+                "fields": {},
+                "sort": [
+                  {
+                    "desc": false,
+                    "field": "Provider"
+                  }
+                ]
+              }
+            }
+          ],
+          "type": "table"
         },
         {
           "gridPos": {
@@ -4119,6 +4154,429 @@
             {
               "id": "joinByField",
               "options": {}
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "includeByName": {},
+                "indexByName": {},
+                "renameByName": {
+                  "Value #1": "",
+                  "Value #2-5": "",
+                  "Value #6-10": "",
+                  "Value #>11": ""
+                }
+              }
+            },
+            {
+              "id": "transpose",
+              "options": {
+                "firstFieldName": "",
+                "restFieldsName": ""
+              }
+            }
+          ],
+          "type": "piechart"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Transactions are sent through P2P.org Syncro Sender (public endpoint) with a 100,000 lamport tip per tx.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "semi-dark-blue",
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "Value #1": {
+                      "index": 0,
+                      "text": "Slot 1"
+                    },
+                    "Value #2-3": {
+                      "index": 1,
+                      "text": "Slots 2-3"
+                    },
+                    "Value #4-5": {
+                      "index": 2,
+                      "text": "Slots 4-5"
+                    },
+                    "Value #6-10": {
+                      "index": 3,
+                      "text": "Slots 6-10"
+                    },
+                    "Value #>11": {
+                      "index": 4,
+                      "text": "Slots >11"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "unit": "none"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 12,
+            "y": 59
+          },
+          "id": 1010,
+          "options": {
+            "displayLabels": [],
+            "legend": {
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "values": [
+                "percent"
+              ]
+            },
+            "pieType": "donut",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "/^1$/",
+              "values": true
+            },
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "12.1.0-88106",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(\r\n  count_over_time(\r\n    (transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", provider=\"P2P-Syncro\", metric_type=\"slot_latency\", response_status=\"success\"} == 1)[${__range}:1m]\r\n  )\r\n)",
+              "format": "table",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "1",
+              "range": false,
+              "refId": "1",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(\r\n  count_over_time(\r\n    (transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", provider=\"P2P-Syncro\", metric_type=\"slot_latency\", response_status=\"success\"} >= 2 and \r\n    transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", provider=\"P2P-Syncro\", metric_type=\"slot_latency\", response_status=\"success\"} <= 3)[${__range}:1m]\r\n  )\r\n)",
+              "format": "table",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "2-5",
+              "range": false,
+              "refId": "2-3",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(\r\n  count_over_time(\r\n    (transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", provider=\"P2P-Syncro\", metric_type=\"slot_latency\", response_status=\"success\"} >= 4 and \r\n    transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", provider=\"P2P-Syncro\", metric_type=\"slot_latency\", response_status=\"success\"} <= 5)[${__range}:1m]\r\n  )\r\n)",
+              "format": "table",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "6-10",
+              "range": false,
+              "refId": "4-5",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(\r\n  count_over_time(\r\n    (transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", provider=\"P2P-Syncro\", metric_type=\"slot_latency\", response_status=\"success\"} >= 6 and \r\n    transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", provider=\"P2P-Syncro\", metric_type=\"slot_latency\", response_status=\"success\"} <= 10)[${__range}:1m]\r\n  )\r\n)",
+              "format": "table",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "6-10",
+              "range": false,
+              "refId": "6-10",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(\r\n  count_over_time(\r\n    (transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", provider=\"P2P-Syncro\", metric_type=\"slot_latency\", response_status=\"success\"} >= 11)[${__range}:1m]\r\n  )\r\n)",
+              "format": "table",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": true,
+              "interval": "",
+              "legendFormat": ">11",
+              "range": false,
+              "refId": ">11",
+              "useBackend": false
+            }
+          ],
+          "title": "P2P-Syncro",
+          "transformations": [
+            {
+              "id": "joinByField",
+              "options": {}
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "includeByName": {},
+                "indexByName": {},
+                "renameByName": {
+                  "Value #1": "",
+                  "Value #2-5": "",
+                  "Value #6-10": "",
+                  "Value #>11": ""
+                }
+              }
+            },
+            {
+              "id": "transpose",
+              "options": {
+                "firstFieldName": "",
+                "restFieldsName": ""
+              }
+            }
+          ],
+          "type": "piechart"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "semi-dark-blue",
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "Value #1": {
+                      "index": 0,
+                      "text": "Slot 1"
+                    },
+                    "Value #2-3": {
+                      "index": 1,
+                      "text": "Slots 2-3"
+                    },
+                    "Value #4-5": {
+                      "index": 2,
+                      "text": "Slots 4-5"
+                    },
+                    "Value #6-10": {
+                      "index": 3,
+                      "text": "Slots 6-10"
+                    },
+                    "Value #>11": {
+                      "index": 4,
+                      "text": "Slots >11"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "unit": "none"
+            }
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 0,
+            "y": 59
+          },
+          "id": 1011,
+          "options": {
+            "displayLabels": [],
+            "legend": {
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "values": [
+                "percent"
+              ]
+            },
+            "pieType": "donut",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "/^1$/",
+              "values": true
+            },
+            "sort": "desc",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(\r\n  count_over_time(\r\n    (transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", provider=\"dRPC\", metric_type=\"slot_latency\", response_status=\"success\"} == 1)[${__range}:1m]\r\n  )\r\n)",
+              "format": "table",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "1",
+              "range": false,
+              "refId": "1",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(\r\n  count_over_time(\r\n    (transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", provider=\"dRPC\", metric_type=\"slot_latency\", response_status=\"success\"} >= 2 and \r\n    transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", provider=\"dRPC\", metric_type=\"slot_latency\", response_status=\"success\"} <= 3)[${__range}:1m]\r\n  )\r\n)",
+              "format": "table",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "2-5",
+              "range": false,
+              "refId": "2-3",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(\r\n  count_over_time(\r\n    (transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", provider=\"dRPC\", metric_type=\"slot_latency\", response_status=\"success\"} >= 4 and \r\n    transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", provider=\"dRPC\", metric_type=\"slot_latency\", response_status=\"success\"} <= 5)[${__range}:1m]\r\n  )\r\n)",
+              "format": "table",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "6-10",
+              "range": false,
+              "refId": "4-5",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(\r\n  count_over_time(\r\n    (transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", provider=\"dRPC\", metric_type=\"slot_latency\", response_status=\"success\"} >= 6 and \r\n    transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", provider=\"dRPC\", metric_type=\"slot_latency\", response_status=\"success\"} <= 10)[${__range}:1m]\r\n  )\r\n)",
+              "format": "table",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "6-10",
+              "range": false,
+              "refId": "6-10",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(\r\n  count_over_time(\r\n    (transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", provider=\"dRPC\", metric_type=\"slot_latency\", response_status=\"success\"} >= 11)[${__range}:1m]\r\n  )\r\n)",
+              "format": "table",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": true,
+              "interval": "",
+              "legendFormat": ">11",
+              "range": false,
+              "refId": ">11",
+              "useBackend": false
+            }
+          ],
+          "title": "dRPC-Growth",
+          "transformations": [
+            {
+              "id": "joinByField",
+              "options": {
+                "mode": "outer"
+              }
             },
             {
               "id": "organize",

--- a/dashboards/dashboards/compare-dashboard-solana.json
+++ b/dashboards/dashboards/compare-dashboard-solana.json
@@ -3994,7 +3994,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Number of slots between transaction submission and confirmation, both using confirmed commitment level. Lower values indicate faster transaction landing on chain.\n\nTransactions are sent every 15 minutes. Compute unit price (priority fee) fixed at 200,000 microlamports per compute unit.\n\nChainstack-Default means a default Solana RPC endpoint (not bloXroute) under Growth plan.\n\nChainstack-Warp means a Solana Trader Node (bloXroute) under Growth plan.\n\nHelius-Default means a default Solana RPC endpoint (staked) under Developer plan.",
+          "description": "Number of slots between transaction submission and confirmation, both using confirmed commitment level. Lower values indicate faster transaction landing on chain.\n\nTransactions are sent every 15 minutes. Compute unit price (priority fee) fixed at 200,000 microlamports per compute unit.\n\nChainstack-Default means a default Solana RPC endpoint (not bloXroute) under Growth plan.\n\nChainstack-Warp means a Solana Trader Node (bloXroute) under Growth plan.\n\nHelius-Default means a default Solana RPC endpoint (staked) under Developer plan.\n\nP2P-Syncro means P2P.org Syncro Sender (public endpoint) with a 100,000 lamport tip per tx.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -5568,6 +5568,217 @@
             }
           ],
           "title": "Chainstack-Default",
+          "transformations": [
+            {
+              "id": "joinByField",
+              "options": {}
+            },
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "includeByName": {},
+                "indexByName": {},
+                "renameByName": {
+                  "Value #1": "",
+                  "Value #2-5": "",
+                  "Value #6-10": "",
+                  "Value #>11": ""
+                }
+              }
+            },
+            {
+              "id": "transpose",
+              "options": {
+                "firstFieldName": "",
+                "restFieldsName": ""
+              }
+            }
+          ],
+          "type": "piechart"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Transactions are sent through P2P.org Syncro Sender (public endpoint) with a 100,000 lamport tip per tx.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "fixedColor": "semi-dark-blue",
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                }
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "Value #1": {
+                      "index": 0,
+                      "text": "Slot 1"
+                    },
+                    "Value #2-3": {
+                      "index": 1,
+                      "text": "Slots 2-3"
+                    },
+                    "Value #4-5": {
+                      "index": 2,
+                      "text": "Slots 4-5"
+                    },
+                    "Value #6-10": {
+                      "index": 3,
+                      "text": "Slots 6-10"
+                    },
+                    "Value #>11": {
+                      "index": 4,
+                      "text": "Slots >11"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "unit": "none"
+            }
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 12,
+            "y": 59
+          },
+          "id": 120,
+          "options": {
+            "displayLabels": [],
+            "legend": {
+              "displayMode": "table",
+              "placement": "right",
+              "showLegend": true,
+              "values": [
+                "percent"
+              ]
+            },
+            "pieType": "donut",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "/^1$/",
+              "values": true
+            },
+            "sort": "desc",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "multi",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(\r\n  count_over_time(\r\n    (transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", provider=\"P2P-Syncro\", metric_type=\"slot_latency\", response_status=\"success\"} == 1)[${__range}:1m]\r\n  )\r\n)",
+              "format": "table",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "1",
+              "range": false,
+              "refId": "1",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(\r\n  count_over_time(\r\n    (transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", provider=\"P2P-Syncro\", metric_type=\"slot_latency\", response_status=\"success\"} >= 2 and \r\n    transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", provider=\"P2P-Syncro\", metric_type=\"slot_latency\", response_status=\"success\"} <= 3)[${__range}:1m]\r\n  )\r\n)",
+              "format": "table",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "2-5",
+              "range": false,
+              "refId": "2-3",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(\r\n  count_over_time(\r\n    (transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", provider=\"P2P-Syncro\", metric_type=\"slot_latency\", response_status=\"success\"} >= 4 and \r\n    transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", provider=\"P2P-Syncro\", metric_type=\"slot_latency\", response_status=\"success\"} <= 5)[${__range}:1m]\r\n  )\r\n)",
+              "format": "table",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "6-10",
+              "range": false,
+              "refId": "4-5",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(\r\n  count_over_time(\r\n    (transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", provider=\"P2P-Syncro\", metric_type=\"slot_latency\", response_status=\"success\"} >= 6 and \r\n    transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", provider=\"P2P-Syncro\", metric_type=\"slot_latency\", response_status=\"success\"} <= 10)[${__range}:1m]\r\n  )\r\n)",
+              "format": "table",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": true,
+              "interval": "",
+              "legendFormat": "6-10",
+              "range": false,
+              "refId": "6-10",
+              "useBackend": false
+            },
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "disableTextWrap": false,
+              "editorMode": "code",
+              "exemplar": false,
+              "expr": "sum(\r\n  count_over_time(\r\n    (transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", provider=\"P2P-Syncro\", metric_type=\"slot_latency\", response_status=\"success\"} >= 11)[${__range}:1m]\r\n  )\r\n)",
+              "format": "table",
+              "fullMetaSearch": false,
+              "includeNullMetadata": true,
+              "instant": true,
+              "interval": "",
+              "legendFormat": ">11",
+              "range": false,
+              "refId": ">11",
+              "useBackend": false
+            }
+          ],
+          "title": "P2P-Syncro",
           "transformations": [
             {
               "id": "joinByField",


### PR DESCRIPTION
## Summary

Adds the P2P-Syncro provider to the Solana landing-section piecharts on the global and EU dashboards, and aligns EU's landing layout to match global.

**Global (`compare-dashboard-solana.json`):**
- New piechart `P2P-Syncro` (id 120) at x=12, y=59 in the Slot distribution row.
- `Transaction confirmation` legend updated with a P2P-Syncro note.

**EU (`compare-dashboard-solana-eu.json`):**
- New piechart `P2P-Syncro` (id 1010) at x=12, y=59.
- New piechart `dRPC-Growth` (id 1011) at x=0, y=59 — cloned from global, was missing in EU.
- Replaced single-stat `Landing rate` panel (id 72) with the per-provider table panel cloned from global so EU matches global styling.
- `Transaction confirmation` legend updated with a P2P-Syncro note.

The shared `Transaction confirmation` timeseries and `Landing rate` table already query `by (provider)`, so P2P-Syncro is showing up there automatically — these panels only needed legend text updates.

Changes already pushed to Grafana via `grafana_sync.py`.

## Test plan

- [x] `dashboards/tests/test_grafana_sync.py` — 21 passed
- [x] JSON validates for both files
- [x] `grafana_sync.py status` showed only the two intended files changed
- [x] Visual check in Grafana after deploy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added P2P-Syncro provider integration to Solana dashboards with dedicated slot distribution visualization.

* **Improvements**
  * Redesigned transaction landing rate panel from stat-style to table format with enhanced data organization and sorting.
  * Enhanced transaction confirmation panel with additional provider details.
  * Updated transaction landing metrics visualization for improved clarity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chainstacklabs/compare-dashboard-functions/pull/79?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->