### PR TITLE
feat(dashboards): Data agreement panels for hyperliquid/solana/ton

### DIFF
--- a/dashboards/dashboards/compare-dashboard-hyperliquid-eu.json
+++ b/dashboards/dashboards/compare-dashboard-hyperliquid-eu.json
@@ -1201,11 +1201,325 @@
     },
     {
       "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 26
+      },
+      "id": 700,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Per provider in this region (EU), did this provider's eth_getBalance for the WHYPE token contract at the probe block match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 28
+          },
+          "id": 701,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Hyperliquid\", source_region=\"fra1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Hyperliquid\", source_region=\"fra1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Hyperliquid\", source_region=\"fra1\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "For each provider in this region (EU), the percentage of samples (eth_getBalance for the WHYPE token contract at the probe block) that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 28
+          },
+          "id": 702,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Hyperliquid\", source_region=\"fra1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Hyperliquid\", source_region=\"fra1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Hyperliquid\", source_region=\"fra1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Hyperliquid\", source_region=\"fra1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "title": "Agreement summary",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Agreed %",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "title": "Data agreement",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 43
       },
       "id": 7,
       "panels": [
@@ -3178,7 +3492,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 44
       },
       "id": 23,
       "panels": [
@@ -3922,7 +4236,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 45
       },
       "id": 32,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-hyperliquid-japan.json
+++ b/dashboards/dashboards/compare-dashboard-hyperliquid-japan.json
@@ -1221,11 +1221,325 @@
     },
     {
       "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 26
+      },
+      "id": 700,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Per provider in this region (Japan), did this provider's eth_getBalance for the WHYPE token contract at the probe block match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 28
+          },
+          "id": 701,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Hyperliquid\", source_region=\"hnd1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Hyperliquid\", source_region=\"hnd1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Hyperliquid\", source_region=\"hnd1\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "For each provider in this region (Japan), the percentage of samples (eth_getBalance for the WHYPE token contract at the probe block) that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 28
+          },
+          "id": 702,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Hyperliquid\", source_region=\"hnd1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Hyperliquid\", source_region=\"hnd1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Hyperliquid\", source_region=\"hnd1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Hyperliquid\", source_region=\"hnd1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "title": "Agreement summary",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Agreed %",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "title": "Data agreement",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 43
       },
       "id": 7,
       "panels": [
@@ -3198,7 +3512,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 44
       },
       "id": 23,
       "panels": [
@@ -4007,7 +4321,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 45
       },
       "id": 32,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-hyperliquid-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-hyperliquid-us-west.json
@@ -1220,11 +1220,325 @@
     },
     {
       "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 26
+      },
+      "id": 700,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Per provider in this region (US West), did this provider's eth_getBalance for the WHYPE token contract at the probe block match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 28
+          },
+          "id": 701,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Hyperliquid\", source_region=\"sfo1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Hyperliquid\", source_region=\"sfo1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Hyperliquid\", source_region=\"sfo1\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "For each provider in this region (US West), the percentage of samples (eth_getBalance for the WHYPE token contract at the probe block) that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 28
+          },
+          "id": 702,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Hyperliquid\", source_region=\"sfo1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Hyperliquid\", source_region=\"sfo1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Hyperliquid\", source_region=\"sfo1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Hyperliquid\", source_region=\"sfo1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "title": "Agreement summary",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Agreed %",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "title": "Data agreement",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 43
       },
       "id": 7,
       "panels": [
@@ -3197,7 +3511,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 44
       },
       "id": 23,
       "panels": [
@@ -4006,7 +4320,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 45
       },
       "id": 32,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-hyperliquid.json
