### PR TITLE
feat(solana-write): signer balance + diagnostic logs + memo provider tag

### DIFF
--- a/common/base_metric.py
+++ b/common/base_metric.py
@@ -146,7 +146,7 @@ class BaseMetric(ABC):
                     f"Ignoring HTTP error [{status_code}] for "
                     f"{self.labels.get_prometheus_labels()}"
                 )
-                return  # Skip metric submission for ignored errors
+                return  # Suppress noisy log; mark_failure already recorded the metric
 
         if isinstance(error, websockets.exceptions.InvalidStatusCode):
             status_code = error.status_code
@@ -155,7 +155,7 @@ class BaseMetric(ABC):
                     f"Ignoring WebSocket connection error [{status_code}] for "
                     f"{self.labels.get_prometheus_labels()}"
                 )
-                return  # Skip metric submission for ignored errors
+                return  # Suppress noisy log; mark_failure already recorded the metric
 
         if not self.values:
             self.update_metric_value(0)

--- a/metrics/p2p_syncro_landing_rate.py
+++ b/metrics/p2p_syncro_landing_rate.py
@@ -8,22 +8,26 @@ lamports) to a Syncro tip account so the public endpoint accepts the tx.
 Public endpoint is rate-limited to 1 RPS — do not increase send cadence.
 """
 
+import logging
 import random
 import time
 from typing import Optional
 
 from solana.rpc.async_api import AsyncClient
-from solana.rpc.types import TxOpts
 from solders.compute_budget import set_compute_unit_limit, set_compute_unit_price
 from solders.instruction import Instruction
 from solders.pubkey import Pubkey
-from solders.rpc.responses import SendTransactionResp
 from solders.system_program import TransferParams, transfer
 from solders.transaction import Transaction
 
 from common.metric_config import MetricLabelKey
 from config.defaults import MetricsServiceConfig
-from metrics.solana_landing_rate import SolanaLandingMetric, generate_fixed_memo
+from metrics.solana_landing_rate import (
+    SolanaLandingMetric,
+    generate_memo,
+)
+
+SYNCRO_LOG_TAG = "[solana-landing-syncro]"
 
 
 class P2PSyncroLandingMetric(SolanaLandingMetric):
@@ -48,8 +52,9 @@ class P2PSyncroLandingMetric(SolanaLandingMetric):
 
     async def _prepare_memo_transaction(self, client: AsyncClient) -> Transaction:
         """Build the memo transaction with a Syncro tip transfer prepended."""
-        memo_text: str = generate_fixed_memo(
-            self.labels.get_label(MetricLabelKey.SOURCE_REGION)  # type: ignore[arg-type]
+        memo_text: str = generate_memo(
+            self.labels.get_label(MetricLabelKey.SOURCE_REGION),  # type: ignore[arg-type]
+            self.labels.get_label(MetricLabelKey.PROVIDER),  # type: ignore[arg-type]
         )
 
         tip_ix = transfer(
@@ -73,7 +78,7 @@ class P2PSyncroLandingMetric(SolanaLandingMetric):
 
         blockhash = await client.get_latest_blockhash()
         if not blockhash or not blockhash.value:
-            raise ValueError("Failed to get latest blockhash")
+            raise ValueError(f"getLatestBlockhash returned empty {self._log_ctx()}")
 
         return Transaction.new_signed_with_payer(
             [tip_ix, compute_limit_ix, compute_price_ix, memo_ix],
@@ -93,28 +98,32 @@ class P2PSyncroLandingMetric(SolanaLandingMetric):
             read_client = await self._create_client()
             tx_client = AsyncClient(self.SYNCRO_TX_ENDPOINT)
 
+            await self._capture_signer_balance(read_client)
             tx: Transaction = await self._prepare_memo_transaction(read_client)
             start_slot: int = await self._get_slot(read_client)
             start_time: float = time.monotonic()
 
-            signature_response: SendTransactionResp = await tx_client.send_transaction(
-                tx, TxOpts(skip_preflight=True, max_retries=0)
+            signature: str = await self._submit(tx_client, tx, tag=SYNCRO_LOG_TAG)
+            logging.info(
+                f"{SYNCRO_LOG_TAG} submitted sig={signature} start_slot={start_slot} "
+                f"{self._log_ctx()}"
             )
-            if not signature_response or not signature_response.value:
-                raise ValueError("Failed to send transaction")
 
             confirmation_slot: int = await self._wait_for_confirmation(
-                read_client,
-                signature_response.value,  # type: ignore
-                self.config.timeout,
+                read_client, signature, self.config.timeout
             )
 
             response_time: float = time.monotonic() - start_time
             self._slot_diff = confirmation_slot - start_slot
             if self._slot_diff < 0:
+                logging.warning(
+                    f"{SYNCRO_LOG_TAG} negative slot diff sig={signature} "
+                    f"confirmation_slot={confirmation_slot} "
+                    f"start_slot={start_slot} {self._log_ctx()}"
+                )
                 raise ValueError(
-                    f"Negative slot difference: {self._slot_diff} "
-                    f"(confirmation_slot={confirmation_slot}, start_slot={start_slot})"
+                    f"negative slot diff: {self._slot_diff} "
+                    f"(confirmation={confirmation_slot}, start={start_slot})"
                 )
             self.update_metric_value(self._slot_diff, "slot_latency")
             return response_time

--- a/metrics/solana_landing_rate.py
+++ b/metrics/solana_landing_rate.py
@@ -1,6 +1,7 @@
 """Solana landing rate metrics with priority fees."""
 
 import asyncio
+import logging
 import os
 import random
 import time
@@ -28,6 +29,8 @@ from common.metric_types import HttpMetric
 from common.metrics_handler import MetricsHandler
 from config.defaults import MetricsServiceConfig
 
+LOG_TAG = "[solana-landing]"
+
 
 class RegionCode(str, Enum):
     """Region codes for memo text generation."""
@@ -38,12 +41,20 @@ class RegionCode(str, Enum):
     DEFAULT = "00"
 
 
-def generate_fixed_memo(region: str) -> str:
-    """Generate fixed-length memo text with region identifier."""
-    region_id = getattr(RegionCode, region.upper(), RegionCode.DEFAULT)
+def generate_memo(region: str, provider: str) -> str:
+    """Generate memo text encoding region + provider for Solscan correlation.
+
+    Layout: ``{region}_{provider}_{rand}_{ts_ms}``. Provider is the existing
+    metric ``provider`` label, which already disambiguates an endpoint's
+    ``http_endpoint`` (e.g. ``Chainstack``) from its ``tx_endpoint``
+    (``Chainstack_tx``) via the factory in ``common/factory.py``. Length
+    varies by provider (10-17 chars); no measurable impact on landing rate
+    (tx well under 1232-byte cap, memo CU well under ``COMPUTE_LIMIT``).
+    """
+    region_id = getattr(RegionCode, region.upper(), RegionCode.DEFAULT).value
     timestamp = int(time.time() * 1000)
     random_id = random.randint(0, 999)
-    return f"{region_id}_{random_id:03d}_{timestamp:013d}"
+    return f"{region_id}_{provider}_{random_id:03d}_{timestamp:013d}"
 
 
 class SolanaLandingMetric(HttpMetric):
@@ -75,21 +86,60 @@ class SolanaLandingMetric(HttpMetric):
         self.private_key: bytes = base58.b58decode(os.environ["SOLANA_PRIVATE_KEY"])
         self.keypair: Keypair = Keypair.from_bytes(self.private_key)
         self._slot_diff = 0
+        self._last_status: Optional[TransactionStatus] = None
+
+    def _log_ctx(self) -> str:
+        """Return short structured context (provider, region) for log lines."""
+        return (
+            f"provider={self.labels.get_label(MetricLabelKey.PROVIDER)} "
+            f"region={self.labels.get_label(MetricLabelKey.SOURCE_REGION)}"
+        )
+
+    def mark_failure(self) -> None:
+        """Zero everything except signer_balance — wallet state is its own signal."""
+        preserved = self.values.pop("signer_balance", None)
+        super().mark_failure()
+        if preserved is not None:
+            self.values["signer_balance"] = preserved
 
     async def _create_client(self) -> AsyncClient:
         endpoint: str = self.get_endpoint()
         return AsyncClient(endpoint)
+
+    async def _capture_signer_balance(self, client: AsyncClient) -> None:
+        """Fetch signer SOL balance and emit as signer_balance value-type.
+
+        Survives ``mark_failure`` via the override above — wallet health
+        is a separate signal from whether this particular send landed, so
+        the dashboard can disambiguate "all RPCs failing" from "fee wallet
+        drained" at a glance.
+        """
+        try:
+            response = await client.get_balance(self.keypair.pubkey())
+            if response and response.value is not None:
+                self.update_metric_value(response.value, "signer_balance")
+        except Exception as e:
+            logging.warning(
+                f"{LOG_TAG} signer balance fetch failed {self._log_ctx()}: {e!r}"
+            )
 
     async def _get_slot(self, client: AsyncClient) -> int:
         response: GetSlotResp = await client.get_slot(
             MetricsServiceConfig.SOLANA_CONFIRMATION_LEVEL
         )  # type: ignore
         if not response or response.value is None:
-            raise ValueError("Failed to get current slot")
+            raise ValueError(f"getSlot returned empty {self._log_ctx()}")
         return response.value
 
     async def _check_status(self, client: AsyncClient, signature: str) -> int | None:
-        """Check single transaction status."""
+        """Check single transaction status.
+
+        Returns the confirmation slot if the tx is Confirmed/Finalized, ``None``
+        if it has not yet reached that threshold. Raises immediately if the
+        status carries an ``err`` (on-chain revert) — that is a distinct
+        failure mode from "not landed yet" and we don't want it masked by the
+        full polling timeout.
+        """
         response: GetSignatureStatusesResp = await client.get_signature_statuses(
             [signature]  # type: ignore
         )
@@ -99,6 +149,15 @@ class SolanaLandingMetric(HttpMetric):
         status: TransactionStatus | None = response.value[0]
         if not status:
             return None
+
+        if status.err is not None:
+            logging.error(
+                f"{LOG_TAG} on-chain revert sig={signature} slot={status.slot} "
+                f"err={status.err!r} {self._log_ctx()}"
+            )
+            raise ValueError(f"on-chain revert at slot {status.slot}: {status.err!r}")
+
+        self._last_status = status
 
         if status.confirmation_status in [
             TransactionConfirmationStatus.Confirmed,
@@ -112,18 +171,34 @@ class SolanaLandingMetric(HttpMetric):
         self, client: AsyncClient, signature: str, timeout: int
     ) -> int:
         """Wait for transaction confirmation using direct status checks."""
+        self._last_status = None
         end_time: float = time.monotonic() + timeout
+        polls = 0
         while time.monotonic() < end_time:
-            status: int | None = await self._check_status(client, signature)
-            if status:
-                return status
+            polls += 1
+            confirmation_slot: int | None = await self._check_status(client, signature)
+            if confirmation_slot is not None:
+                return confirmation_slot
             await asyncio.sleep(self.POLL_INTERVAL)
 
-        raise ValueError(f"Transaction confirmation timeout after {timeout}s")
+        last = self._last_status
+        last_repr = (
+            f"status={last.confirmation_status} slot={last.slot}"
+            if last is not None
+            else "never_seen"
+        )
+        logging.warning(
+            f"{LOG_TAG} confirmation timeout sig={signature} polls={polls} "
+            f"last={last_repr} timeout={timeout}s {self._log_ctx()}"
+        )
+        raise ValueError(
+            f"confirmation timeout after {timeout}s sig={signature} last={last_repr}"
+        )
 
     async def _prepare_memo_transaction(self, client: AsyncClient) -> Transaction:
-        memo_text: str = generate_fixed_memo(
-            self.labels.get_label(MetricLabelKey.SOURCE_REGION)  # type: ignore
+        memo_text: str = generate_memo(
+            self.labels.get_label(MetricLabelKey.SOURCE_REGION),  # type: ignore
+            self.labels.get_label(MetricLabelKey.PROVIDER),  # type: ignore
         )
 
         compute_limit_ix: Instruction = set_compute_unit_limit(
@@ -141,7 +216,7 @@ class SolanaLandingMetric(HttpMetric):
 
         blockhash: GetLatestBlockhashResp = await client.get_latest_blockhash()
         if not blockhash or not blockhash.value:
-            raise ValueError("Failed to get latest blockhash")
+            raise ValueError(f"getLatestBlockhash returned empty {self._log_ctx()}")
 
         return Transaction.new_signed_with_payer(
             [compute_limit_ix, compute_price_ix, memo_ix],
@@ -150,36 +225,58 @@ class SolanaLandingMetric(HttpMetric):
             blockhash.value.blockhash,
         )
 
+    async def _submit(
+        self, client: AsyncClient, tx: Transaction, tag: str = LOG_TAG
+    ) -> str:
+        """Send the transaction; log RPC errors with context before re-raising.
+
+        Returns the signature as a string. Falsy response is treated as a send
+        failure and raises ``ValueError`` with provider context.
+        """
+        try:
+            signature_response: SendTransactionResp = await client.send_transaction(
+                tx, TxOpts(skip_preflight=True, max_retries=0)
+            )
+        except Exception as e:
+            logging.error(f"{tag} sendTransaction failed {self._log_ctx()}: {e!r}")
+            raise
+        if not signature_response or not signature_response.value:
+            raise ValueError(
+                f"sendTransaction returned empty response {self._log_ctx()}"
+            )
+        return str(signature_response.value)
+
     async def fetch_data(self) -> Optional[float]:
         """Send a memo transaction and return elapsed wall-clock time.
 
         Initializes both response_time and slot_latency metric types, submits
         a signed memo transaction, waits for confirmation, and stores the slot
