### PR TITLE
feat(dashboards): Data correctness panels across all EVM chains (v2.1 anchor)

### DIFF
--- a/dashboards/dashboards/compare-dashboard-arbitrum-eu.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum-eu.json
@@ -1250,7 +1250,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Per provider in this region (EU), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "description": "Per provider, did this provider's eth_getBalance at VERIFY_BLOCK match the proof-anchored truth (balance_verified) at the same block. Green - matched. Red - mismatched. Grey - no sample.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1272,10 +1272,25 @@
               "mappings": [
                 {
                   "options": {
+                    "0": {
+                      "color": "red",
+                      "index": 0,
+                      "text": "Mismatched"
+                    },
+                    "1": {
+                      "color": "green",
+                      "index": 1,
+                      "text": "Verified"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
                     "match": "null",
                     "result": {
                       "color": "grey",
-                      "index": 0,
+                      "index": 2,
                       "text": "No data"
                     }
                   },
@@ -1327,7 +1342,7 @@
             "h": 8,
             "w": 18,
             "x": 0,
-            "y": 39
+            "y": 28
           },
           "id": 1301,
           "options": {
@@ -1339,7 +1354,7 @@
             "legend": {
               "displayMode": "list",
               "placement": "bottom",
-              "showLegend": true
+              "showLegend": false
             },
             "mergeValues": true,
             "rowHeight": 0.8,
@@ -1358,13 +1373,13 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"fra1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"fra1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"fra1\"}\n    )\n  )\n)",
+              "expr": "min by (provider) (\n  last_over_time(response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Arbitrum\"}[16m])\n  == bool on(block_number) group_left()\n  last_over_time(response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Arbitrum\"}[16m])\n)",
               "legendFormat": "{{provider}}",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Provider agreement",
+          "title": "Provider verified",
           "type": "state-timeline"
         },
         {
@@ -1372,7 +1387,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "For each provider in this region (EU), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "description": "Per provider, the percentage of samples whose hashed balance at VERIFY_BLOCK matched the proof-anchored truth (balance_verified) over the chosen time range. 100% means always verified. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1431,7 +1446,7 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Agreed %"
+                  "options": "Verified %"
                 },
                 "properties": [
                   {
@@ -1484,7 +1499,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 39
+            "y": 28
           },
           "id": 1302,
           "options": {
@@ -1501,7 +1516,7 @@
             "sortBy": [
               {
                 "desc": true,
-                "displayName": "Agreed %"
+                "displayName": "Verified %"
               }
             ]
           },
@@ -1513,14 +1528,14 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"fra1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"fra1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"fra1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"fra1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "expr": "sum by (provider) (\n  sum_over_time(\n    (\n      response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Arbitrum\"}\n      == bool on(block_number) group_left()\n      response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Arbitrum\"}\n    )[$__range:1m]\n  )\n)\n/\nsum by (provider) (\n  count_over_time(\n    response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Arbitrum\"}[$__range:1m]\n  )\n)",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",
               "refId": "A"
             }
           ],
-          "title": "Agreement summary",
+          "title": "Verification summary",
           "transformations": [
             {
               "id": "organize",
@@ -1533,16 +1548,139 @@
                   "provider": 0
                 },
                 "renameByName": {
-                  "Value": "Agreed %",
+                  "Value": "Verified %",
                   "provider": "Provider"
                 }
               }
             }
           ],
           "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "State-root verifier health. Each round queries all configured providers for the block's stateRoot \u2014 requires unanimous agreement \u2014 then runs eth_getProof via Chainstack and locally MPT-verifies it to derive the canonical eth_getBalance at PROBE_ADDRESS (= balance_verified). Codes: 0 OK \u00b7 1 stateRoot disagreement \u00b7 2 proof math invalid \u00b7 3 anchor unavailable \u00b7 4 proof unavailable. Non-zero \u2192 no balance_verified this round.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "green",
+                      "index": 0,
+                      "text": "OK"
+                    },
+                    "1": {
+                      "color": "red",
+                      "index": 1,
+                      "text": "stateRoot disagreement"
+                    },
+                    "2": {
+                      "color": "red",
+                      "index": 2,
+                      "text": "proof math invalid"
+                    },
+                    "3": {
+                      "color": "yellow",
+                      "index": 3,
+                      "text": "anchor unavailable"
+                    },
+                    "4": {
+                      "color": "yellow",
+                      "index": 4,
+                      "text": "proof unavailable"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 5,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 36
+          },
+          "id": 1303,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "last_over_time(response_latency_seconds{metric_type=\"verifier_status\", blockchain=\"Arbitrum\"}[16m])",
+              "legendFormat": "status",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Verifier status",
+          "type": "state-timeline"
         }
       ],
-      "title": "Data agreement",
+      "title": "Data correctness",
       "type": "row"
     },
     {

--- a/dashboards/dashboards/compare-dashboard-arbitrum-japan.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum-japan.json
@@ -1236,7 +1236,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Per provider in this region (JP), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "description": "Per provider, did this provider's eth_getBalance at VERIFY_BLOCK match the proof-anchored truth (balance_verified) at the same block. Green - matched. Red - mismatched. Grey - no sample.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1258,10 +1258,25 @@
               "mappings": [
                 {
                   "options": {
+                    "0": {
+                      "color": "red",
+                      "index": 0,
+                      "text": "Mismatched"
+                    },
+                    "1": {
+                      "color": "green",
+                      "index": 1,
+                      "text": "Verified"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
                     "match": "null",
                     "result": {
                       "color": "grey",
-                      "index": 0,
+                      "index": 2,
                       "text": "No data"
                     }
                   },
@@ -1313,7 +1328,7 @@
             "h": 8,
             "w": 18,
             "x": 0,
-            "y": 39
+            "y": 28
           },
           "id": 1301,
           "options": {
@@ -1325,7 +1340,7 @@
             "legend": {
               "displayMode": "list",
               "placement": "bottom",
-              "showLegend": true
+              "showLegend": false
             },
             "mergeValues": true,
             "rowHeight": 0.8,
@@ -1344,13 +1359,13 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"hnd1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"hnd1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"hnd1\"}\n    )\n  )\n)",
+              "expr": "min by (provider) (\n  last_over_time(response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Arbitrum\"}[16m])\n  == bool on(block_number) group_left()\n  last_over_time(response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Arbitrum\"}[16m])\n)",
               "legendFormat": "{{provider}}",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Provider agreement",
+          "title": "Provider verified",
           "type": "state-timeline"
         },
         {
@@ -1358,7 +1373,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "For each provider in this region (JP), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "description": "Per provider, the percentage of samples whose hashed balance at VERIFY_BLOCK matched the proof-anchored truth (balance_verified) over the chosen time range. 100% means always verified. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1417,7 +1432,7 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Agreed %"
+                  "options": "Verified %"
                 },
                 "properties": [
                   {
@@ -1470,7 +1485,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 39
+            "y": 28
           },
           "id": 1302,
           "options": {
@@ -1487,7 +1502,7 @@
             "sortBy": [
               {
                 "desc": true,
-                "displayName": "Agreed %"
+                "displayName": "Verified %"
               }
             ]
           },
@@ -1499,14 +1514,14 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"hnd1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"hnd1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"hnd1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"hnd1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "expr": "sum by (provider) (\n  sum_over_time(\n    (\n      response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Arbitrum\"}\n      == bool on(block_number) group_left()\n      response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Arbitrum\"}\n    )[$__range:1m]\n  )\n)\n/\nsum by (provider) (\n  count_over_time(\n    response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Arbitrum\"}[$__range:1m]\n  )\n)",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",
               "refId": "A"
             }
           ],
-          "title": "Agreement summary",
+          "title": "Verification summary",
           "transformations": [
             {
               "id": "organize",
@@ -1519,16 +1534,139 @@
                   "provider": 0
                 },
                 "renameByName": {
-                  "Value": "Agreed %",
+                  "Value": "Verified %",
                   "provider": "Provider"
                 }
               }
             }
           ],
           "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "State-root verifier health. Each round queries all configured providers for the block's stateRoot \u2014 requires unanimous agreement \u2014 then runs eth_getProof via Chainstack and locally MPT-verifies it to derive the canonical eth_getBalance at PROBE_ADDRESS (= balance_verified). Codes: 0 OK \u00b7 1 stateRoot disagreement \u00b7 2 proof math invalid \u00b7 3 anchor unavailable \u00b7 4 proof unavailable. Non-zero \u2192 no balance_verified this round.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "green",
+                      "index": 0,
+                      "text": "OK"
+                    },
+                    "1": {
+                      "color": "red",
+                      "index": 1,
+                      "text": "stateRoot disagreement"
+                    },
+                    "2": {
+                      "color": "red",
+                      "index": 2,
+                      "text": "proof math invalid"
+                    },
+                    "3": {
+                      "color": "yellow",
+                      "index": 3,
+                      "text": "anchor unavailable"
+                    },
+                    "4": {
+                      "color": "yellow",
+                      "index": 4,
+                      "text": "proof unavailable"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 5,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 36
+          },
+          "id": 1303,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "last_over_time(response_latency_seconds{metric_type=\"verifier_status\", blockchain=\"Arbitrum\"}[16m])",
+              "legendFormat": "status",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Verifier status",
+          "type": "state-timeline"
         }
       ],