+++ b/dashboards/dashboards/compare-dashboard-hyperliquid.json
@@ -1996,11 +1996,361 @@
     },
     {
       "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 36
+      },
+      "id": 700,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Per provider, did this provider's eth_getBalance for the WHYPE token contract at the probe block match the majority answer in every region it participated in at this moment. Green - matched the majority everywhere. Red - was an outlier in at least one region. Grey - no data captured.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 38
+          },
+          "id": 701,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Hyperliquid\"}\n    )\n    *\n    on(source_region, block_number, value) group_left()\n    count by (source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Hyperliquid\"}\n    )\n  )\n  ==\n  bool on(source_region, block_number) group_left()\n  max by (source_region, block_number) (\n    count by (source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Hyperliquid\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "For each provider in each region, the percentage of samples (eth_getBalance for the WHYPE token contract at the probe block) that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Region"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 70
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "fra1": {
+                            "index": 0,
+                            "text": "EU"
+                          },
+                          "sfo1": {
+                            "index": 2,
+                            "text": "US West"
+                          },
+                          "sin1": {
+                            "index": 1,
+                            "text": "SG"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 38
+          },
+          "id": 702,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider, source_region) (\n  max_over_time(\n    (\n      (\n        group by (provider, source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Hyperliquid\"}\n        )\n        *\n        on(source_region, block_number, value) group_left()\n        count by (source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Hyperliquid\"}\n        )\n      )\n      ==\n      bool on(source_region, block_number) group_left()\n      max by (source_region, block_number) (\n        count by (source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Hyperliquid\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider, source_region) (\n  max_over_time(\n    (\n      group by (provider, source_region, block_number, value) (\n        response_latency_seconds{metric_type=\"balance_observed\", blockchain=\"Hyperliquid\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "title": "Agreement summary",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 2,
+                  "provider": 0,
+                  "source_region": 1
+                },
+                "renameByName": {
+                  "Value": "Agreed %",
+                  "provider": "Provider",
+                  "source_region": "Region"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "title": "Data agreement",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 37
       },
       "id": 105,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-solana-eu.json
+++ b/dashboards/dashboards/compare-dashboard-solana-eu.json
@@ -1081,11 +1081,325 @@
     },
     {
       "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 26
+      },
+      "id": 720,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Per provider in this region (EU), did this provider's getAccountInfo for the USDC mint, pinned to the probe slot via minContextSlot match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 28
+          },
+          "id": 721,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"account_observed\", blockchain=\"Solana\", source_region=\"fra1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"account_observed\", blockchain=\"Solana\", source_region=\"fra1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"account_observed\", blockchain=\"Solana\", source_region=\"fra1\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "For each provider in this region (EU), the percentage of samples (getAccountInfo for the USDC mint, pinned to the probe slot via minContextSlot) that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 28
+          },
+          "id": 722,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"account_observed\", blockchain=\"Solana\", source_region=\"fra1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"account_observed\", blockchain=\"Solana\", source_region=\"fra1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"account_observed\", blockchain=\"Solana\", source_region=\"fra1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"account_observed\", blockchain=\"Solana\", source_region=\"fra1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "title": "Agreement summary",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Agreed %",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "title": "Data agreement",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 43
       },
       "id": 7,
       "panels": [
@@ -2779,7 +3093,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 44
       },
       "id": 69,
       "panels": [
@@ -4614,7 +4928,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 45
       },
       "id": 23,
       "panels": [
@@ -5522,7 +5836,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 46
       },
       "id": 999,
       "panels": [
@@ -6430,7 +6744,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 46
+        "y": 47
       },
       "id": 43,
       "panels": [
@@ -7338,7 +7652,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 47
+        "y": 48
       },
       "id": 32,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-solana-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-solana-singapore.json
@@ -1081,11 +1081,325 @@
     },
     {
       "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 26
+      },
+      "id": 720,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Per provider in this region (SG), did this provider's getAccountInfo for the USDC mint, pinned to the probe slot via minContextSlot match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 28
+          },
+          "id": 721,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"account_observed\", blockchain=\"Solana\", source_region=\"sin1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"account_observed\", blockchain=\"Solana\", source_region=\"sin1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"account_observed\", blockchain=\"Solana\", source_region=\"sin1\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "For each provider in this region (SG), the percentage of samples (getAccountInfo for the USDC mint, pinned to the probe slot via minContextSlot) that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 28
+          },
+          "id": 722,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"account_observed\", blockchain=\"Solana\", source_region=\"sin1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"account_observed\", blockchain=\"Solana\", source_region=\"sin1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"account_observed\", blockchain=\"Solana\", source_region=\"sin1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"account_observed\", blockchain=\"Solana\", source_region=\"sin1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "title": "Agreement summary",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Agreed %",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "title": "Data agreement",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 43
       },
       "id": 7,
       "panels": [
@@ -2779,7 +3093,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 44
       },
       "id": 23,
       "panels": [
@@ -3687,7 +4001,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 45
       },
       "id": 999,
       "panels": [
@@ -4595,7 +4909,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 46
       },
       "id": 43,
       "panels": [
@@ -5503,7 +5817,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 46
+        "y": 47
       },
       "id": 32,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-solana-us-west.json
