### PR TITLE
feat: data agreement metrics for hyperliquid/solana/ton

### DIFF
--- a/api/read/solana.py
+++ b/api/read/solana.py
@@ -3,6 +3,7 @@
 from common.metrics_handler import BaseVercelHandler, MetricsHandler
 from config.defaults import MetricsServiceConfig
 from metrics.solana import (
+    HTTPAccountAgreementMetric,
     HTTPGetBalanceLatencyMetric,
     HTTPGetBlockLatencyMetric,
     HTTPGetProgramAccsLatencyMetric,
@@ -20,6 +21,7 @@ METRICS = [
     (HTTPGetBlockLatencyMetric, METRIC_NAME),
     (HTTPGetTxLatencyMetric, METRIC_NAME),
     (HTTPGetProgramAccsLatencyMetric, METRIC_NAME),
+    (HTTPAccountAgreementMetric, METRIC_NAME),
 ]
 
 

--- a/api/read/ton.py
+++ b/api/read/ton.py
@@ -3,6 +3,7 @@
 from common.metrics_handler import BaseVercelHandler, MetricsHandler
 from config.defaults import MetricsServiceConfig
 from metrics.ton import (
+    HTTPAccountAgreementMetric,
     HTTPGetAddressBalanceLatencyMetric,
     HTTPGetBlockHeaderLatencyMetric,
     HTTPGetBlockTxsLatencyMetric,
@@ -20,6 +21,7 @@ METRICS = [
     (HTTPGetAddressBalanceLatencyMetric, METRIC_NAME),
     (HTTPGetBlockTxsLatencyMetric, METRIC_NAME),
     (HTTPGetWalletTxsLatencyMetric, METRIC_NAME),
+    (HTTPAccountAgreementMetric, METRIC_NAME),
 ]
 
 

--- a/common/balance_hash.py
+++ b/common/balance_hash.py
@@ -34,3 +34,23 @@ def hash_balance_to_float(balance: int) -> float:
         raise ValueError(f"balance must be non-negative, got {balance}")
     digest: bytes = hashlib.sha256(str(balance).encode("utf-8")).digest()
     return float(int.from_bytes(digest[:7], "big") & _MASK_52)
+
+
+def hash_bytes_to_float(payload: bytes) -> float:
+    """Hash an arbitrary byte string to a 52-bit float64.
+
+    Same shape and collision profile as ``hash_balance_to_float``, but skips
+    the decimal-string step so callers can hash a canonicalised account-state
+    blob (Solana ``getAccountInfo`` fields; TON v3 ``account_state_hash`` or
+    v2 ``code``+``data``) without first deriving an int. Identical inputs
+    produce identical floats.
+
+    Args:
+        payload: Canonicalised account-state bytes.
+
+    Returns:
+        The low 52 bits of ``sha256(payload)`` as a float, exactly
+        representable in float64.
+    """
+    digest: bytes = hashlib.sha256(payload).digest()
+    return float(int.from_bytes(digest[:7], "big") & _MASK_52)

--- a/common/metrics_handler.py
+++ b/common/metrics_handler.py
@@ -90,8 +90,8 @@ class MetricsHandler:
 
         Structurally identical to ``_emit_observed_balances`` but for non-EVM
         chains: Solana's ``getAccountInfo`` at a pinned finalised slot and
-        TON's ``getAddressInformation`` at a bucketed masterchain seqno. The
-        captured hash already lives on the instance as
+        TON's ``runGetMethod(get_jetton_data)`` at a bucketed masterchain
+        seqno. The captured hash already lives on the instance as
         ``_captured_account_hash`` (pre-hashed to a 52-bit float by
         ``common.balance_hash.hash_bytes_to_float``). The per-value
         ``block_number`` label carries the anchor hex (slot for Solana,

--- a/common/metrics_handler.py
+++ b/common/metrics_handler.py
@@ -66,7 +66,8 @@ class MetricsHandler:
 
         Only ``EVMAccBalanceLatencyMetric`` subclasses carry both
         ``_captured_balance`` and ``_old_block_hex``; everything else is
-        skipped via getattr.
+        skipped via getattr. Hyperliquid joined this path 2026-05-19 (Data
+        agreement on HyperEVM balances at depth where dRPC/Alchemy converge).
 
         Returns:
             None
@@ -82,6 +83,37 @@ class MetricsHandler:
                 hash_balance_to_float(balance),
                 "balance_observed",
                 labels={"block_number": block_hex},
+            )
+
+    def _emit_observed_accounts(self) -> None:
+        """Emit hashed observed account states (Solana/TON Data agreement).
+
+        Structurally identical to ``_emit_observed_balances`` but for non-EVM
+        chains: Solana's ``getAccountInfo`` at a pinned finalised slot and
+        TON's ``getAddressInformation`` at a bucketed masterchain seqno. The
+        captured hash already lives on the instance as
+        ``_captured_account_hash`` (pre-hashed to a 52-bit float by
+        ``common.balance_hash.hash_bytes_to_float``). The per-value
+        ``block_number`` label carries the anchor hex (slot for Solana,
+        bucketed seqno for TON) so the follow-up Grafana panel joins on the
+        same string across providers.
+
+        Returns:
+            None
+        """
+        for instance in self._instances:
+            account_hash = getattr(instance, "_captured_account_hash", None)
+            if account_hash is None:
+                continue
+            anchor_hex = getattr(instance, "_anchor_slot_hex", None) or getattr(
+                instance, "_anchor_seqno_hex", None
+            )
+            if not anchor_hex:
+                continue
+            instance.update_metric_value(
+                account_hash,
+                "account_observed",
+                labels={"block_number": anchor_hex},
             )
 
     def get_metrics_influx_format(self) -> list[str]:
@@ -177,6 +209,7 @@ class MetricsHandler:
 
             self._emit_block_numbers()
             self._emit_observed_balances()
+            self._emit_observed_accounts()
 
             metrics_text: str = self.get_metrics_text()
             if metrics_text:

--- a/metrics/hyperliquid.py
+++ b/metrics/hyperliquid.py
@@ -4,7 +4,11 @@ For Hyperliquid Info API metrics (clearinghouseState, openOrders, etc.),
 see metrics.hyperliquid_info module.
 """
 
-from common.metric_types import EVMBlockNumberLatencyMetric, HttpCallLatencyMetricBase
+from common.metric_types import (
+    EVMAccBalanceLatencyMetric,
+    EVMBlockNumberLatencyMetric,
+    HttpCallLatencyMetricBase,
+)
 
 
 class HTTPEthCallLatencyMetric(HttpCallLatencyMetricBase):
@@ -46,22 +50,17 @@ class HTTPTxReceiptLatencyMetric(HttpCallLatencyMetricBase):
         return [state_data["tx"]]
 
 
-class HTTPAccBalanceLatencyMetric(HttpCallLatencyMetricBase):
-    """Collects latency for account balance queries."""
+class HTTPAccBalanceLatencyMetric(EVMAccBalanceLatencyMetric):
+    """eth_getBalance latency for Hyperliquid (HyperEVM).
 
-    @property
-    def method(self) -> str:
-        """Return the RPC method name."""
-        return "eth_getBalance"
+    Probes Wrapped HYPE at a historical block from ``state_data["old_block"]``,
+    enabling cross-provider Data agreement on the captured balance (emitted as
+    ``balance_observed`` by ``MetricsHandler._emit_observed_balances``). Empirical
+    re-test 2026-05-19 confirmed dRPC and Alchemy converge byte-for-byte at
+    depth; Quicknode's archive is shallow and will show as the outlier.
+    """
 
-    @staticmethod
-    def get_params_from_state(state_data: dict) -> list:
-        """Get parameters with fixed monitoring address."""
-        return [
-            "0xFC1286EeddF81d6955eDAd5C8D99B8Aa32F3D2AA",
-            # state_data["old_block"],
-            "latest",
-        ]  # Only latest block is supported
+    probe_address = "0x5555555555555555555555555555555555555555"
 
 
 class HTTPBlockNumberLatencyMetric(EVMBlockNumberLatencyMetric):

--- a/metrics/solana.py
+++ b/metrics/solana.py
@@ -1,7 +1,8 @@
 """Solana metrics implementation for HTTP endpoints."""
 
-from typing import Any
+from typing import Any, Optional
 
+from common.balance_hash import hash_bytes_to_float
 from common.metric_types import HttpCallLatencyMetricBase
 
 
@@ -111,6 +112,84 @@ class HTTPGetBlockLatencyMetric(HttpCallLatencyMetricBase):
                 "rewards": False,  # Further reduce response size
             },
         ]
+
+
+# USDC mint: an SPL token mint with a moving but deterministic ``supply``
+# field embedded in the account ``data`` (changes with mints/burns). Pinning
+# ``getAccountInfo`` to a finalized slot via ``minContextSlot`` makes every
+# healthy provider return identical bytes, so the canonical hash diverges
+# only when a provider serves stale or non-canonical state.
+_AGREEMENT_PROBE_ACCOUNT: str = "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
+
+
+class HTTPAccountAgreementMetric(HttpCallLatencyMetricBase):
+    """Cross-provider Data agreement for Solana account state.
+
+    Pins ``getAccountInfo`` to the same historical slot across providers via
+    ``minContextSlot`` so each provider returns identical bytes. The slot is
+    taken verbatim from ``state_data["old_block"]`` (already populated by the
+    state-update cron, same field the v1 balance probes use). The captured
+    fields (owner, lamports, executable, rentEpoch, base64 data) are
+    canonicalised and hashed to a 52-bit float, then emitted as
+    ``metric_type=account_observed`` with ``block_number=<slot_hex>`` so the
+    follow-up Grafana panel can join on the slot.
+    """
+
+    @property
+    def method(self) -> str:
+        """Return the RPC method name."""
+        return "getAccountInfo"
+
+    @staticmethod
+    def validate_state(state_data: dict[str, Any]) -> bool:
+        """Require the historical-slot anchor in state data."""
+        return bool(state_data and state_data.get("old_block"))
+
+    @staticmethod
+    def get_params_from_state(state_data: dict[str, Any]) -> list[Any]:
+        """Build getAccountInfo params pinned to the historical slot."""
+        anchor_slot = int(state_data["old_block"])
+        return [
+            _AGREEMENT_PROBE_ACCOUNT,
+            {
+                "encoding": "base64",
+                "commitment": "finalized",
+                "minContextSlot": anchor_slot,
+            },
+        ]
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Stash the anchor slot hex for the account_observed emit step."""
+        state_data = kwargs.get("state_data") or {}
+        super().__init__(*args, **kwargs)
+        anchor_slot = int(state_data["old_block"])
+        self._anchor_slot_hex: str = hex(anchor_slot)
+        self._captured_account_hash: Optional[float] = None
+
+    def mark_failure(self) -> None:
+        """Clear the captured hash on failure to suppress the emit."""
+        super().mark_failure()
+        self._captured_account_hash = None
+
+    def _on_json_response(self, json_response: dict[str, Any]) -> None:
+        """Canonicalise the account value fields and hash them."""
+        result = json_response.get("result")
+        if not isinstance(result, dict):
+            return
+        value = result.get("value")
+        if not isinstance(value, dict):
+            # Account may legitimately be missing at this slot; skip emit.
+            return
+        owner = str(value.get("owner", ""))
+        lamports = int(value.get("lamports", 0))
+        executable = bool(value.get("executable", False))
+        rent_epoch = int(value.get("rentEpoch", 0))
+        data_field = value.get("data", [])
+        data_b64 = data_field[0] if isinstance(data_field, list) and data_field else ""
+        canonical = (
+            f"{owner}|{lamports}|{int(executable)}|{rent_epoch}|{data_b64}"
+        ).encode()
+        self._captured_account_hash = hash_bytes_to_float(canonical)
 
 
 class HTTPGetProgramAccsLatencyMetric(HttpCallLatencyMetricBase):

--- a/metrics/ton.py
+++ b/metrics/ton.py
@@ -1,7 +1,8 @@
 """TON (The Open Network) metrics implementation for HTTP endpoints."""
 
-from typing import Any
+from typing import Any, Optional
 
+from common.balance_hash import hash_bytes_to_float
 from common.metric_types import HttpCallLatencyMetricBase
 
 
@@ -97,6 +98,100 @@ class HTTPGetAddressBalanceLatencyMetric(HttpCallLatencyMetricBase):
     def get_params_from_state(state_data: dict) -> dict:
         """Returns parameters for TON address balance check."""
         return {"address": "EQDtFpEwcFAEcRe5mLVh2N6C0x-_hJEM7W61_JLnSF74p4q2"}
+
+
+# USDT jetton master: ``get_jetton_data`` returns total_supply / admin /
+# content / wallet_code on the v2 ``runGetMethod`` surface, which all four
+# TON providers (Chainstack, QuickNode, TonCenter, dRPC) accept with a
+# ``seqno`` parameter for historical pinning. Empirically verified that the
+# seqno param is honoured and all four agree on identical stack output at
+# the pinned masterchain seqno. ``total_supply`` moves on Tether mint/burn
+# events, giving a moving-but-deterministic target.
+_AGREEMENT_PROBE_ADDRESS: str = "EQCxE6mUtQJKFnGfaROTKOt1lZbDiiX1kCixRv7Nw2Id_sDs"
+
+
+def _canonicalise_stack(stack: Any) -> str:
+    """Render a TVM stack as a deterministic, provider-agnostic string.
+
+    Stack entries come back as ``[type, value]`` pairs where ``value`` is
+    either a hex string (``num``) or a dict carrying a base64 BoC plus a
+    decoded ``object`` tree (``cell``/``slice``). We pin to the encoded BoC
+    bytes only — the decoded ``object`` view varies in shape between
+    providers and isn't load-bearing for agreement.
+    """
+    if not isinstance(stack, list):
+        return ""
+    parts: list[str] = []
+    for entry in stack:
+        if not isinstance(entry, list) or len(entry) != 2:
+            parts.append(repr(entry))
+            continue
+        tag, value = entry
+        if isinstance(value, dict):
+            parts.append(f"{tag}:{value.get('bytes', '')}")
+        else:
+            parts.append(f"{tag}:{value}")
+    return "|".join(parts)
+
+
+class HTTPAccountAgreementMetric(HttpCallLatencyMetricBase):
+    """Cross-provider Data agreement for TON account state.
+
+    Calls v2 ``runGetMethod`` with ``get_jetton_data`` on the USDT jetton
+    master, pinned to a settled masterchain seqno via the ``seqno`` param.
+    All four TON providers in our pool (Chainstack, QuickNode, TonCenter,
+    dRPC) accept the param and return identical stacks at the pinned point.
+    The stack (total_supply, mintable flag, admin address, content cell,
+    wallet code cell) is canonicalised and hashed to a 52-bit float, then
+    emitted as ``metric_type=account_observed`` with the seqno as
+    ``block_number=<seqno_hex>`` so the dashboard panel can join per round.
+    """
+
+    @property
+    def method(self) -> str:
+        """Return the RPC method name."""
+        return "runGetMethod"
+
+    @staticmethod
+    def validate_state(state_data: dict[str, Any]) -> bool:
+        """Require the masterchain block identifier in state data."""
+        return bool(state_data and state_data.get("old_block"))
+
+    @staticmethod
+    def get_params_from_state(state_data: dict[str, Any]) -> dict[str, Any]:
+        """Return runGetMethod params pinned to the masterchain seqno."""
+        seqno = int(state_data["old_block"].split(":")[2])
+        return {
+            "address": _AGREEMENT_PROBE_ADDRESS,
+            "method": "get_jetton_data",
+            "stack": [],
+            "seqno": seqno,
+        }
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Stash the seqno hex for the account_observed emit step."""
+        state_data = kwargs.get("state_data") or {}
+        super().__init__(*args, **kwargs)
+        seqno = int(state_data["old_block"].split(":")[2])
+        self._anchor_seqno_hex: str = hex(seqno)
+        self._captured_account_hash: Optional[float] = None
+
+    def mark_failure(self) -> None:
+        """Clear the captured hash on failure to suppress the emit."""
+        super().mark_failure()
+        self._captured_account_hash = None
+
+    def _on_json_response(self, json_response: dict[str, Any]) -> None:
+        """Canonicalise the TVM stack and hash it."""
+        result = json_response.get("result")
+        if not isinstance(result, dict):
+            return
+        if result.get("exit_code", 0) != 0:
+            return
+        canonical = _canonicalise_stack(result.get("stack")).encode()
+        if not canonical:
+            return
+        self._captured_account_hash = hash_bytes_to_float(canonical)
 
 
 class HTTPGetBlockTxsLatencyMetric(HttpCallLatencyMetricBase):


### PR DESCRIPTION
Add Data agreement metrics for Hyperliquid (HyperEVM), Solana, and TON. Each chain now emits a per-provider hashed value at a settled anchor (HyperEVM: block_number from existing state, Solana: finalized slot via minContextSlot, TON: masterchain seqno bucketed to 30) using the same shape as Monad's existing balance_observed series, so a follow-up Grafana PR can drop in cross-provider modal-comparison panels.

Solana and TON use a new account_observed series; Hyperliquid reuses balance_observed because HyperEVM is structurally EVM and slots into the v1 EVMAccBalanceLatencyMetric path. Empirical research before this PR confirmed: HyperEVM has canonical historical state (dRPC + Alchemy agree at depth, Quicknode's archive is shallow — the panel will surface that); Solana lacks any RPC-exposed consensus anchor; TON's account-side proofs are reachable only via ADNL/TCP, not HTTP. Data agreement is the ceiling reachable from Vercel for all three. Dashboard panels are a separate follow-up PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added account-agreement metrics for Solana and TON to collect historical account agreement data and latency.
  * Metrics handler now emits observed-account events when handlers expose captured account hashes.
  * Added a hashing utility to canonicalize and verify account data.

* **Improvements**
  * Hyperliquid account-balance metric updated to probe historical blocks for more accurate balance observations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chainstacklabs/compare-dashboard-functions/pull/81?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->