-      "title": "Data agreement",
+      "title": "Data correctness",
       "type": "row"
     },
     {

--- a/dashboards/dashboards/compare-dashboard-arbitrum-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum-us-west.json
@@ -1234,7 +1234,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Per provider in this region (US West), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "description": "Per provider, did this provider's eth_getBalance at VERIFY_BLOCK match the proof-anchored truth (balance_verified) at the same block. Green - matched. Red - mismatched. Grey - no sample.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1256,10 +1256,25 @@
               "mappings": [
                 {
                   "options": {
+                    "0": {
+                      "color": "red",
+                      "index": 0,
+                      "text": "Mismatched"
+                    },
+                    "1": {
+                      "color": "green",
+                      "index": 1,
+                      "text": "Verified"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
                     "match": "null",
                     "result": {
                       "color": "grey",
-                      "index": 0,
+                      "index": 2,
                       "text": "No data"
                     }
                   },
@@ -1311,7 +1326,7 @@
             "h": 8,
             "w": 18,
             "x": 0,
-            "y": 39
+            "y": 28
           },
           "id": 1301,
           "options": {
@@ -1323,7 +1338,7 @@
             "legend": {
               "displayMode": "list",
               "placement": "bottom",
-              "showLegend": true
+              "showLegend": false
             },
             "mergeValues": true,
             "rowHeight": 0.8,
@@ -1342,13 +1357,13 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"sfo1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"sfo1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"sfo1\"}\n    )\n  )\n)",
+              "expr": "min by (provider) (\n  last_over_time(response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Arbitrum\"}[16m])\n  == bool on(block_number) group_left()\n  last_over_time(response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Arbitrum\"}[16m])\n)",
               "legendFormat": "{{provider}}",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Provider agreement",
+          "title": "Provider verified",
           "type": "state-timeline"
         },
         {
@@ -1356,7 +1371,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "For each provider in this region (US West), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "description": "Per provider, the percentage of samples whose hashed balance at VERIFY_BLOCK matched the proof-anchored truth (balance_verified) over the chosen time range. 100% means always verified. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1415,7 +1430,7 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Agreed %"
+                  "options": "Verified %"
                 },
                 "properties": [
                   {
@@ -1468,7 +1483,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 39
+            "y": 28
           },
           "id": 1302,
           "options": {
@@ -1485,7 +1500,7 @@
             "sortBy": [
               {
                 "desc": true,
-                "displayName": "Agreed %"
+                "displayName": "Verified %"
               }
             ]
           },
@@ -1497,14 +1512,14 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"sfo1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"sfo1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"sfo1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\", source_region=\"sfo1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "expr": "sum by (provider) (\n  sum_over_time(\n    (\n      response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Arbitrum\"}\n      == bool on(block_number) group_left()\n      response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Arbitrum\"}\n    )[$__range:1m]\n  )\n)\n/\nsum by (provider) (\n  count_over_time(\n    response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Arbitrum\"}[$__range:1m]\n  )\n)",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",
               "refId": "A"
             }
           ],
-          "title": "Agreement summary",
+          "title": "Verification summary",
           "transformations": [
             {
               "id": "organize",
@@ -1517,16 +1532,139 @@
                   "provider": 0
                 },
                 "renameByName": {
-                  "Value": "Agreed %",
+                  "Value": "Verified %",
                   "provider": "Provider"
                 }
               }
             }
           ],
           "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "State-root verifier health. Each round queries all configured providers for the block's stateRoot \u2014 requires unanimous agreement \u2014 then runs eth_getProof via Chainstack and locally MPT-verifies it to derive the canonical eth_getBalance at PROBE_ADDRESS (= balance_verified). Codes: 0 OK \u00b7 1 stateRoot disagreement \u00b7 2 proof math invalid \u00b7 3 anchor unavailable \u00b7 4 proof unavailable. Non-zero \u2192 no balance_verified this round.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "green",
+                      "index": 0,
+                      "text": "OK"
+                    },
+                    "1": {
+                      "color": "red",
+                      "index": 1,
+                      "text": "stateRoot disagreement"
+                    },
+                    "2": {
+                      "color": "red",
+                      "index": 2,
+                      "text": "proof math invalid"
+                    },
+                    "3": {
+                      "color": "yellow",
+                      "index": 3,
+                      "text": "anchor unavailable"
+                    },
+                    "4": {
+                      "color": "yellow",
+                      "index": 4,
+                      "text": "proof unavailable"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 5,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 36
+          },
+          "id": 1303,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "last_over_time(response_latency_seconds{metric_type=\"verifier_status\", blockchain=\"Arbitrum\"}[16m])",
+              "legendFormat": "status",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Verifier status",
+          "type": "state-timeline"
         }
       ],
-      "title": "Data agreement",
+      "title": "Data correctness",
       "type": "row"
     },
     {

--- a/dashboards/dashboards/compare-dashboard-arbitrum.json
+++ b/dashboards/dashboards/compare-dashboard-arbitrum.json
@@ -1760,7 +1760,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Per provider, did this provider's answer match the majority answer in every region it participated in at this moment. Green - matched the majority everywhere. Red - was an outlier in at least one region. Grey - no data captured.",
+          "description": "Per provider, did this provider's eth_getBalance at VERIFY_BLOCK match the proof-anchored truth (balance_verified) at the same block. Green - matched. Red - mismatched. Grey - no sample.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1782,10 +1782,25 @@
               "mappings": [
                 {
                   "options": {
+                    "0": {
+                      "color": "red",
+                      "index": 0,
+                      "text": "Mismatched"
+                    },
+                    "1": {
+                      "color": "green",
+                      "index": 1,
+                      "text": "Verified"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
                     "match": "null",
                     "result": {
                       "color": "grey",
-                      "index": 0,
+                      "index": 2,
                       "text": "No data"
                     }
                   },
@@ -1849,7 +1864,7 @@
             "legend": {
               "displayMode": "list",
               "placement": "bottom",
-              "showLegend": true
+              "showLegend": false
             },
             "mergeValues": true,
             "rowHeight": 0.8,
@@ -1868,13 +1883,13 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "min by (provider) (\n  (\n    group by (provider, source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\"}\n    )\n    *\n    on(source_region, block_number, value) group_left()\n    count by (source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\"}\n    )\n  )\n  ==\n  bool on(source_region, block_number) group_left()\n  max by (source_region, block_number) (\n    count by (source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\"}\n    )\n  )\n)",
+              "expr": "min by (provider) (\n  last_over_time(response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Arbitrum\"}[16m])\n  == bool on(block_number) group_left()\n  last_over_time(response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Arbitrum\"}[16m])\n)",
               "legendFormat": "{{provider}}",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Provider agreement",
+          "title": "Provider verified",
           "type": "state-timeline"
         },
         {
@@ -1882,7 +1897,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "For each provider in each region, the percentage of samples this provider returned that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "description": "Per provider, the percentage of samples whose hashed balance at VERIFY_BLOCK matched the proof-anchored truth (balance_verified) over the chosen time range. 100% means always verified. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1941,41 +1956,7 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Region"
-                },
-                "properties": [
-                  {
-                    "id": "custom.width",
-                    "value": 70
-                  },
-                  {
-                    "id": "mappings",
-                    "value": [
-                      {
-                        "options": {
-                          "fra1": {
-                            "index": 0,
-                            "text": "EU"
-                          },
-                          "hnd1": {
-                            "index": 1,
-                            "text": "JP"
-                          },
-                          "sfo1": {
-                            "index": 2,
-                            "text": "US West"
-                          }
-                        },
-                        "type": "value"
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Agreed %"
+                  "options": "Verified %"
                 },
                 "properties": [
                   {
@@ -2045,7 +2026,7 @@
             "sortBy": [
               {
                 "desc": true,
-                "displayName": "Agreed %"
+                "displayName": "Verified %"
               }
             ]
           },
@@ -2057,14 +2038,14 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "sum by (provider, source_region) (\n  max_over_time(\n    (\n      (\n        group by (provider, source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\"}\n        )\n        *\n        on(source_region, block_number, value) group_left()\n        count by (source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\"}\n        )\n      )\n      ==\n      bool on(source_region, block_number) group_left()\n      max by (source_region, block_number) (\n        count by (source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider, source_region) (\n  max_over_time(\n    (\n      group by (provider, source_region, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Arbitrum\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "expr": "sum by (provider) (\n  sum_over_time(\n    (\n      response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Arbitrum\"}\n      == bool on(block_number) group_left()\n      response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Arbitrum\"}\n    )[$__range:1m]\n  )\n)\n/\nsum by (provider) (\n  count_over_time(\n    response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Arbitrum\"}[$__range:1m]\n  )\n)",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",
               "refId": "A"
             }
           ],
-          "title": "Agreement summary",
+          "title": "Verification summary",
           "transformations": [
             {
               "id": "organize",
@@ -2073,22 +2054,143 @@
                   "Time": true
                 },
                 "indexByName": {
-                  "Value": 2,
-                  "provider": 0,
-                  "source_region": 1
+                  "Value": 1,
+                  "provider": 0
                 },
                 "renameByName": {
-                  "Value": "Agreed %",
-                  "provider": "Provider",
-                  "source_region": "Region"
+                  "Value": "Verified %",
+                  "provider": "Provider"
                 }
               }
             }
           ],
           "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "State-root verifier health. Each round queries all configured providers for the block's stateRoot \u2014 requires unanimous agreement \u2014 then runs eth_getProof via Chainstack and locally MPT-verifies it to derive the canonical eth_getBalance at PROBE_ADDRESS (= balance_verified). Codes: 0 OK \u00b7 1 stateRoot disagreement \u00b7 2 proof math invalid \u00b7 3 anchor unavailable \u00b7 4 proof unavailable. Non-zero \u2192 no balance_verified this round.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "green",
+                      "index": 0,
+                      "text": "OK"
+                    },
+                    "1": {
+                      "color": "red",
+                      "index": 1,
+                      "text": "stateRoot disagreement"
+                    },
+                    "2": {
+                      "color": "red",
+                      "index": 2,
+                      "text": "proof math invalid"
+                    },
+                    "3": {
+                      "color": "yellow",
+                      "index": 3,
+                      "text": "anchor unavailable"
+                    },
+                    "4": {
+                      "color": "yellow",
+                      "index": 4,
+                      "text": "proof unavailable"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 5,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 45
+          },
+          "id": 303,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "last_over_time(response_latency_seconds{metric_type=\"verifier_status\", blockchain=\"Arbitrum\"}[16m])",
+              "legendFormat": "status",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Verifier status",
+          "type": "state-timeline"
         }
       ],
-      "title": "Data agreement",
+      "title": "Data correctness",
       "type": "row"
     },
     {

--- a/dashboards/dashboards/compare-dashboard-base-eu.json
+++ b/dashboards/dashboards/compare-dashboard-base-eu.json
@@ -1234,7 +1234,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Per provider in this region (EU), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "description": "Per provider, did this provider's eth_getBalance at VERIFY_BLOCK match the proof-anchored truth (balance_verified) at the same block. Green - matched. Red - mismatched. Grey - no sample.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1256,10 +1256,25 @@
               "mappings": [
                 {
                   "options": {
+                    "0": {
+                      "color": "red",
+                      "index": 0,
+                      "text": "Mismatched"
+                    },
+                    "1": {
+                      "color": "green",
+                      "index": 1,
+                      "text": "Verified"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
                     "match": "null",
                     "result": {
                       "color": "grey",
-                      "index": 0,
+                      "index": 2,
                       "text": "No data"
                     }
                   },
@@ -1311,7 +1326,7 @@
             "h": 8,
             "w": 18,
             "x": 0,
-            "y": 39
+            "y": 28
           },
           "id": 1301,
           "options": {
@@ -1323,7 +1338,7 @@
             "legend": {
               "displayMode": "list",
               "placement": "bottom",
-              "showLegend": true
+              "showLegend": false
             },
             "mergeValues": true,
             "rowHeight": 0.8,
@@ -1342,13 +1357,13 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"fra1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"fra1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"fra1\"}\n    )\n  )\n)",
+              "expr": "min by (provider) (\n  last_over_time(response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Base\"}[16m])\n  == bool on(block_number) group_left()\n  last_over_time(response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Base\"}[16m])\n)",
               "legendFormat": "{{provider}}",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Provider agreement",
+          "title": "Provider verified",
           "type": "state-timeline"
         },
         {
@@ -1356,7 +1371,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "For each provider in this region (EU), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "description": "Per provider, the percentage of samples whose hashed balance at VERIFY_BLOCK matched the proof-anchored truth (balance_verified) over the chosen time range. 100% means always verified. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1415,7 +1430,7 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Agreed %"
+                  "options": "Verified %"
                 },
                 "properties": [
                   {
@@ -1468,7 +1483,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 39
+            "y": 28
           },
           "id": 1302,
           "options": {
@@ -1485,7 +1500,7 @@
             "sortBy": [
               {
                 "desc": true,
-                "displayName": "Agreed %"
+                "displayName": "Verified %"
               }
             ]
           },
@@ -1497,14 +1512,14 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"fra1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"fra1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"fra1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"fra1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "expr": "sum by (provider) (\n  sum_over_time(\n    (\n      response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Base\"}\n      == bool on(block_number) group_left()\n      response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Base\"}\n    )[$__range:1m]\n  )\n)\n/\nsum by (provider) (\n  count_over_time(\n    response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Base\"}[$__range:1m]\n  )\n)",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",
               "refId": "A"
             }
           ],
-          "title": "Agreement summary",
+          "title": "Verification summary",
           "transformations": [
             {
               "id": "organize",
@@ -1517,16 +1532,139 @@
                   "provider": 0
                 },
                 "renameByName": {
-                  "Value": "Agreed %",
+                  "Value": "Verified %",
                   "provider": "Provider"
                 }
               }
             }
           ],
           "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "State-root verifier health. Each round queries all configured providers for the block's stateRoot \u2014 requires unanimous agreement \u2014 then runs eth_getProof via Chainstack and locally MPT-verifies it to derive the canonical eth_getBalance at PROBE_ADDRESS (= balance_verified). Codes: 0 OK \u00b7 1 stateRoot disagreement \u00b7 2 proof math invalid \u00b7 3 anchor unavailable \u00b7 4 proof unavailable. Non-zero \u2192 no balance_verified this round.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "green",
+                      "index": 0,
+                      "text": "OK"
+                    },
+                    "1": {
+                      "color": "red",
+                      "index": 1,
+                      "text": "stateRoot disagreement"
+                    },
+                    "2": {
+                      "color": "red",
+                      "index": 2,
+                      "text": "proof math invalid"
+                    },
+                    "3": {
+                      "color": "yellow",
+                      "index": 3,
+                      "text": "anchor unavailable"
+                    },
+                    "4": {
+                      "color": "yellow",
+                      "index": 4,
+                      "text": "proof unavailable"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 5,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 36
+          },
+          "id": 1303,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "last_over_time(response_latency_seconds{metric_type=\"verifier_status\", blockchain=\"Base\"}[16m])",
+              "legendFormat": "status",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Verifier status",
+          "type": "state-timeline"
         }
       ],