-        difference as slot_latency.
+        difference as slot_latency. Also captures the signer's SOL balance via
+        a separate value-type so the dashboard can distinguish fee-wallet
+        drain from RPC outages.
         """
         # Since we use here an additional value (metric_type),
         # let's initialize all used metric types.
         self.update_metric_value(0, "response_time")
         self.update_metric_value(0, "slot_latency")
 
-        client = None  # type: ignore
+        client: Optional[AsyncClient] = None
         try:
-            client: AsyncClient = await self._create_client()
+            client = await self._create_client()
+            await self._capture_signer_balance(client)
             tx: Transaction = await self._prepare_memo_transaction(client)
 
             start_slot: int = await self._get_slot(client)
             start_time: float = time.monotonic()
 
-            signature_response: SendTransactionResp = await client.send_transaction(
-                tx, TxOpts(skip_preflight=True, max_retries=0)
+            signature: str = await self._submit(client, tx)
+            logging.info(
+                f"{LOG_TAG} submitted sig={signature} start_slot={start_slot} "
+                f"{self._log_ctx()}"
             )
-            if not signature_response or not signature_response.value:
-                raise ValueError("Failed to send transaction")
 
             confirmation_slot: int = await self._wait_for_confirmation(
-                client,
-                signature_response.value,  # type: ignore
-                self.config.timeout,
+                client, signature, self.config.timeout
             )
 
             # `response_time` is not representative,
@@ -187,9 +284,14 @@ class SolanaLandingMetric(HttpMetric):
             response_time: float = time.monotonic() - start_time
             self._slot_diff: int = confirmation_slot - start_slot
             if self._slot_diff < 0:
+                logging.warning(
+                    f"{LOG_TAG} negative slot diff sig={signature} "
+                    f"confirmation_slot={confirmation_slot} "
+                    f"start_slot={start_slot} {self._log_ctx()}"
+                )
                 raise ValueError(
-                    f"Negative slot difference: {self._slot_diff} "
-                    f"(confirmation_slot={confirmation_slot}, start_slot={start_slot})"
+                    f"negative slot diff: {self._slot_diff} "
+                    f"(confirmation={confirmation_slot}, start={start_slot})"
                 )
             self.update_metric_value(self._slot_diff, "slot_latency")
             return response_time


### PR DESCRIPTION
## Summary

Three coherent changes to the Solana write path, all aimed at answering "what just happened to this tx?":

- **Signer balance metric** — emit `signer_balance` as a separate value-type that survives `mark_failure`. The dashboard can now distinguish "all providers landing=0 because the fee wallet drained" from "all providers genuinely broken" at a glance.
- **Diagnostic logging** — every failure mode now has a greppable, contextful log line:
  - On-chain reverts (`status.err`) are detected in `_check_status` and fast-fail with `slot=X err=InstructionError(...)` instead of waiting 55s.
  - `_wait_for_confirmation` tracks last-seen status; on timeout it logs `sig=… polls=N last=status=Processed slot=X` (or `last=never_seen`) — paste the sig into Solana Explorer.
  - `sendTransaction` is wrapped so `SolanaRpcException` details (insufficient funds, blockhash not found, simulation rejected) hit the log with provider + region context before being re-raised.
  - Every log line tagged `[solana-landing]` or `[solana-landing-syncro]`.
- **Memo with provider tag** — `02_Chainstack_417_1737900012345`, `02_Chainstack_tx_417_…`, `02_Alchemy-Growth_…`, etc. Solscan memo search now correlates tx → provider trivially. No `endpoints.json` schema change — the existing factory `_tx` suffix already disambiguates Chainstack's `http_endpoint` vs `tx_endpoint`.

### Bonus catches

- **Latent enum format bug**: `RegionCode.value` instead of relying on the unstable `(str, Enum) __format__` behavior across Python 3.10/3.11/3.12+. Production memos were showing as `RegionCode.FRA1_…` instead of `02_…` (visible on Solscan).
- **Misleading comments** in `common/base_metric.py:handle_error` updated — said "Skip metric submission" but `mark_failure` had already recorded the metric; the early return only suppresses the noisy log. Behavior unchanged.

### Provider/region label preservation through failure

| Failure mode | Before this PR | After |
|---|---|---|
| Confirmation timeout | Generic "Transaction confirmation timeout after 55s" | `sig=… polls=11 last=status=Processed slot=X provider=Helius-Developer region=fra1` |
| On-chain revert | Same as timeout (waited 55s, never confirmed) | Immediate `on-chain revert sig=… slot=X err=InstructionError(0, 'InsufficientFunds')` |
| sendTransaction RPC error | Wrapped, traceback only | `sendTransaction failed provider=Alchemy-Growth region=fra1: SolanaRpcException(error_msg='...')` |
| Fee wallet drained | Looks identical to RPC outage | `signer_balance` panel drops; landing-rate goes to 0 across all providers |

### Why no `COMPUTE_LIMIT` bump

Considered bumping `1000 → 5000` for memo-growth headroom, then reverted. At ~250 CU actual consumption + variable memo length up to ~37 bytes, 1000 CU is still 3-4x headroom. Right-sizing CU limit is also the better-landing pattern (smaller block-budget footprint at packing time).

## Test plan

- [x] `uvx black --check` clean on touched files
- [x] `uvx ruff check` clean on touched files
- [x] `uvx mypy` — pre-existing 4 errors in `solana_landing_rate.py`, zero new errors introduced (net reduced from 10 → 4 via `Optional[AsyncClient]` typing cleanup)
- [x] Behavioral test confirms `mark_failure` preserves `signer_balance` while zeroing `response_time` and `slot_latency`
- [x] Memo output verified across all current Solana providers + regions: 31-37 chars, all under tx-size cap
- [ ] **Post-merge**: watch a couple of cron runs; verify `signer_balance` panel populates; confirm at least one Solscan lookup via the new memo prefix

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metrics now capture wallet signer balance data for improved health monitoring.
  * Transaction memos now include provider and region information for better tracking.

* **Bug Fixes**
  * Enhanced error handling for ignored HTTP errors.
  * Improved transaction confirmation tracking with detailed status logging.
  * Clearer error messages with provider and region context.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chainstacklabs/compare-dashboard-functions/pull/84?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->