+++ b/dashboards/dashboards/compare-dashboard-solana-us-west.json
@@ -1082,11 +1082,325 @@
     },
     {
       "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 26
+      },
+      "id": 720,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Per provider in this region (US West), did this provider's getAccountInfo for the USDC mint, pinned to the probe slot via minContextSlot match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 28
+          },
+          "id": 721,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"account_observed\", blockchain=\"Solana\", source_region=\"sfo1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"account_observed\", blockchain=\"Solana\", source_region=\"sfo1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"account_observed\", blockchain=\"Solana\", source_region=\"sfo1\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "For each provider in this region (US West), the percentage of samples (getAccountInfo for the USDC mint, pinned to the probe slot via minContextSlot) that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 28
+          },
+          "id": 722,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"account_observed\", blockchain=\"Solana\", source_region=\"sfo1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"account_observed\", blockchain=\"Solana\", source_region=\"sfo1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"account_observed\", blockchain=\"Solana\", source_region=\"sfo1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"account_observed\", blockchain=\"Solana\", source_region=\"sfo1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "title": "Agreement summary",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Agreed %",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "title": "Data agreement",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 43
       },
       "id": 7,
       "panels": [
@@ -2780,7 +3094,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 44
       },
       "id": 23,
       "panels": [
@@ -3688,7 +4002,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 45
       },
       "id": 999,
       "panels": [
@@ -4596,7 +4910,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 46
       },
       "id": 43,
       "panels": [
@@ -5504,7 +5818,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 46
+        "y": 47
       },
       "id": 32,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-solana.json
+++ b/dashboards/dashboards/compare-dashboard-solana.json
@@ -1823,11 +1823,361 @@
     },
     {
       "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 36
+      },
+      "id": 720,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Per provider, did this provider's getAccountInfo for the USDC mint, pinned to the probe slot via minContextSlot match the majority answer in every region it participated in at this moment. Green - matched the majority everywhere. Red - was an outlier in at least one region. Grey - no data captured.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 38
+          },
+          "id": 721,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"account_observed\", blockchain=\"Solana\"}\n    )\n    *\n    on(source_region, block_number, value) group_left()\n    count by (source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"account_observed\", blockchain=\"Solana\"}\n    )\n  )\n  ==\n  bool on(source_region, block_number) group_left()\n  max by (source_region, block_number) (\n    count by (source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"account_observed\", blockchain=\"Solana\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "For each provider in each region, the percentage of samples (getAccountInfo for the USDC mint, pinned to the probe slot via minContextSlot) that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Region"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 70
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "fra1": {
+                            "index": 0,
+                            "text": "EU"
+                          },
+                          "sfo1": {
+                            "index": 2,
+                            "text": "US West"
+                          },
+                          "sin1": {
+                            "index": 1,
+                            "text": "SG"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 38
+          },
+          "id": 722,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider, source_region) (\n  max_over_time(\n    (\n      (\n        group by (provider, source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"account_observed\", blockchain=\"Solana\"}\n        )\n        *\n        on(source_region, block_number, value) group_left()\n        count by (source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"account_observed\", blockchain=\"Solana\"}\n        )\n      )\n      ==\n      bool on(source_region, block_number) group_left()\n      max by (source_region, block_number) (\n        count by (source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"account_observed\", blockchain=\"Solana\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider, source_region) (\n  max_over_time(\n    (\n      group by (provider, source_region, block_number, value) (\n        response_latency_seconds{metric_type=\"account_observed\", blockchain=\"Solana\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "title": "Agreement summary",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 2,
+                  "provider": 0,
+                  "source_region": 1
+                },
+                "renameByName": {
+                  "Value": "Agreed %",
+                  "provider": "Provider",
+                  "source_region": "Region"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "title": "Data agreement",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 37
       },
       "id": 118,
       "panels": [
@@ -3985,7 +4335,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 37
+        "y": 38
       },
       "id": 119,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-ton-eu.json
+++ b/dashboards/dashboards/compare-dashboard-ton-eu.json
@@ -1050,11 +1050,325 @@
     },
     {
       "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 26
+      },
+      "id": 740,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Per provider in this region (EU), did this provider's runGetMethod(get_jetton_data) on the USDT master, pinned to the probe seqno match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 28
+          },
+          "id": 741,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"account_observed\", blockchain=\"TON\", source_region=\"fra1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"account_observed\", blockchain=\"TON\", source_region=\"fra1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"account_observed\", blockchain=\"TON\", source_region=\"fra1\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "For each provider in this region (EU), the percentage of samples (runGetMethod(get_jetton_data) on the USDT master, pinned to the probe seqno) that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 28
+          },
+          "id": 742,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"account_observed\", blockchain=\"TON\", source_region=\"fra1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"account_observed\", blockchain=\"TON\", source_region=\"fra1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"account_observed\", blockchain=\"TON\", source_region=\"fra1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"account_observed\", blockchain=\"TON\", source_region=\"fra1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "title": "Agreement summary",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Agreed %",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "title": "Data agreement",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 43
       },
       "id": 7,
       "panels": [
@@ -2468,7 +2782,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 44
       },
       "id": 999,
       "panels": [
@@ -3227,7 +3541,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 45
       },
       "id": 23,
       "panels": [
@@ -3986,7 +4300,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 46
       },
       "id": 55,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-ton-singapore.json