-      "title": "Data agreement",
+      "title": "Data correctness",
       "type": "row"
     },
     {

--- a/dashboards/dashboards/compare-dashboard-base-japan.json
+++ b/dashboards/dashboards/compare-dashboard-base-japan.json
@@ -1233,7 +1233,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Per provider in this region (JP), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "description": "Per provider, did this provider's eth_getBalance at VERIFY_BLOCK match the proof-anchored truth (balance_verified) at the same block. Green - matched. Red - mismatched. Grey - no sample.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1255,10 +1255,25 @@
               "mappings": [
                 {
                   "options": {
+                    "0": {
+                      "color": "red",
+                      "index": 0,
+                      "text": "Mismatched"
+                    },
+                    "1": {
+                      "color": "green",
+                      "index": 1,
+                      "text": "Verified"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
                     "match": "null",
                     "result": {
                       "color": "grey",
-                      "index": 0,
+                      "index": 2,
                       "text": "No data"
                     }
                   },
@@ -1310,7 +1325,7 @@
             "h": 8,
             "w": 18,
             "x": 0,
-            "y": 39
+            "y": 28
           },
           "id": 1301,
           "options": {
@@ -1322,7 +1337,7 @@
             "legend": {
               "displayMode": "list",
               "placement": "bottom",
-              "showLegend": true
+              "showLegend": false
             },
             "mergeValues": true,
             "rowHeight": 0.8,
@@ -1341,13 +1356,13 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"hnd1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"hnd1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"hnd1\"}\n    )\n  )\n)",
+              "expr": "min by (provider) (\n  last_over_time(response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Base\"}[16m])\n  == bool on(block_number) group_left()\n  last_over_time(response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Base\"}[16m])\n)",
               "legendFormat": "{{provider}}",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Provider agreement",
+          "title": "Provider verified",
           "type": "state-timeline"
         },
         {
@@ -1355,7 +1370,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "For each provider in this region (JP), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "description": "Per provider, the percentage of samples whose hashed balance at VERIFY_BLOCK matched the proof-anchored truth (balance_verified) over the chosen time range. 100% means always verified. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1414,7 +1429,7 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Agreed %"
+                  "options": "Verified %"
                 },
                 "properties": [
                   {
@@ -1467,7 +1482,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 39
+            "y": 28
           },
           "id": 1302,
           "options": {
@@ -1484,7 +1499,7 @@
             "sortBy": [
               {
                 "desc": true,
-                "displayName": "Agreed %"
+                "displayName": "Verified %"
               }
             ]
           },
@@ -1496,14 +1511,14 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"hnd1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"hnd1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"hnd1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"hnd1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "expr": "sum by (provider) (\n  sum_over_time(\n    (\n      response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Base\"}\n      == bool on(block_number) group_left()\n      response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Base\"}\n    )[$__range:1m]\n  )\n)\n/\nsum by (provider) (\n  count_over_time(\n    response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Base\"}[$__range:1m]\n  )\n)",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",
               "refId": "A"
             }
           ],
-          "title": "Agreement summary",
+          "title": "Verification summary",
           "transformations": [
             {
               "id": "organize",
@@ -1516,16 +1531,139 @@
                   "provider": 0
                 },
                 "renameByName": {
-                  "Value": "Agreed %",
+                  "Value": "Verified %",
                   "provider": "Provider"
                 }
               }
             }
           ],
           "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "State-root verifier health. Each round queries all configured providers for the block's stateRoot \u2014 requires unanimous agreement \u2014 then runs eth_getProof via Chainstack and locally MPT-verifies it to derive the canonical eth_getBalance at PROBE_ADDRESS (= balance_verified). Codes: 0 OK \u00b7 1 stateRoot disagreement \u00b7 2 proof math invalid \u00b7 3 anchor unavailable \u00b7 4 proof unavailable. Non-zero \u2192 no balance_verified this round.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "green",
+                      "index": 0,
+                      "text": "OK"
+                    },
+                    "1": {
+                      "color": "red",
+                      "index": 1,
+                      "text": "stateRoot disagreement"
+                    },
+                    "2": {
+                      "color": "red",
+                      "index": 2,
+                      "text": "proof math invalid"
+                    },
+                    "3": {
+                      "color": "yellow",
+                      "index": 3,
+                      "text": "anchor unavailable"
+                    },
+                    "4": {
+                      "color": "yellow",
+                      "index": 4,
+                      "text": "proof unavailable"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 5,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 36
+          },
+          "id": 1303,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "last_over_time(response_latency_seconds{metric_type=\"verifier_status\", blockchain=\"Base\"}[16m])",
+              "legendFormat": "status",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Verifier status",
+          "type": "state-timeline"
         }
       ],
-      "title": "Data agreement",
+      "title": "Data correctness",
       "type": "row"
     },
     {

--- a/dashboards/dashboards/compare-dashboard-base-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-base-us-west.json
@@ -1233,7 +1233,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Per provider in this region (US West), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "description": "Per provider, did this provider's eth_getBalance at VERIFY_BLOCK match the proof-anchored truth (balance_verified) at the same block. Green - matched. Red - mismatched. Grey - no sample.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1255,10 +1255,25 @@
               "mappings": [
                 {
                   "options": {
+                    "0": {
+                      "color": "red",
+                      "index": 0,
+                      "text": "Mismatched"
+                    },
+                    "1": {
+                      "color": "green",
+                      "index": 1,
+                      "text": "Verified"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
                     "match": "null",
                     "result": {
                       "color": "grey",
-                      "index": 0,
+                      "index": 2,
                       "text": "No data"
                     }
                   },
@@ -1310,7 +1325,7 @@
             "h": 8,
             "w": 18,
             "x": 0,
-            "y": 39
+            "y": 28
           },
           "id": 1301,
           "options": {
@@ -1322,7 +1337,7 @@
             "legend": {
               "displayMode": "list",
               "placement": "bottom",
-              "showLegend": true
+              "showLegend": false
             },
             "mergeValues": true,
             "rowHeight": 0.8,
@@ -1341,13 +1356,13 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"sfo1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"sfo1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"sfo1\"}\n    )\n  )\n)",
+              "expr": "min by (provider) (\n  last_over_time(response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Base\"}[16m])\n  == bool on(block_number) group_left()\n  last_over_time(response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Base\"}[16m])\n)",
               "legendFormat": "{{provider}}",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Provider agreement",
+          "title": "Provider verified",
           "type": "state-timeline"
         },
         {
@@ -1355,7 +1370,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "For each provider in this region (US West), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "description": "Per provider, the percentage of samples whose hashed balance at VERIFY_BLOCK matched the proof-anchored truth (balance_verified) over the chosen time range. 100% means always verified. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1414,7 +1429,7 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Agreed %"
+                  "options": "Verified %"
                 },
                 "properties": [
                   {
@@ -1467,7 +1482,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 39
+            "y": 28
           },
           "id": 1302,
           "options": {
@@ -1484,7 +1499,7 @@
             "sortBy": [
               {
                 "desc": true,
-                "displayName": "Agreed %"
+                "displayName": "Verified %"
               }
             ]
           },
@@ -1496,14 +1511,14 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"sfo1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"sfo1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"sfo1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\", source_region=\"sfo1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "expr": "sum by (provider) (\n  sum_over_time(\n    (\n      response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Base\"}\n      == bool on(block_number) group_left()\n      response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Base\"}\n    )[$__range:1m]\n  )\n)\n/\nsum by (provider) (\n  count_over_time(\n    response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Base\"}[$__range:1m]\n  )\n)",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",
               "refId": "A"
             }
           ],
-          "title": "Agreement summary",
+          "title": "Verification summary",
           "transformations": [
             {
               "id": "organize",
@@ -1516,16 +1531,139 @@
                   "provider": 0
                 },
                 "renameByName": {
-                  "Value": "Agreed %",
+                  "Value": "Verified %",
                   "provider": "Provider"
                 }
               }
             }
           ],
           "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "State-root verifier health. Each round queries all configured providers for the block's stateRoot \u2014 requires unanimous agreement \u2014 then runs eth_getProof via Chainstack and locally MPT-verifies it to derive the canonical eth_getBalance at PROBE_ADDRESS (= balance_verified). Codes: 0 OK \u00b7 1 stateRoot disagreement \u00b7 2 proof math invalid \u00b7 3 anchor unavailable \u00b7 4 proof unavailable. Non-zero \u2192 no balance_verified this round.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "green",
+                      "index": 0,
+                      "text": "OK"
+                    },
+                    "1": {
+                      "color": "red",
+                      "index": 1,
+                      "text": "stateRoot disagreement"
+                    },
+                    "2": {
+                      "color": "red",
+                      "index": 2,
+                      "text": "proof math invalid"
+                    },
+                    "3": {
+                      "color": "yellow",
+                      "index": 3,
+                      "text": "anchor unavailable"
+                    },
+                    "4": {
+                      "color": "yellow",
+                      "index": 4,
+                      "text": "proof unavailable"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 5,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 36
+          },
+          "id": 1303,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "last_over_time(response_latency_seconds{metric_type=\"verifier_status\", blockchain=\"Base\"}[16m])",
+              "legendFormat": "status",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Verifier status",
+          "type": "state-timeline"
         }
       ],
-      "title": "Data agreement",
+      "title": "Data correctness",
       "type": "row"
     },
     {

--- a/dashboards/dashboards/compare-dashboard-base.json
+++ b/dashboards/dashboards/compare-dashboard-base.json
@@ -1748,7 +1748,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Per provider, did this provider's answer match the majority answer in every region it participated in at this moment. Green - matched the majority everywhere. Red - was an outlier in at least one region. Grey - no data captured.",
+          "description": "Per provider, did this provider's eth_getBalance at VERIFY_BLOCK match the proof-anchored truth (balance_verified) at the same block. Green - matched. Red - mismatched. Grey - no sample.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1770,10 +1770,25 @@
               "mappings": [
                 {
                   "options": {
+                    "0": {
+                      "color": "red",
+                      "index": 0,
+                      "text": "Mismatched"
+                    },
+                    "1": {
+                      "color": "green",
+                      "index": 1,
+                      "text": "Verified"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
                     "match": "null",
                     "result": {
                       "color": "grey",
-                      "index": 0,
+                      "index": 2,
                       "text": "No data"
                     }
                   },
@@ -1837,7 +1852,7 @@
             "legend": {
               "displayMode": "list",
               "placement": "bottom",
-              "showLegend": true
+              "showLegend": false
             },
             "mergeValues": true,
             "rowHeight": 0.8,
@@ -1856,13 +1871,13 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "min by (provider) (\n  (\n    group by (provider, source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\"}\n    )\n    *\n    on(source_region, block_number, value) group_left()\n    count by (source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\"}\n    )\n  )\n  ==\n  bool on(source_region, block_number) group_left()\n  max by (source_region, block_number) (\n    count by (source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\"}\n    )\n  )\n)",
+              "expr": "min by (provider) (\n  last_over_time(response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Base\"}[16m])\n  == bool on(block_number) group_left()\n  last_over_time(response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Base\"}[16m])\n)",
               "legendFormat": "{{provider}}",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Provider agreement",
+          "title": "Provider verified",
           "type": "state-timeline"
         },
         {
@@ -1870,7 +1885,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "For each provider in each region, the percentage of samples this provider returned that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "description": "Per provider, the percentage of samples whose hashed balance at VERIFY_BLOCK matched the proof-anchored truth (balance_verified) over the chosen time range. 100% means always verified. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1929,41 +1944,7 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Region"
-                },
-                "properties": [
-                  {
-                    "id": "custom.width",
-                    "value": 70
-                  },
-                  {
-                    "id": "mappings",
-                    "value": [
-                      {
-                        "options": {
-                          "fra1": {
-                            "index": 0,
-                            "text": "EU"
-                          },
-                          "hnd1": {
-                            "index": 1,
-                            "text": "JP"
-                          },
-                          "sfo1": {
-                            "index": 2,
-                            "text": "US West"
-                          }
-                        },
-                        "type": "value"
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Agreed %"
+                  "options": "Verified %"
                 },
                 "properties": [
                   {
@@ -2033,7 +2014,7 @@
             "sortBy": [
               {
                 "desc": true,
-                "displayName": "Agreed %"
+                "displayName": "Verified %"
               }
             ]
           },
@@ -2045,14 +2026,14 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "sum by (provider, source_region) (\n  max_over_time(\n    (\n      (\n        group by (provider, source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\"}\n        )\n        *\n        on(source_region, block_number, value) group_left()\n        count by (source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\"}\n        )\n      )\n      ==\n      bool on(source_region, block_number) group_left()\n      max by (source_region, block_number) (\n        count by (source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider, source_region) (\n  max_over_time(\n    (\n      group by (provider, source_region, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Base\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "expr": "sum by (provider) (\n  sum_over_time(\n    (\n      response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Base\"}\n      == bool on(block_number) group_left()\n      response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Base\"}\n    )[$__range:1m]\n  )\n)\n/\nsum by (provider) (\n  count_over_time(\n    response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Base\"}[$__range:1m]\n  )\n)",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",
               "refId": "A"
             }
           ],
-          "title": "Agreement summary",
+          "title": "Verification summary",
           "transformations": [
             {
               "id": "organize",
@@ -2061,22 +2042,143 @@
                   "Time": true
                 },
                 "indexByName": {
-                  "Value": 2,
-                  "provider": 0,
-                  "source_region": 1
+                  "Value": 1,
+                  "provider": 0
                 },
                 "renameByName": {
-                  "Value": "Agreed %",
-                  "provider": "Provider",
-                  "source_region": "Region"
+                  "Value": "Verified %",
+                  "provider": "Provider"
                 }
               }
             }
           ],
           "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "State-root verifier health. Each round queries all configured providers for the block's stateRoot \u2014 requires unanimous agreement \u2014 then runs eth_getProof via Chainstack and locally MPT-verifies it to derive the canonical eth_getBalance at PROBE_ADDRESS (= balance_verified). Codes: 0 OK \u00b7 1 stateRoot disagreement \u00b7 2 proof math invalid \u00b7 3 anchor unavailable \u00b7 4 proof unavailable. Non-zero \u2192 no balance_verified this round.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "green",
+                      "index": 0,
+                      "text": "OK"
+                    },
+                    "1": {
+                      "color": "red",
+                      "index": 1,
+                      "text": "stateRoot disagreement"
+                    },
+                    "2": {
+                      "color": "red",
+                      "index": 2,
+                      "text": "proof math invalid"
+                    },
+                    "3": {
+                      "color": "yellow",
+                      "index": 3,
+                      "text": "anchor unavailable"
+                    },
+                    "4": {
+                      "color": "yellow",
+                      "index": 4,
+                      "text": "proof unavailable"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 5,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 44
+          },
+          "id": 303,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "last_over_time(response_latency_seconds{metric_type=\"verifier_status\", blockchain=\"Base\"}[16m])",
+              "legendFormat": "status",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Verifier status",
+          "type": "state-timeline"
         }
       ],
-      "title": "Data agreement",
+      "title": "Data correctness",
       "type": "row"
     },
     {

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain-eu.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain-eu.json
@@ -1232,7 +1232,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Per provider in this region (EU), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "description": "Per provider, did this provider's eth_getBalance at VERIFY_BLOCK match the proof-anchored truth (balance_verified) at the same block. Green - matched. Red - mismatched. Grey - no sample.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1254,10 +1254,25 @@
               "mappings": [
                 {
                   "options": {
+                    "0": {
+                      "color": "red",
+                      "index": 0,
+                      "text": "Mismatched"
+                    },
+                    "1": {
+                      "color": "green",
+                      "index": 1,
+                      "text": "Verified"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
                     "match": "null",
                     "result": {
                       "color": "grey",
-                      "index": 0,
+                      "index": 2,
                       "text": "No data"
                     }
                   },
@@ -1309,7 +1324,7 @@
             "h": 8,
             "w": 18,
             "x": 0,
-            "y": 39
+            "y": 28
           },
           "id": 1301,
           "options": {
@@ -1321,7 +1336,7 @@
             "legend": {
               "displayMode": "list",
               "placement": "bottom",
-              "showLegend": true
+              "showLegend": false
             },
             "mergeValues": true,
             "rowHeight": 0.8,
@@ -1340,13 +1355,13 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"fra1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"fra1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"fra1\"}\n    )\n  )\n)",
+              "expr": "min by (provider) (\n  last_over_time(response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"BNB\"}[16m])\n  == bool on(block_number) group_left()\n  last_over_time(response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"BNB\"}[16m])\n)",
               "legendFormat": "{{provider}}",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Provider agreement",
+          "title": "Provider verified",
           "type": "state-timeline"
         },
         {
@@ -1354,7 +1369,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "For each provider in this region (EU), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "description": "Per provider, the percentage of samples whose hashed balance at VERIFY_BLOCK matched the proof-anchored truth (balance_verified) over the chosen time range. 100% means always verified. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1413,7 +1428,7 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Agreed %"
+                  "options": "Verified %"
                 },
                 "properties": [
                   {
@@ -1466,7 +1481,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 39
+            "y": 28
           },
           "id": 1302,
           "options": {
@@ -1483,7 +1498,7 @@
             "sortBy": [
               {
                 "desc": true,
-                "displayName": "Agreed %"
+                "displayName": "Verified %"
               }
             ]
           },
@@ -1495,14 +1510,14 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"fra1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"fra1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"fra1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"fra1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "expr": "sum by (provider) (\n  sum_over_time(\n    (\n      response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"BNB\"}\n      == bool on(block_number) group_left()\n      response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"BNB\"}\n    )[$__range:1m]\n  )\n)\n/\nsum by (provider) (\n  count_over_time(\n    response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"BNB\"}[$__range:1m]\n  )\n)",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",
               "refId": "A"
             }
           ],
-          "title": "Agreement summary",
+          "title": "Verification summary",
           "transformations": [
             {
               "id": "organize",
@@ -1515,16 +1530,139 @@
                   "provider": 0
                 },
                 "renameByName": {
-                  "Value": "Agreed %",
+                  "Value": "Verified %",
                   "provider": "Provider"
                 }
               }
             }
           ],
           "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "State-root verifier health. Each round queries all configured providers for the block's stateRoot \u2014 requires unanimous agreement \u2014 then runs eth_getProof via Chainstack and locally MPT-verifies it to derive the canonical eth_getBalance at PROBE_ADDRESS (= balance_verified). Codes: 0 OK \u00b7 1 stateRoot disagreement \u00b7 2 proof math invalid \u00b7 3 anchor unavailable \u00b7 4 proof unavailable. Non-zero \u2192 no balance_verified this round.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "green",
+                      "index": 0,
+                      "text": "OK"
+                    },
+                    "1": {
+                      "color": "red",
+                      "index": 1,
+                      "text": "stateRoot disagreement"
+                    },
+                    "2": {
+                      "color": "red",
+                      "index": 2,
+                      "text": "proof math invalid"
+                    },
+                    "3": {
+                      "color": "yellow",
+                      "index": 3,
+                      "text": "anchor unavailable"
+                    },
+                    "4": {
+                      "color": "yellow",
+                      "index": 4,
+                      "text": "proof unavailable"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 5,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 36
+          },
+          "id": 1303,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "last_over_time(response_latency_seconds{metric_type=\"verifier_status\", blockchain=\"BNB\"}[16m])",
+              "legendFormat": "status",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Verifier status",
+          "type": "state-timeline"
         }
       ],