+++ b/dashboards/dashboards/compare-dashboard-ton-singapore.json
@@ -1050,11 +1050,325 @@
     },
     {
       "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 26
+      },
+      "id": 740,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Per provider in this region (SG), did this provider's runGetMethod(get_jetton_data) on the USDT master, pinned to the probe seqno match the majority answer for the same block at this moment. Green - matched the majority. Red - was an outlier. Grey - no data captured.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 28
+          },
+          "id": 741,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, block_number, value) (\n      response_latency_seconds{metric_type=\"account_observed\", blockchain=\"TON\", source_region=\"sin1\"}\n    )\n    *\n    on(block_number, value) group_left()\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"account_observed\", blockchain=\"TON\", source_region=\"sin1\"}\n    )\n  )\n  ==\n  bool on(block_number) group_left()\n  max by (block_number) (\n    count by (block_number, value) (\n      response_latency_seconds{metric_type=\"account_observed\", blockchain=\"TON\", source_region=\"sin1\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "For each provider in this region (SG), the percentage of samples (runGetMethod(get_jetton_data) on the USDT master, pinned to the probe seqno) that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 28
+          },
+          "id": 742,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider) (\n  max_over_time(\n    (\n      (\n        group by (provider, block_number, value) (\n          response_latency_seconds{metric_type=\"account_observed\", blockchain=\"TON\", source_region=\"sin1\"}\n        )\n        *\n        on(block_number, value) group_left()\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"account_observed\", blockchain=\"TON\", source_region=\"sin1\"}\n        )\n      )\n      ==\n      bool on(block_number) group_left()\n      max by (block_number) (\n        count by (block_number, value) (\n          response_latency_seconds{metric_type=\"account_observed\", blockchain=\"TON\", source_region=\"sin1\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider) (\n  max_over_time(\n    (\n      group by (provider, block_number, value) (\n        response_latency_seconds{metric_type=\"account_observed\", blockchain=\"TON\", source_region=\"sin1\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "title": "Agreement summary",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 1,
+                  "provider": 0
+                },
+                "renameByName": {
+                  "Value": "Agreed %",
+                  "provider": "Provider"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "title": "Data agreement",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 43
       },
       "id": 7,
       "panels": [
@@ -2468,7 +2782,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 43
+        "y": 44
       },
       "id": 23,
       "panels": [
@@ -3227,7 +3541,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 45
       },
       "id": 63,
       "panels": [
@@ -3986,7 +4300,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 46
       },
       "id": 55,
       "panels": [

--- a/dashboards/dashboards/compare-dashboard-ton.json
+++ b/dashboards/dashboards/compare-dashboard-ton.json
@@ -1599,11 +1599,361 @@
     },
     {
       "collapsed": true,
+      "datasource": {
+        "type": "prometheus",
+        "uid": "grafanacloud-prom"
+      },
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 35
+      },
+      "id": 740,
+      "panels": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "Per provider, did this provider's runGetMethod(get_jetton_data) on the USDT master, pinned to the probe seqno match the majority answer in every region it participated in at this moment. Green - matched the majority everywhere. Red - was an outlier in at least one region. Grey - no data captured.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "axisPlacement": "auto",
+                "fillOpacity": 80,
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "insertNulls": false,
+                "lineWidth": 0,
+                "spanNulls": false
+              },
+              "decimals": 0,
+              "mappings": [
+                {
+                  "options": {
+                    "match": "null",
+                    "result": {
+                      "color": "grey",
+                      "index": 0,
+                      "text": "No data"
+                    }
+                  },
+                  "type": "special"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "red",
+                    "value": null
+                  },
+                  {
+                    "color": "green",
+                    "value": 1
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Chainstack"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "Chainstack-Growth"
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "dRPC"
+                },
+                "properties": [
+                  {
+                    "id": "displayName",
+                    "value": "dRPC-Growth"
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 18,
+            "x": 0,
+            "y": 37
+          },
+          "id": 741,
+          "options": {
+            "alignValue": "left",
+            "annotations": {
+              "clustering": -1,
+              "multiLane": false
+            },
+            "legend": {
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "mergeValues": true,
+            "rowHeight": 0.8,
+            "showValue": "never",
+            "tooltip": {
+              "hideZeros": false,
+              "mode": "single",
+              "sort": "none"
+            }
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "min by (provider) (\n  (\n    group by (provider, source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"account_observed\", blockchain=\"TON\"}\n    )\n    *\n    on(source_region, block_number, value) group_left()\n    count by (source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"account_observed\", blockchain=\"TON\"}\n    )\n  )\n  ==\n  bool on(source_region, block_number) group_left()\n  max by (source_region, block_number) (\n    count by (source_region, block_number, value) (\n      response_latency_seconds{metric_type=\"account_observed\", blockchain=\"TON\"}\n    )\n  )\n)",
+              "legendFormat": "{{provider}}",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Provider agreement",
+          "type": "state-timeline"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "grafanacloud-prom"
+          },
+          "description": "For each provider in each region, the percentage of samples (runGetMethod(get_jetton_data) on the USDT master, pinned to the probe seqno) that matched the majority answer for the same block, over the chosen time range. 100% means always agreed with the majority. Sorted highest first.",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "align": "auto",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Provider"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 130
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "Chainstack": {
+                            "index": 0,
+                            "text": "Chainstack-Growth"
+                          },
+                          "dRPC": {
+                            "index": 1,
+                            "text": "dRPC-Growth"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Region"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 70
+                  },
+                  {
+                    "id": "mappings",
+                    "value": [
+                      {
+                        "options": {
+                          "fra1": {
+                            "index": 0,
+                            "text": "EU"
+                          },
+                          "sfo1": {
+                            "index": 2,
+                            "text": "US West"
+                          },
+                          "sin1": {
+                            "index": 1,
+                            "text": "SG"
+                          }
+                        },
+                        "type": "value"
+                      }
+                    ]
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Agreed %"
+                },
+                "properties": [
+                  {
+                    "id": "unit",
+                    "value": "percentunit"
+                  },
+                  {
+                    "id": "decimals",
+                    "value": 2
+                  },
+                  {
+                    "id": "min",
+                    "value": 0
+                  },
+                  {
+                    "id": "max",
+                    "value": 1
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "type": "color-text"
+                    }
+                  },
+                  {
+                    "id": "thresholds",
+                    "value": {
+                      "mode": "absolute",
+                      "steps": [
+                        {
+                          "color": "red",
+                          "value": null
+                        },
+                        {
+                          "color": "yellow",
+                          "value": 0.95
+                        },
+                        {
+                          "color": "green",
+                          "value": 0.99
+                        }
+                      ]
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 6,
+            "x": 18,
+            "y": 37
+          },
+          "id": 742,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Agreed %"
+              }
+            ]
+          },
+          "pluginVersion": "13.1.0-24455754975",
+          "targets": [
+            {
+              "datasource": {
+                "type": "prometheus",
+                "uid": "grafanacloud-prom"
+              },
+              "editorMode": "code",
+              "expr": "sum by (provider, source_region) (\n  max_over_time(\n    (\n      (\n        group by (provider, source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"account_observed\", blockchain=\"TON\"}\n        )\n        *\n        on(source_region, block_number, value) group_left()\n        count by (source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"account_observed\", blockchain=\"TON\"}\n        )\n      )\n      ==\n      bool on(source_region, block_number) group_left()\n      max by (source_region, block_number) (\n        count by (source_region, block_number, value) (\n          response_latency_seconds{metric_type=\"account_observed\", blockchain=\"TON\"}\n        )\n      )\n    )[$__range:1m]\n  ) > bool 0\n)\n/\nsum by (provider, source_region) (\n  max_over_time(\n    (\n      group by (provider, source_region, block_number, value) (\n        response_latency_seconds{metric_type=\"account_observed\", blockchain=\"TON\"}\n      )\n    )[$__range:1m]\n  )\n)",
+              "format": "table",
+              "instant": true,
+              "legendFormat": "__auto",
+              "refId": "A"
+            }
+          ],
+          "title": "Agreement summary",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {
+                  "Value": 2,
+                  "provider": 0,
+                  "source_region": 1
+                },
+                "renameByName": {
+                  "Value": "Agreed %",
+                  "provider": "Provider",
+                  "source_region": "Region"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "title": "Data agreement",
+      "type": "row"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 36
       },
       "id": 113,
       "panels": [

--- a/scripts/add_data_agreement_panels.py
+++ b/scripts/add_data_agreement_panels.py
@@ -1,0 +1,257 @@
+"""Insert a Data agreement row into hyperliquid/solana/ton dashboards.
+
+Template is Monad's existing Data agreement row. We swap:
+- blockchain tag value
+- metric_type (balance_observed for HL EVM; account_observed for SOL/TON)
+- panel descriptions (per chain + global vs regional)
+- source_region pin (regional only)
+- panel + row IDs (unique per chain)
+- gridPos.y (insert after Block lag row, bump everything below)
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+from typing import Any
+
+DASH_DIR = Path(__file__).resolve().parents[1] / "dashboards" / "dashboards"
+MONAD_GLOBAL = DASH_DIR / "compare-dashboard-monad.json"
+MONAD_EU = DASH_DIR / "compare-dashboard-monad-eu.json"
+
+
+def load(p: Path) -> dict[str, Any]:
+    return json.loads(p.read_text())
+
+
+def dump(p: Path, d: dict[str, Any]) -> None:
+    p.write_text(json.dumps(d, indent=2) + "\n")
+
+
+def find_row_index(dash: dict[str, Any], title: str) -> int:
+    for i, p in enumerate(dash["panels"]):
+        if p.get("type") == "row" and p.get("title") == title:
+            return i
+    raise ValueError(f"row '{title}' not found")
+
+
+def extract_monad_row(monad: dict[str, Any]) -> dict[str, Any]:
+    idx = find_row_index(monad, "Data agreement")
+    return copy.deepcopy(monad["panels"][idx])
+
+
+# Chain → (blockchain tag, metric_type, observation_phrase, probe_phrase)
+CHAINS = {
+    "hyperliquid": {
+        "blockchain": "Hyperliquid",
+        "metric_type": "balance_observed",
+        "observation_global": "eth_getBalance for the WHYPE token contract at the probe block",
+        "observation_regional": "eth_getBalance for the WHYPE token contract at the probe block",
+        "id_base": 700,
+    },
+    "solana": {
+        "blockchain": "Solana",
+        "metric_type": "account_observed",
+        "observation_global": "getAccountInfo for the USDC mint, pinned to the probe slot via minContextSlot",
+        "observation_regional": "getAccountInfo for the USDC mint, pinned to the probe slot via minContextSlot",
+        "id_base": 720,
+    },
+    "ton": {
+        "blockchain": "TON",
+        "metric_type": "account_observed",
+        "observation_global": "runGetMethod(get_jetton_data) on the USDT master, pinned to the probe seqno",
+        "observation_regional": "runGetMethod(get_jetton_data) on the USDT master, pinned to the probe seqno",
+        "id_base": 740,
+    },
+}
+
+REGION_NAMES = {
+    "fra1": "EU",
+    "sfo1": "US West",
+    "sin1": "SG",
+    "hnd1": "Japan",
+}
+
+
+# (filename suffix, source_region or None for global)
+DASH_TARGETS = {
+    "hyperliquid": [
+        ("compare-dashboard-hyperliquid.json", None),
+        ("compare-dashboard-hyperliquid-eu.json", "fra1"),
+        ("compare-dashboard-hyperliquid-japan.json", "hnd1"),
+        ("compare-dashboard-hyperliquid-us-west.json", "sfo1"),
+    ],
+    "solana": [
+        ("compare-dashboard-solana.json", None),
+        ("compare-dashboard-solana-eu.json", "fra1"),
+        ("compare-dashboard-solana-singapore.json", "sin1"),
+        ("compare-dashboard-solana-us-west.json", "sfo1"),
+    ],
+    "ton": [
+        ("compare-dashboard-ton.json", None),
+        ("compare-dashboard-ton-eu.json", "fra1"),
+        ("compare-dashboard-ton-singapore.json", "sin1"),
+    ],
+}
+
+
+def rewrite_global_row(
+    row: dict[str, Any],
+    chain: dict[str, Any],
+    row_y: int,
+) -> dict[str, Any]:
+    """Adapt the Monad GLOBAL Data agreement row for the target chain."""
+    blockchain = chain["blockchain"]
+    metric_type = chain["metric_type"]
+    obs = chain["observation_global"]
+    base = chain["id_base"]
+
+    row["id"] = base
+    row["gridPos"]["y"] = row_y
+    inner_y = row_y + 2
+
+    timeline, summary = row["panels"]
+    timeline["id"] = base + 1
+    timeline["gridPos"]["y"] = inner_y
+    timeline["description"] = (
+        f"Per provider, did this provider's {obs} match the majority answer "
+        "in every region it participated in at this moment. Green - matched "
+        "the majority everywhere. Red - was an outlier in at least one region. "
+        "Grey - no data captured."
+    )
+    summary["id"] = base + 2
+    summary["gridPos"]["y"] = inner_y
+    summary["description"] = (
+        f"For each provider in each region, the percentage of samples "
+        f"({obs}) that matched the majority answer for the same block, "
+        "over the chosen time range. 100% means always agreed with the "
+        "majority. Sorted highest first."
+    )
+
+    for tgt in timeline["targets"]:
+        tgt["expr"] = (
+            tgt["expr"]
+            .replace('metric_type="balance_observed"', f'metric_type="{metric_type}"')
+            .replace('blockchain="Monad"', f'blockchain="{blockchain}"')
+        )
+    for tgt in summary["targets"]:
+        tgt["expr"] = (
+            tgt["expr"]
+            .replace('metric_type="balance_observed"', f'metric_type="{metric_type}"')
+            .replace('blockchain="Monad"', f'blockchain="{blockchain}"')
+        )
+    return row
+
+
+def rewrite_regional_row(
+    row: dict[str, Any],
+    chain: dict[str, Any],
+    row_y: int,
+    source_region: str,
+) -> dict[str, Any]:
+    """Adapt the Monad REGIONAL Data agreement row for the target chain + region."""
+    blockchain = chain["blockchain"]
+    metric_type = chain["metric_type"]
+    obs = chain["observation_regional"]
+    base = chain["id_base"]
+    region_name = REGION_NAMES[source_region]
+
+    row["id"] = base
+    row["gridPos"]["y"] = row_y
+    inner_y = row_y + 2
+
+    timeline, summary = row["panels"]
+    timeline["id"] = base + 1
+    timeline["gridPos"]["y"] = inner_y
+    timeline["description"] = (
+        f"Per provider in this region ({region_name}), did this provider's "
+        f"{obs} match the majority answer for the same block at this moment. "
+        "Green - matched the majority. Red - was an outlier. Grey - no data "
+        "captured."
+    )
+    summary["id"] = base + 2
+    summary["gridPos"]["y"] = inner_y
+    summary["description"] = (
+        f"For each provider in this region ({region_name}), the percentage "
+        f"of samples ({obs}) that matched the majority answer for the same "
+        "block, over the chosen time range. 100% means always agreed with "
+        "the majority. Sorted highest first."
+    )
+
+    for tgt in timeline["targets"]:
+        # Monad regional template uses source_region="fra1"; swap region + chain.
+        tgt["expr"] = (
+            tgt["expr"]
+            .replace('metric_type="balance_observed"', f'metric_type="{metric_type}"')
+            .replace('blockchain="Monad"', f'blockchain="{blockchain}"')
+            .replace('source_region="fra1"', f'source_region="{source_region}"')
+        )
+    for tgt in summary["targets"]:
+        tgt["expr"] = (
+            tgt["expr"]
+            .replace('metric_type="balance_observed"', f'metric_type="{metric_type}"')
+            .replace('blockchain="Monad"', f'blockchain="{blockchain}"')
+            .replace('source_region="fra1"', f'source_region="{source_region}"')
+        )
+    return row
+
+
+def insert_into_dashboard(
+    dash_path: Path,
+    chain: dict[str, Any],
+    source_region: str | None,
+    monad_global_row: dict[str, Any],
+    monad_regional_row: dict[str, Any],
+) -> None:
+    dash = load(dash_path)
+
+    # Remove pre-existing Data agreement row (idempotent re-runs).
+    dash["panels"] = [
+        p
+        for p in dash["panels"]
+        if not (p.get("type") == "row" and p.get("title") == "Data agreement")
+    ]
+
+    block_lag_idx = find_row_index(dash, "Block lag")
+    block_lag_y = dash["panels"][block_lag_idx]["gridPos"]["y"]
+    insert_y = block_lag_y + 1
+
+    # Bump y of every panel whose y >= insert_y.
+    for p in dash["panels"]:
+        if p["gridPos"]["y"] >= insert_y:
+            p["gridPos"]["y"] += 1
+
+    if source_region is None:
+        new_row = rewrite_global_row(copy.deepcopy(monad_global_row), chain, insert_y)
+    else:
+        new_row = rewrite_regional_row(
+            copy.deepcopy(monad_regional_row), chain, insert_y, source_region
+        )
+
+    dash["panels"].insert(block_lag_idx + 1, new_row)
+    dump(dash_path, dash)
+    kind = "global" if source_region is None else f"regional ({source_region})"
+    print(f"[ok] {dash_path.name} — inserted Data agreement {kind} row")
+
+
+def main() -> None:
+    monad_global = load(MONAD_GLOBAL)
+    monad_eu = load(MONAD_EU)
+    monad_global_row = extract_monad_row(monad_global)
+    monad_regional_row = extract_monad_row(monad_eu)
+
+    for chain_key, targets in DASH_TARGETS.items():
+        chain = CHAINS[chain_key]
+        for filename, source_region in targets:
+            insert_into_dashboard(
+                DASH_DIR / filename,
+                chain,
+                source_region,
+                monad_global_row,
+                monad_regional_row,
+            )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds a **Data agreement** collapsed row (Provider agreement state-timeline + Agreement summary table) to all 11 hyperliquid/solana/ton dashboards — 3 global + 8 regional.
- Reuses Monad's cross-provider-consensus query template; swaps `metric_type` (`balance_observed` for HL, `account_observed` for SOL/TON), `blockchain` tag, `source_region` pin (regional only), and per-chain probe context in panel descriptions.
- Closes the dashboard gap left after #81 shipped the underlying metrics without surfacing them.

Panel descriptions name the actual probe per chain:
- HL → eth_getBalance on the WHYPE token contract
- SOL → getAccountInfo on the USDC mint, pinned via `minContextSlot`
- TON → runGetMethod(get_jetton_data) on the USDT master, pinned by seqno

Generated via `scripts/add_data_agreement_panels.py` (included for reproducibility / future re-runs).

## Test plan
- [x] All 11 dashboards pushed to Grafana and visually reviewed
- [x] Provider agreement timeline renders green/red per provider
- [x] Agreement summary table shows Agreed % with correct thresholds
- [x] Row inserted between Block lag and Historical data; subsequent rows' `y` bumped by 1
- [x] Panel IDs unique per chain (700s HL, 720s SOL, 740s TON) — no collisions