-      "title": "Data agreement",
+      "title": "Data correctness",
       "type": "row"
     },
     {

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain-singapore.json
@@ -1232,7 +1232,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Per provider in this region (SG), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "description": "Per provider, did this provider's eth_getBalance at VERIFY_BLOCK match the proof-anchored truth (balance_verified) at the same block. Green - matched. Red - mismatched. Grey - no sample.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1254,10 +1254,25 @@
               "mappings": [
                 {
                   "options": {
+                    "0": {
+                      "color": "red",
+                      "index": 0,
+                      "text": "Mismatched"
+                    },
+                    "1": {
+                      "color": "green",
+                      "index": 1,
+                      "text": "Verified"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
                     "match": "null",
                     "result": {
                       "color": "grey",
-                      "index": 0,
+                      "index": 2,
                       "text": "No data"
                     }
                   },
@@ -1309,7 +1324,7 @@
             "h": 8,
             "w": 18,
             "x": 0,
-            "y": 39
+            "y": 28
           },
           "id": 1301,
           "options": {
@@ -1321,7 +1336,7 @@
             "legend": {
               "displayMode": "list",
               "placement": "bottom",
-              "showLegend": true
+              "showLegend": false
             },
             "mergeValues": true,
             "rowHeight": 0.8,
@@ -1340,13 +1355,13 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"sin1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"sin1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"sin1\"}\n    )\n  )\n)",
+              "expr": "min by (provider) (\n  last_over_time(response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"BNB\"}[16m])\n  == bool on(block_number) group_left()\n  last_over_time(response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"BNB\"}[16m])\n)",
               "legendFormat": "{{provider}}",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Provider agreement",
+          "title": "Provider verified",
           "type": "state-timeline"
         },
         {
@@ -1354,7 +1369,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "For each provider in this region (SG), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "description": "Per provider, the percentage of samples whose hashed balance at VERIFY_BLOCK matched the proof-anchored truth (balance_verified) over the chosen time range. 100% means always verified. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1413,7 +1428,7 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Agreed %"
+                  "options": "Verified %"
                 },
                 "properties": [
                   {
@@ -1466,7 +1481,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 39
+            "y": 28
           },
           "id": 1302,
           "options": {
@@ -1483,7 +1498,7 @@
             "sortBy": [
               {
                 "desc": true,
-                "displayName": "Agreed %"
+                "displayName": "Verified %"
               }
             ]
           },
@@ -1495,14 +1510,14 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"sin1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"sin1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"sin1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"sin1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "expr": "sum by (provider) (\n  sum_over_time(\n    (\n      response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"BNB\"}\n      == bool on(block_number) group_left()\n      response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"BNB\"}\n    )[$__range:1m]\n  )\n)\n/\nsum by (provider) (\n  count_over_time(\n    response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"BNB\"}[$__range:1m]\n  )\n)",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",
               "refId": "A"
             }
           ],
-          "title": "Agreement summary",
+          "title": "Verification summary",
           "transformations": [
             {
               "id": "organize",
@@ -1515,16 +1530,139 @@
                   "provider": 0
                 },
                 "renameByName": {
-                  "Value": "Agreed %",
+                  "Value": "Verified %",
                   "provider": "Provider"
                 }
               }
             }
           ],
           "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "State-root verifier health. Each round queries all configured providers for the block's stateRoot \u2014 requires unanimous agreement \u2014 then runs eth_getProof via Chainstack and locally MPT-verifies it to derive the canonical eth_getBalance at PROBE_ADDRESS (= balance_verified). Codes: 0 OK \u00b7 1 stateRoot disagreement \u00b7 2 proof math invalid \u00b7 3 anchor unavailable \u00b7 4 proof unavailable. Non-zero \u2192 no balance_verified this round.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "green",
+                      "index": 0,
+                      "text": "OK"
+                    },
+                    "1": {
+                      "color": "red",
+                      "index": 1,
+                      "text": "stateRoot disagreement"
+                    },
+                    "2": {
+                      "color": "red",
+                      "index": 2,
+                      "text": "proof math invalid"
+                    },
+                    "3": {
+                      "color": "yellow",
+                      "index": 3,
+                      "text": "anchor unavailable"
+                    },
+                    "4": {
+                      "color": "yellow",
+                      "index": 4,
+                      "text": "proof unavailable"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 5,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 36
+          },
+          "id": 1303,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "last_over_time(response_latency_seconds{metric_type=\"verifier_status\", blockchain=\"BNB\"}[16m])",
+              "legendFormat": "status",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Verifier status",
+          "type": "state-timeline"
         }
       ],
-      "title": "Data agreement",
+      "title": "Data correctness",
       "type": "row"
     },
     {

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain-us-west.json
@@ -1232,7 +1232,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Per provider in this region (US West), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "description": "Per provider, did this provider's eth_getBalance at VERIFY_BLOCK match the proof-anchored truth (balance_verified) at the same block. Green - matched. Red - mismatched. Grey - no sample.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1254,10 +1254,25 @@
               "mappings": [
                 {
                   "options": {
+                    "0": {
+                      "color": "red",
+                      "index": 0,
+                      "text": "Mismatched"
+                    },
+                    "1": {
+                      "color": "green",
+                      "index": 1,
+                      "text": "Verified"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
                     "match": "null",
                     "result": {
                       "color": "grey",
-                      "index": 0,
+                      "index": 2,
                       "text": "No data"
                     }
                   },
@@ -1309,7 +1324,7 @@
             "h": 8,
             "w": 18,
             "x": 0,
-            "y": 39
+            "y": 28
           },
           "id": 1301,
           "options": {
@@ -1321,7 +1336,7 @@
             "legend": {
               "displayMode": "list",
               "placement": "bottom",
-              "showLegend": true
+              "showLegend": false
             },
             "mergeValues": true,
             "rowHeight": 0.8,
@@ -1340,13 +1355,13 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"sfo1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"sfo1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"sfo1\"}\n    )\n  )\n)",
+              "expr": "min by (provider) (\n  last_over_time(response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"BNB\"}[16m])\n  == bool on(block_number) group_left()\n  last_over_time(response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"BNB\"}[16m])\n)",
               "legendFormat": "{{provider}}",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Provider agreement",
+          "title": "Provider verified",
           "type": "state-timeline"
         },
         {
@@ -1354,7 +1369,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "For each provider in this region (US West), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "description": "Per provider, the percentage of samples whose hashed balance at VERIFY_BLOCK matched the proof-anchored truth (balance_verified) over the chosen time range. 100% means always verified. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1413,7 +1428,7 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Agreed %"
+                  "options": "Verified %"
                 },
                 "properties": [
                   {
@@ -1466,7 +1481,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 39
+            "y": 28
           },
           "id": 1302,
           "options": {
@@ -1483,7 +1498,7 @@
             "sortBy": [
               {
                 "desc": true,
-                "displayName": "Agreed %"
+                "displayName": "Verified %"
               }
             ]
           },
@@ -1495,14 +1510,14 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"sfo1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"sfo1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"sfo1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\", source_region=\"sfo1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "expr": "sum by (provider) (\n  sum_over_time(\n    (\n      response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"BNB\"}\n      == bool on(block_number) group_left()\n      response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"BNB\"}\n    )[$__range:1m]\n  )\n)\n/\nsum by (provider) (\n  count_over_time(\n    response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"BNB\"}[$__range:1m]\n  )\n)",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",
               "refId": "A"
             }
           ],
-          "title": "Agreement summary",
+          "title": "Verification summary",
           "transformations": [
             {
               "id": "organize",
@@ -1515,16 +1530,139 @@
                   "provider": 0
                 },
                 "renameByName": {
-                  "Value": "Agreed %",
+                  "Value": "Verified %",
                   "provider": "Provider"
                 }
               }
             }
           ],
           "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "State-root verifier health. Each round queries all configured providers for the block's stateRoot \u2014 requires unanimous agreement \u2014 then runs eth_getProof via Chainstack and locally MPT-verifies it to derive the canonical eth_getBalance at PROBE_ADDRESS (= balance_verified). Codes: 0 OK \u00b7 1 stateRoot disagreement \u00b7 2 proof math invalid \u00b7 3 anchor unavailable \u00b7 4 proof unavailable. Non-zero \u2192 no balance_verified this round.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "green",
+                      "index": 0,
+                      "text": "OK"
+                    },
+                    "1": {
+                      "color": "red",
+                      "index": 1,
+                      "text": "stateRoot disagreement"
+                    },
+                    "2": {
+                      "color": "red",
+                      "index": 2,
+                      "text": "proof math invalid"
+                    },
+                    "3": {
+                      "color": "yellow",
+                      "index": 3,
+                      "text": "anchor unavailable"
+                    },
+                    "4": {
+                      "color": "yellow",
+                      "index": 4,
+                      "text": "proof unavailable"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 5,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 36
+          },
+          "id": 1303,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "last_over_time(response_latency_seconds{metric_type=\"verifier_status\", blockchain=\"BNB\"}[16m])",
+              "legendFormat": "status",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Verifier status",
+          "type": "state-timeline"
         }
       ],
-      "title": "Data agreement",
+      "title": "Data correctness",
       "type": "row"
     },
     {

--- a/dashboards/dashboards/compare-dashboard-bnb-smart-chain.json
+++ b/dashboards/dashboards/compare-dashboard-bnb-smart-chain.json
@@ -1736,7 +1736,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Per provider, did this provider's answer match the majority answer in every region it participated in at this moment. Green - matched the majority everywhere. Red - was an outlier in at least one region. Grey - no data captured.",
+          "description": "Per provider, did this provider's eth_getBalance at VERIFY_BLOCK match the proof-anchored truth (balance_verified) at the same block. Green - matched. Red - mismatched. Grey - no sample.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1758,10 +1758,25 @@
               "mappings": [
                 {
                   "options": {
+                    "0": {
+                      "color": "red",
+                      "index": 0,
+                      "text": "Mismatched"
+                    },
+                    "1": {
+                      "color": "green",
+                      "index": 1,
+                      "text": "Verified"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
                     "match": "null",
                     "result": {
                       "color": "grey",
-                      "index": 0,
+                      "index": 2,
                       "text": "No data"
                     }
                   },
@@ -1825,7 +1840,7 @@
             "legend": {
               "displayMode": "list",
               "placement": "bottom",
-              "showLegend": true
+              "showLegend": false
             },
             "mergeValues": true,
             "rowHeight": 0.8,
@@ -1844,13 +1859,13 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "min by (provider) (\n  (\n    group by (provider, source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\"}\n    )\n    *\n    on(source_region, block_number, value) group_left()\n    count by (source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\"}\n    )\n  )\n  ==\n  bool on(source_region, block_number) group_left()\n  max by (source_region, block_number) (\n    count by (source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\"}\n    )\n  )\n)",
+              "expr": "min by (provider) (\n  last_over_time(response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"BNB\"}[16m])\n  == bool on(block_number) group_left()\n  last_over_time(response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"BNB\"}[16m])\n)",
               "legendFormat": "{{provider}}",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Provider agreement",
+          "title": "Provider verified",
           "type": "state-timeline"
         },
         {
@@ -1858,7 +1873,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "For each provider in each region, the percentage of samples this provider returned that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "description": "Per provider, the percentage of samples whose hashed balance at VERIFY_BLOCK matched the proof-anchored truth (balance_verified) over the chosen time range. 100% means always verified. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1917,41 +1932,7 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Region"
-                },
-                "properties": [
-                  {
-                    "id": "custom.width",
-                    "value": 70
-                  },
-                  {
-                    "id": "mappings",
-                    "value": [
-                      {
-                        "options": {
-                          "fra1": {
-                            "index": 0,
-                            "text": "EU"
-                          },
-                          "sfo1": {
-                            "index": 2,
-                            "text": "US West"
-                          },
-                          "sin1": {
-                            "index": 1,
-                            "text": "SG"
-                          }
-                        },
-                        "type": "value"
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Agreed %"
+                  "options": "Verified %"
                 },
                 "properties": [
                   {
@@ -2021,7 +2002,7 @@
             "sortBy": [
               {
                 "desc": true,
-                "displayName": "Agreed %"
+                "displayName": "Verified %"
               }
             ]
           },
@@ -2033,14 +2014,14 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "sum by (provider, source_region) (\n  max_over_time(\n    (\n      (\n        group by (provider, source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\"}\n        )\n        *\n        on(source_region, block_number, value) group_left()\n        count by (source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\"}\n        )\n      )\n      ==\n      bool on(source_region, block_number) group_left()\n      max by (source_region, block_number) (\n        count by (source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider, source_region) (\n  max_over_time(\n    (\n      group by (provider, source_region, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"BNB\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "expr": "sum by (provider) (\n  sum_over_time(\n    (\n      response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"BNB\"}\n      == bool on(block_number) group_left()\n      response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"BNB\"}\n    )[$__range:1m]\n  )\n)\n/\nsum by (provider) (\n  count_over_time(\n    response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"BNB\"}[$__range:1m]\n  )\n)",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",
               "refId": "A"
             }
           ],
-          "title": "Agreement summary",
+          "title": "Verification summary",
           "transformations": [
             {
               "id": "organize",
@@ -2049,22 +2030,143 @@
                   "Time": true
                 },
                 "indexByName": {
-                  "Value": 2,
-                  "provider": 0,
-                  "source_region": 1
+                  "Value": 1,
+                  "provider": 0
                 },
                 "renameByName": {
-                  "Value": "Agreed %",
-                  "provider": "Provider",
-                  "source_region": "Region"
+                  "Value": "Verified %",
+                  "provider": "Provider"
                 }
               }
             }
           ],
           "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "State-root verifier health. Each round queries all configured providers for the block's stateRoot \u2014 requires unanimous agreement \u2014 then runs eth_getProof via Chainstack and locally MPT-verifies it to derive the canonical eth_getBalance at PROBE_ADDRESS (= balance_verified). Codes: 0 OK \u00b7 1 stateRoot disagreement \u00b7 2 proof math invalid \u00b7 3 anchor unavailable \u00b7 4 proof unavailable. Non-zero \u2192 no balance_verified this round.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "green",
+                      "index": 0,
+                      "text": "OK"
+                    },
+                    "1": {
+                      "color": "red",
+                      "index": 1,
+                      "text": "stateRoot disagreement"
+                    },
+                    "2": {
+                      "color": "red",
+                      "index": 2,
+                      "text": "proof math invalid"
+                    },
+                    "3": {
+                      "color": "yellow",
+                      "index": 3,
+                      "text": "anchor unavailable"
+                    },
+                    "4": {
+                      "color": "yellow",
+                      "index": 4,
+                      "text": "proof unavailable"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 5,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 44
+          },
+          "id": 303,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "last_over_time(response_latency_seconds{metric_type=\"verifier_status\", blockchain=\"BNB\"}[16m])",
+              "legendFormat": "status",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Verifier status",
+          "type": "state-timeline"
         }
       ],
-      "title": "Data agreement",
+      "title": "Data correctness",
       "type": "row"
     },
     {

--- a/dashboards/dashboards/compare-dashboard-ethereum-eu.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum-eu.json
@@ -1159,7 +1159,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Per provider in this region (EU), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "description": "Per provider, did this provider's eth_getBalance at VERIFY_BLOCK match the proof-anchored truth (balance_verified) at the same block. Green - matched. Red - mismatched. Grey - no sample.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1181,10 +1181,25 @@
               "mappings": [
                 {
                   "options": {
+                    "0": {
+                      "color": "red",
+                      "index": 0,
+                      "text": "Mismatched"
+                    },
+                    "1": {
+                      "color": "green",
+                      "index": 1,
+                      "text": "Verified"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
                     "match": "null",
                     "result": {
                       "color": "grey",
-                      "index": 0,
+                      "index": 2,
                       "text": "No data"
                     }
                   },
@@ -1236,7 +1251,7 @@
             "h": 8,
             "w": 18,
             "x": 0,
-            "y": 39
+            "y": 28
           },
           "id": 1301,
           "options": {
@@ -1248,7 +1263,7 @@
             "legend": {
               "displayMode": "list",
               "placement": "bottom",
-              "showLegend": true
+              "showLegend": false
             },
             "mergeValues": true,
             "rowHeight": 0.8,
@@ -1267,13 +1282,13 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"fra1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"fra1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"fra1\"}\n    )\n  )\n)",
+              "expr": "min by (provider) (\n  last_over_time(response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Ethereum\"}[16m])\n  == bool on(block_number) group_left()\n  last_over_time(response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Ethereum\"}[16m])\n)",
               "legendFormat": "{{provider}}",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Provider agreement",
+          "title": "Provider verified",
           "type": "state-timeline"
         },
         {
@@ -1281,7 +1296,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "For each provider in this region (EU), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "description": "Per provider, the percentage of samples whose hashed balance at VERIFY_BLOCK matched the proof-anchored truth (balance_verified) over the chosen time range. 100% means always verified. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1340,7 +1355,7 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Agreed %"
+                  "options": "Verified %"
                 },
                 "properties": [
                   {
@@ -1393,7 +1408,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 39
+            "y": 28
           },
           "id": 1302,
           "options": {
@@ -1410,7 +1425,7 @@
             "sortBy": [
               {
                 "desc": true,
-                "displayName": "Agreed %"
+                "displayName": "Verified %"
               }
             ]
           },
@@ -1422,14 +1437,14 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"fra1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"fra1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"fra1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"fra1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "expr": "sum by (provider) (\n  sum_over_time(\n    (\n      response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Ethereum\"}\n      == bool on(block_number) group_left()\n      response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Ethereum\"}\n    )[$__range:1m]\n  )\n)\n/\nsum by (provider) (\n  count_over_time(\n    response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Ethereum\"}[$__range:1m]\n  )\n)",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",
               "refId": "A"
             }
           ],
-          "title": "Agreement summary",
+          "title": "Verification summary",
           "transformations": [
             {
               "id": "organize",
@@ -1442,16 +1457,139 @@
                   "provider": 0
                 },
                 "renameByName": {
-                  "Value": "Agreed %",
+                  "Value": "Verified %",
                   "provider": "Provider"
                 }
               }
             }
           ],
           "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "State-root verifier health. Each round queries all configured providers for the block's stateRoot \u2014 requires unanimous agreement \u2014 then runs eth_getProof via Chainstack and locally MPT-verifies it to derive the canonical eth_getBalance at PROBE_ADDRESS (= balance_verified). Codes: 0 OK \u00b7 1 stateRoot disagreement \u00b7 2 proof math invalid \u00b7 3 anchor unavailable \u00b7 4 proof unavailable. Non-zero \u2192 no balance_verified this round.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "green",
+                      "index": 0,
+                      "text": "OK"
+                    },
+                    "1": {
+                      "color": "red",
+                      "index": 1,
+                      "text": "stateRoot disagreement"
+                    },
+                    "2": {
+                      "color": "red",
+                      "index": 2,
+                      "text": "proof math invalid"
+                    },
+                    "3": {
+                      "color": "yellow",
+                      "index": 3,
+                      "text": "anchor unavailable"
+                    },
+                    "4": {
+                      "color": "yellow",
+                      "index": 4,
+                      "text": "proof unavailable"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 5,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 36
+          },
+          "id": 1303,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "last_over_time(response_latency_seconds{metric_type=\"verifier_status\", blockchain=\"Ethereum\"}[16m])",
+              "legendFormat": "status",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Verifier status",
+          "type": "state-timeline"
         }
       ],
-      "title": "Data agreement",
+      "title": "Data correctness",
       "type": "row"
     },
     {

--- a/dashboards/dashboards/compare-dashboard-ethereum-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum-singapore.json
@@ -1233,7 +1233,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Per provider in this region (SG), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "description": "Per provider, did this provider's eth_getBalance at VERIFY_BLOCK match the proof-anchored truth (balance_verified) at the same block. Green - matched. Red - mismatched. Grey - no sample.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1255,10 +1255,25 @@
               "mappings": [
                 {
                   "options": {
+                    "0": {
+                      "color": "red",
+                      "index": 0,
+                      "text": "Mismatched"
+                    },
+                    "1": {
+                      "color": "green",
+                      "index": 1,
+                      "text": "Verified"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
                     "match": "null",
                     "result": {
                       "color": "grey",
-                      "index": 0,
+                      "index": 2,
                       "text": "No data"
                     }
                   },
@@ -1310,7 +1325,7 @@
             "h": 8,
             "w": 18,
             "x": 0,
-            "y": 39
+            "y": 28
           },
           "id": 1301,
           "options": {
@@ -1322,7 +1337,7 @@
             "legend": {
               "displayMode": "list",
               "placement": "bottom",
-              "showLegend": true
+              "showLegend": false
             },
             "mergeValues": true,
             "rowHeight": 0.8,
@@ -1341,13 +1356,13 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"sin1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"sin1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"sin1\"}\n    )\n  )\n)",
+              "expr": "min by (provider) (\n  last_over_time(response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Ethereum\"}[16m])\n  == bool on(block_number) group_left()\n  last_over_time(response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Ethereum\"}[16m])\n)",
               "legendFormat": "{{provider}}",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Provider agreement",
+          "title": "Provider verified",
           "type": "state-timeline"
         },
         {
@@ -1355,7 +1370,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "For each provider in this region (SG), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "description": "Per provider, the percentage of samples whose hashed balance at VERIFY_BLOCK matched the proof-anchored truth (balance_verified) over the chosen time range. 100% means always verified. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1414,7 +1429,7 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Agreed %"
+                  "options": "Verified %"
                 },
                 "properties": [
                   {
@@ -1467,7 +1482,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 39
+            "y": 28
           },
           "id": 1302,
           "options": {
@@ -1484,7 +1499,7 @@
             "sortBy": [
               {
                 "desc": true,
-                "displayName": "Agreed %"
+                "displayName": "Verified %"
               }
             ]
           },
@@ -1496,14 +1511,14 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"sin1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"sin1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"sin1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"sin1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "expr": "sum by (provider) (\n  sum_over_time(\n    (\n      response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Ethereum\"}\n      == bool on(block_number) group_left()\n      response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Ethereum\"}\n    )[$__range:1m]\n  )\n)\n/\nsum by (provider) (\n  count_over_time(\n    response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Ethereum\"}[$__range:1m]\n  )\n)",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",
               "refId": "A"
             }
           ],
-          "title": "Agreement summary",
+          "title": "Verification summary",
           "transformations": [
             {
               "id": "organize",
@@ -1516,16 +1531,139 @@
                   "provider": 0
                 },
                 "renameByName": {
-                  "Value": "Agreed %",
+                  "Value": "Verified %",
                   "provider": "Provider"
                 }
               }
             }
           ],
           "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "State-root verifier health. Each round queries all configured providers for the block's stateRoot \u2014 requires unanimous agreement \u2014 then runs eth_getProof via Chainstack and locally MPT-verifies it to derive the canonical eth_getBalance at PROBE_ADDRESS (= balance_verified). Codes: 0 OK \u00b7 1 stateRoot disagreement \u00b7 2 proof math invalid \u00b7 3 anchor unavailable \u00b7 4 proof unavailable. Non-zero \u2192 no balance_verified this round.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "green",
+                      "index": 0,
+                      "text": "OK"
+                    },
+                    "1": {
+                      "color": "red",
+                      "index": 1,
+                      "text": "stateRoot disagreement"
+                    },
+                    "2": {
+                      "color": "red",
+                      "index": 2,
+                      "text": "proof math invalid"
+                    },
+                    "3": {
+                      "color": "yellow",
+                      "index": 3,
+                      "text": "anchor unavailable"
+                    },
+                    "4": {
+                      "color": "yellow",
+                      "index": 4,
+                      "text": "proof unavailable"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 5,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 36
+          },
+          "id": 1303,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "last_over_time(response_latency_seconds{metric_type=\"verifier_status\", blockchain=\"Ethereum\"}[16m])",
+              "legendFormat": "status",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Verifier status",
+          "type": "state-timeline"
         }
       ],
-      "title": "Data agreement",
+      "title": "Data correctness",
       "type": "row"
     },
     {

--- a/dashboards/dashboards/compare-dashboard-ethereum-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum-us-west.json
@@ -1233,7 +1233,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Per provider in this region (US West), did this provider's answer match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "description": "Per provider, did this provider's eth_getBalance at VERIFY_BLOCK match the proof-anchored truth (balance_verified) at the same block. Green - matched. Red - mismatched. Grey - no sample.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1255,10 +1255,25 @@
               "mappings": [
                 {
                   "options": {
+                    "0": {
+                      "color": "red",
+                      "index": 0,
+                      "text": "Mismatched"
+                    },
+                    "1": {
+                      "color": "green",
+                      "index": 1,
+                      "text": "Verified"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
                     "match": "null",
                     "result": {
                       "color": "grey",
-                      "index": 0,
+                      "index": 2,
                       "text": "No data"
                     }
                   },
@@ -1310,7 +1325,7 @@
             "h": 8,
             "w": 18,
             "x": 0,
-            "y": 39
+            "y": 28
           },
           "id": 1301,
           "options": {
@@ -1322,7 +1337,7 @@
             "legend": {
               "displayMode": "list",
               "placement": "bottom",
-              "showLegend": true
+              "showLegend": false
             },
             "mergeValues": true,
             "rowHeight": 0.8,
@@ -1341,13 +1356,13 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"sfo1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"sfo1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"sfo1\"}\n    )\n  )\n)",
+              "expr": "min by (provider) (\n  last_over_time(response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Ethereum\"}[16m])\n  == bool on(block_number) group_left()\n  last_over_time(response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Ethereum\"}[16m])\n)",
               "legendFormat": "{{provider}}",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Provider agreement",
+          "title": "Provider verified",
           "type": "state-timeline"
         },
         {
@@ -1355,7 +1370,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "For each provider in this region (US West), the percentage of samples that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "description": "Per provider, the percentage of samples whose hashed balance at VERIFY_BLOCK matched the proof-anchored truth (balance_verified) over the chosen time range. 100% means always verified. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1414,7 +1429,7 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Agreed %"
+                  "options": "Verified %"
                 },
                 "properties": [
                   {
@@ -1467,7 +1482,7 @@
             "h": 8,
             "w": 6,
             "x": 18,
-            "y": 39
+            "y": 28
           },
           "id": 1302,
           "options": {
@@ -1484,7 +1499,7 @@
             "sortBy": [
               {
                 "desc": true,
-                "displayName": "Agreed %"
+                "displayName": "Verified %"
               }
             ]
           },
@@ -1496,14 +1511,14 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"sfo1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"sfo1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"sfo1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\", source_region=\"sfo1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "expr": "sum by (provider) (\n  sum_over_time(\n    (\n      response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Ethereum\"}\n      == bool on(block_number) group_left()\n      response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Ethereum\"}\n    )[$__range:1m]\n  )\n)\n/\nsum by (provider) (\n  count_over_time(\n    response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Ethereum\"}[$__range:1m]\n  )\n)",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",
               "refId": "A"
             }
           ],
-          "title": "Agreement summary",
+          "title": "Verification summary",
           "transformations": [
             {
               "id": "organize",
@@ -1516,16 +1531,139 @@
                   "provider": 0
                 },
                 "renameByName": {
-                  "Value": "Agreed %",
+                  "Value": "Verified %",
                   "provider": "Provider"
                 }
               }
             }
           ],
           "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "State-root verifier health. Each round queries all configured providers for the block's stateRoot \u2014 requires unanimous agreement \u2014 then runs eth_getProof via Chainstack and locally MPT-verifies it to derive the canonical eth_getBalance at PROBE_ADDRESS (= balance_verified). Codes: 0 OK \u00b7 1 stateRoot disagreement \u00b7 2 proof math invalid \u00b7 3 anchor unavailable \u00b7 4 proof unavailable. Non-zero \u2192 no balance_verified this round.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "green",
+                      "index": 0,
+                      "text": "OK"
+                    },
+                    "1": {
+                      "color": "red",
+                      "index": 1,
+                      "text": "stateRoot disagreement"
+                    },
+                    "2": {
+                      "color": "red",
+                      "index": 2,
+                      "text": "proof math invalid"
+                    },
+                    "3": {
+                      "color": "yellow",
+                      "index": 3,
+                      "text": "anchor unavailable"
+                    },
+                    "4": {
+                      "color": "yellow",
+                      "index": 4,
+                      "text": "proof unavailable"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 5,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 36
+          },
+          "id": 1303,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "last_over_time(response_latency_seconds{metric_type=\"verifier_status\", blockchain=\"Ethereum\"}[16m])",
+              "legendFormat": "status",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Verifier status",
+          "type": "state-timeline"
         }
       ],
-      "title": "Data agreement",
+      "title": "Data correctness",
       "type": "row"
     },
     {

--- a/dashboards/dashboards/compare-dashboard-ethereum.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum.json
@@ -2025,7 +2025,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Health of the independent state-root verifier (api/support/verify_state.py), a Vercel cron that runs from fra1 every 15 minutes. Each round it picks a recent block, asks a quorum of independent beacon providers (Alchemy and other non-Chainstack/non-dRPC nodes) for that block's stateRoot, then uses eth_getProof to derive the canonical eth_getBalance answer at PROBE_ADDRESS. That proof-anchored value is balance_verified — the ground truth the 'Provider verified' panel above compares every provider's response against. Status codes: 0 = OK (stateRoot quorum + MPT proof succeeded). 1 = stateRoot disagreement among beacon providers. 2 = proof math invalid. 3 = anchor unavailable (no beacon stateRoot). 4 = proof unavailable (eth_getProof failed). Non-zero values mean no balance_verified was emitted this round, so 'Provider verified' will show grey for that interval.",
+          "description": "State-root verifier health. Each round queries all configured providers for the block's stateRoot — requires unanimous agreement — then runs eth_getProof via Chainstack and locally MPT-verifies it to derive the canonical eth_getBalance at PROBE_ADDRESS (= balance_verified). Codes: 0 OK · 1 stateRoot disagreement · 2 proof math invalid · 3 anchor unavailable · 4 proof unavailable. Non-zero → no balance_verified this round.",
           "fieldConfig": {
             "defaults": {
               "color": {

--- a/dashboards/dashboards/compare-dashboard-ethereum.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum.json
@@ -1822,7 +1822,7 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Ethereum\"}\n== bool on(block_number) group_left()\nresponse_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Ethereum\"}",
+              "expr": "min by (provider) (\n  response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Ethereum\"}\n  == bool on(block_number) group_left()\n  response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Ethereum\"}\n)",
               "legendFormat": "{{provider}}",
               "range": true,
               "refId": "A"
@@ -1977,7 +1977,7 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Ethereum\"}\n      == bool on(block_number) group_left()\n      response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Ethereum\"}\n    )[$__range:1m]\n  )\n)\n/\nsum by (provider) (\n  count_over_time(\n    response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Ethereum\"}[$__range:1m]\n  )\n)",
+              "expr": "sum by (provider) (\n  sum_over_time(\n    (\n      response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Ethereum\"}\n      == bool on(block_number) group_left()\n      response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Ethereum\"}\n    )[$__range:1m]\n  )\n)\n/\nsum by (provider) (\n  count_over_time(\n    response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Ethereum\"}[$__range:1m]\n  )\n)",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",

--- a/dashboards/dashboards/compare-dashboard-ethereum.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum.json
@@ -2025,7 +2025,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Verifier health code. 0=OK (stateRoot quorum + MPT proof verified). 1=stateRoot disagreement among beacon providers. 2=proof math invalid. 3=anchor unavailable (no beacon/stateRoot). 4=proof unavailable (eth_getProof failed). Non-zero values mean the verifier could not produce an authoritative balance_verified for this round.",
+          "description": "Health of the independent state-root verifier (api/support/verify_state.py), a Vercel cron that runs from fra1 every 15 minutes. Each round it picks a recent block, asks a quorum of independent beacon providers (Alchemy and other non-Chainstack/non-dRPC nodes) for that block's stateRoot, then uses eth_getProof to derive the canonical eth_getBalance answer at PROBE_ADDRESS. That proof-anchored value is balance_verified — the ground truth the 'Provider verified' panel above compares every provider's response against. Status codes: 0 = OK (stateRoot quorum + MPT proof succeeded). 1 = stateRoot disagreement among beacon providers. 2 = proof math invalid. 3 = anchor unavailable (no beacon stateRoot). 4 = proof unavailable (eth_getProof failed). Non-zero values mean no balance_verified was emitted this round, so 'Provider verified' will show grey for that interval.",
           "fieldConfig": {
             "defaults": {
               "color": {

--- a/dashboards/dashboards/compare-dashboard-ethereum.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum.json
@@ -2144,7 +2144,7 @@
           "type": "state-timeline"
         }
       ],
-      "title": "Verified state",
+      "title": "Data correctness",
       "type": "row"
     },
     {

--- a/dashboards/dashboards/compare-dashboard-ethereum.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum.json
@@ -2093,6 +2093,14 @@
                   {
                     "color": "green",
                     "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 1
+                  },
+                  {
+                    "color": "yellow",
+                    "value": 3
                   }
                 ]
               }

--- a/dashboards/dashboards/compare-dashboard-ethereum.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum.json
@@ -1736,10 +1736,25 @@
               "mappings": [
                 {
                   "options": {
+                    "0": {
+                      "color": "red",
+                      "index": 0,
+                      "text": "Mismatched"
+                    },
+                    "1": {
+                      "color": "green",
+                      "index": 1,
+                      "text": "Verified"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
                     "match": "null",
                     "result": {
                       "color": "grey",
-                      "index": 0,
+                      "index": 2,
                       "text": "No data"
                     }
                   },

--- a/dashboards/dashboards/compare-dashboard-ethereum.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum.json
@@ -1818,7 +1818,7 @@
             "legend": {
               "displayMode": "list",
               "placement": "bottom",
-              "showLegend": true
+              "showLegend": false
             },
             "mergeValues": true,
             "rowHeight": 0.8,
@@ -2119,7 +2119,7 @@
             },
             "mergeValues": true,
             "rowHeight": 0.8,
-            "showValue": "always",
+            "showValue": "auto",
             "tooltip": {
               "hideZeros": false,
               "mode": "single",

--- a/dashboards/dashboards/compare-dashboard-ethereum.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum.json
@@ -1714,7 +1714,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "Per provider, did this provider's answer match the majority answer in every region it participated in at this moment. Green - matched the majority everywhere. Red - was an outlier in at least one region. Grey - no data captured.",
+          "description": "Per provider, did this provider's eth_getBalance at VERIFY_BLOCK match the proof-anchored truth (balance_verified) at the same block. Green - matched. Red - mismatched. Grey - no sample.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1822,13 +1822,13 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "min by (provider) (\n  (\n    group by (provider, source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\"}\n    )\n    *\n    on(source_region, block_number, value) group_left()\n    count by (source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\"}\n    )\n  )\n  ==\n  bool on(source_region, block_number) group_left()\n  max by (source_region, block_number) (\n    count by (source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\"}\n    )\n  )\n)",
+              "expr": "response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Ethereum\"}\n== bool on(block_number) group_left()\nresponse_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Ethereum\"}",
               "legendFormat": "{{provider}}",
               "range": true,
               "refId": "A"
             }
           ],
-          "title": "Provider agreement",
+          "title": "Provider verified",
           "type": "state-timeline"
         },
         {
@@ -1836,7 +1836,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "For each provider in each region, the percentage of samples this provider returned that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "description": "Per provider, the percentage of samples whose hashed balance at VERIFY_BLOCK matched the proof-anchored truth (balance_verified) over the chosen time range. 100% means always verified. Sorted highest first.",
           "fieldConfig": {
             "defaults": {
               "color": {
@@ -1895,41 +1895,7 @@
               {
                 "matcher": {
                   "id": "byName",
-                  "options": "Region"
-                },
-                "properties": [
-                  {
-                    "id": "custom.width",
-                    "value": 70
-                  },
-                  {
-                    "id": "mappings",
-                    "value": [
-                      {
-                        "options": {
-                          "fra1": {
-                            "index": 0,
-                            "text": "EU"
-                          },
-                          "sfo1": {
-                            "index": 2,
-                            "text": "US West"
-                          },
-                          "sin1": {
-                            "index": 1,
-                            "text": "SG"
-                          }
-                        },
-                        "type": "value"
-                      }
-                    ]
-                  }
-                ]
-              },
-              {
-                "matcher": {
-                  "id": "byName",
-                  "options": "Agreed %"
+                  "options": "Verified %"
                 },
                 "properties": [
                   {
@@ -1999,7 +1965,7 @@
             "sortBy": [
               {
                 "desc": true,
-                "displayName": "Agreed %"
+                "displayName": "Verified %"
               }
             ]
           },
@@ -2011,14 +1977,14 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "sum by (provider, source_region) (\n  max_over_time(\n    (\n      (\n        group by (provider, source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\"}\n        )\n        *\n        on(source_region, block_number, value) group_left()\n        count by (source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\"}\n        )\n      )\n      ==\n      bool on(source_region, block_number) group_left()\n      max by (source_region, block_number) (\n        count by (source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider, source_region) (\n  max_over_time(\n    (\n      group by (provider, source_region, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Ethereum\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Ethereum\"}\n      == bool on(block_number) group_left()\n      response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Ethereum\"}\n    )[$__range:1m]\n  )\n)\n/\nsum by (provider) (\n  count_over_time(\n    response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Ethereum\"}[$__range:1m]\n  )\n)",
               "format": "table",
               "instant": true,
               "legendFormat": "__auto",
               "refId": "A"
             }
           ],
-          "title": "Agreement summary",
+          "title": "Verification summary",
           "transformations": [
             {
               "id": "organize",
@@ -2027,22 +1993,143 @@
                   "Time": true
                 },
                 "indexByName": {
-                  "Value": 2,
-                  "provider": 0,
-                  "source_region": 1
+                  "Value": 1,
+                  "provider": 0
                 },
                 "renameByName": {
-                  "Value": "Agreed %",
-                  "provider": "Provider",
-                  "source_region": "Region"
+                  "Value": "Verified %",
+                  "provider": "Provider"
                 }
               }
             }
           ],
           "type": "table"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Verifier health code. 0=OK (stateRoot quorum + MPT proof verified). 1=stateRoot disagreement among beacon providers. 2=proof math invalid. 3=anchor unavailable (no beacon/stateRoot). 4=proof unavailable (eth_getProof failed). Non-zero values mean the verifier could not produce an authoritative balance_verified for this round.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "0": {
+                      "color": "green",
+                      "index": 0,
+                      "text": "OK"
+                    },
+                    "1": {
+                      "color": "red",
+                      "index": 1,
+                      "text": "stateRoot disagreement"
+                    },
+                    "2": {
+                      "color": "red",
+                      "index": 2,
+                      "text": "proof math invalid"
+                    },
+                    "3": {
+                      "color": "yellow",
+                      "index": 3,
+                      "text": "anchor unavailable"
+                    },
+                    "4": {
+                      "color": "yellow",
+                      "index": 4,
+                      "text": "proof unavailable"
+                    }
+                  },
+                  "type": "value"
+                },
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 5,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 24,
+            "x": 0,
+            "y": 45
+          },
+          "id": 303,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": false
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "always",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "response_latency_seconds{metric_type=\"verifier_status\", blockchain=\"Ethereum\"}",
+              "legendFormat": "status",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Verifier status",
+          "type": "state-timeline"
         }
       ],
-      "title": "Data agreement",
+      "title": "Verified state",
       "type": "row"
     },
     {

--- a/dashboards/dashboards/compare-dashboard-ethereum.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum.json
@@ -1822,7 +1822,7 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "min by (provider) (\n  response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Ethereum\"}\n  == bool on(block_number) group_left()\n  response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Ethereum\"}\n)",
+              "expr": "min by (provider) (\n  last_over_time(response_latency_seconds{metric_type=\"balance_observed_verified\", blockchain=\"Ethereum\"}[16m])\n  == bool on(block_number) group_left()\n  last_over_time(response_latency_seconds{metric_type=\"balance_verified\", blockchain=\"Ethereum\"}[16m])\n)",
               "legendFormat": "{{provider}}",
               "range": true,
               "refId": "A"
@@ -2119,7 +2119,7 @@
                 "uid": "grafanacloud-prom"
               },
               "editorMode": "code",
-              "expr": "response_latency_seconds{metric_type=\"verifier_status\", blockchain=\"Ethereum\"}",
+              "expr": "last_over_time(response_latency_seconds{metric_type=\"verifier_status\", blockchain=\"Ethereum\"}[16m])",
               "legendFormat": "status",
               "range": true,
               "refId": "A"

--- a/dashboards/dashboards/compare-dashboard-ethereum.json
+++ b/dashboards/dashboards/compare-dashboard-ethereum.json
@@ -2093,14 +2093,6 @@
                   {
                     "color": "green",
                     "value": null
-                  },
-                  {
-                    "color": "red",
-                    "value": 1
-                  },
-                  {
-                    "color": "yellow",
-                    "value": 3
                   }
                 ]
               }
@@ -2127,7 +2119,7 @@
             },
             "mergeValues": true,
             "rowHeight": 0.8,
-            "showValue": "auto",
+            "showValue": "never",
             "tooltip": {
               "hideZeros": false,
               "mode": "single",


### PR DESCRIPTION
## Summary

Retroactive PR for the v2.1 dashboard panel swap that was rolled out directly on master. Posted here for review/paper trail.

Replaces every EVM chain's "Data agreement" row (v1 PromQL mode-quorum on `balance_observed`) with a new "Data correctness" row anchored on v2.1's proof-derived `balance_verified`.

**Scope:** 16 dashboards
- Ethereum + 3 regionals (eu/singapore/us-west)
- Base + 3 regionals (eu/japan/us-west)
- BNB Smart Chain + 3 regionals (eu/singapore/us-west)
- Arbitrum + 3 regionals (eu/japan/us-west)

**New panels per dashboard:**
- **Provider verified** — state-timeline, `min by (provider)` over `balance_observed_verified == bool on(block_number) group_left() balance_verified`, wrapped in `last_over_time(...[16m])` to bridge the 15-min cron cadence.
- **Verification summary** — table, `sum_over_time(matches) / sum_over_time(count_over_time(observed))` per provider. Region column dropped since the verifier runs in fra1 only.
- **Verifier status** — state-timeline of the `verifier_status` code (0 OK · 1 stateRoot disagreement · 2 proof math invalid · 3 anchor unavailable · 4 proof unavailable), with value mappings for colors and clean cells (no text, no legend, no threshold ladder).

**Iteration history** captured in commit log — early versions hit Grafana's threshold-rendering quirks (≪1/1+ legend, ∞ in cells); commits `dd47701`, `bc989f2`, `5effb14`, `959e48c` walk through the fixes.

**Non-EVM chains** (Solana, TON, Hyperliquid, Monad) are intentionally untouched — the verifier is MPT-specific and only `VERIFY_BLOCK_OFFSET_RANGES` lists Ethereum/Base/BNB/Arbitrum.

## Test plan

- [x] All 16 dashboards push to Grafana without error (already done, on master)
- [x] JSON validity verified before push
- [x] Provider verified panel collapses to one row per provider (no `block_number` cardinality explosion)
- [x] Verification summary % is sensible (num/den both use `_over_time` so the 5-min staleness window cancels out)
- [x] Verifier status cells render via value mappings only — no ∞, no threshold-band legend
- [x] Visually spot-check each of the 15 non-Ethereum-global dashboards in Grafana