### PR TITLE
fix(solana-dashboards): exclude no-balance failures from landing-rate table

### DIFF
--- a/dashboards/dashboards/compare-dashboard-solana-eu.json
+++ b/dashboards/dashboards/compare-dashboard-solana-eu.json
@@ -3267,7 +3267,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "The success rate of transaction landing, calculated by dividing successful confirmations by total attempts over the selected time range. Data grouped by provider and displayed as a percentage.\n\nChainstack-Default means a default Solana RPC endpoint (not bloXroute) under Growth plan.\n\nChainstack-Warp means a Solana Trader Node (bloXroute) under Growth plan.\n\nHelius-Default means a default Solana RPC endpoint (staked) under Developer plan.",
+          "description": "The success rate of transaction landing, calculated by dividing successful confirmations by total attempts over the selected time range. Data grouped by provider and displayed as a percentage.\n\nAttempts where the fee wallet had ≤ 0.0002 SOL at probe time are excluded from the denominator, so wallet drain doesn't penalize providers.\n\nChainstack-Default means a default Solana RPC endpoint (not bloXroute) under Growth plan.\n\nChainstack-Warp means a Solana Trader Node (bloXroute) under Growth plan.\n\nHelius-Default means a default Solana RPC endpoint (staked) under Developer plan.",
           "fieldConfig": {
             "defaults": {
               "custom": {
@@ -3377,7 +3377,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(count_over_time(transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", metric_type=\"slot_latency\", api_method=\"sendTransaction\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", metric_type=\"slot_latency\", api_method=\"sendTransaction\"}[$__range])) by (provider)",
+              "expr": "sum(count_over_time(transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", metric_type=\"slot_latency\", api_method=\"sendTransaction\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(\r\n  (\r\n    transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", metric_type=\"slot_latency\", api_method=\"sendTransaction\"}\r\n    unless ignoring(metric_type)\r\n    (transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", metric_type=\"signer_balance\", response_status=\"failed\"} <= 200000)\r\n  )[$__range:]\r\n)) by (provider)",
               "format": "table",
               "fullMetaSearch": false,
               "includeNullMetadata": true,

--- a/dashboards/dashboards/compare-dashboard-solana-eu.json
+++ b/dashboards/dashboards/compare-dashboard-solana-eu.json
@@ -3267,7 +3267,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "The success rate of transaction landing, calculated by dividing successful confirmations by total attempts over the selected time range. Data grouped by provider and displayed as a percentage.\n\nAttempts where the fee wallet had ≤ 0.0002 SOL at probe time are excluded from the denominator, so wallet drain doesn't penalize providers.\n\nChainstack-Default means a default Solana RPC endpoint (not bloXroute) under Growth plan.\n\nChainstack-Warp means a Solana Trader Node (bloXroute) under Growth plan.\n\nHelius-Default means a default Solana RPC endpoint (staked) under Developer plan.",
+          "description": "The success rate of transaction landing, calculated by dividing successful confirmations by total attempts over the selected time range. Data grouped by provider and displayed as a percentage.\n\nFailed attempts where the fee wallet had ≤ 0.0002 SOL at probe time are excluded from the denominator, so wallet drain doesn't penalize providers.\n\nChainstack-Default means a default Solana RPC endpoint (not bloXroute) under Growth plan.\n\nChainstack-Warp means a Solana Trader Node (bloXroute) under Growth plan.\n\nHelius-Default means a default Solana RPC endpoint (staked) under Developer plan.",
           "fieldConfig": {
             "defaults": {
               "custom": {
@@ -3377,7 +3377,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(count_over_time(transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", metric_type=\"slot_latency\", api_method=\"sendTransaction\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(\r\n  (\r\n    transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", metric_type=\"slot_latency\", api_method=\"sendTransaction\"}\r\n    unless ignoring(metric_type)\r\n    (transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", metric_type=\"signer_balance\", response_status=\"failed\"} <= 200000)\r\n  )[$__range:]\r\n)) by (provider)",
+              "expr": "sum(count_over_time(\r\n  (transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", metric_type=\"slot_latency\", api_method=\"sendTransaction\", response_status=\"success\"})[$__range:]\r\n)) by (provider)\r\n/\r\nsum(count_over_time(\r\n  (\r\n    transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", metric_type=\"slot_latency\", api_method=\"sendTransaction\"}\r\n    unless ignoring(metric_type)\r\n    (transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", metric_type=\"signer_balance\", response_status=\"failed\"} <= 200000)\r\n  )[$__range:]\r\n)) by (provider)",
               "format": "table",
               "fullMetaSearch": false,
               "includeNullMetadata": true,

--- a/dashboards/dashboards/compare-dashboard-solana.json
+++ b/dashboards/dashboards/compare-dashboard-solana.json
@@ -4508,7 +4508,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "The success rate of transaction landing, calculated by dividing successful confirmations by total attempts over the selected time range. Data grouped by provider and displayed as a percentage.\n\nAttempts where the fee wallet had ≤ 0.0002 SOL at probe time are excluded from the denominator, so wallet drain doesn't penalize providers.\n\nChainstack-Default means a default Solana RPC endpoint (not bloXroute) under Growth plan.\n\nChainstack-Warp means a Solana Trader Node (bloXroute) under Growth plan.\n\nHelius-Default means a default Solana RPC endpoint (staked) under Developer plan.",
+          "description": "The success rate of transaction landing, calculated by dividing successful confirmations by total attempts over the selected time range. Data grouped by provider and displayed as a percentage.\n\nFailed attempts where the fee wallet had ≤ 0.0002 SOL at probe time are excluded from the denominator, so wallet drain doesn't penalize providers.\n\nChainstack-Default means a default Solana RPC endpoint (not bloXroute) under Growth plan.\n\nChainstack-Warp means a Solana Trader Node (bloXroute) under Growth plan.\n\nHelius-Default means a default Solana RPC endpoint (staked) under Developer plan.",
           "fieldConfig": {
             "defaults": {
               "custom": {
@@ -4618,7 +4618,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(count_over_time(transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", metric_type=\"slot_latency\", api_method=\"sendTransaction\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(\r\n  (\r\n    transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", metric_type=\"slot_latency\", api_method=\"sendTransaction\"}\r\n    unless ignoring(metric_type)\r\n    (transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", metric_type=\"signer_balance\", response_status=\"failed\"} <= 200000)\r\n  )[$__range:]\r\n)) by (provider)",
+              "expr": "sum(count_over_time(\r\n  (transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", metric_type=\"slot_latency\", api_method=\"sendTransaction\", response_status=\"success\"})[$__range:]\r\n)) by (provider)\r\n/\r\nsum(count_over_time(\r\n  (\r\n    transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", metric_type=\"slot_latency\", api_method=\"sendTransaction\"}\r\n    unless ignoring(metric_type)\r\n    (transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", metric_type=\"signer_balance\", response_status=\"failed\"} <= 200000)\r\n  )[$__range:]\r\n)) by (provider)",
               "format": "table",
               "fullMetaSearch": false,
               "includeNullMetadata": true,

--- a/dashboards/dashboards/compare-dashboard-solana.json
+++ b/dashboards/dashboards/compare-dashboard-solana.json
@@ -4508,7 +4508,7 @@
             "type": "prometheus",
             "uid": "grafanacloud-prom"
           },
-          "description": "The success rate of transaction landing, calculated by dividing successful confirmations by total attempts over the selected time range. Data grouped by provider and displayed as a percentage.\n\nChainstack-Default means a default Solana RPC endpoint (not bloXroute) under Growth plan.\n\nChainstack-Warp means a Solana Trader Node (bloXroute) under Growth plan.\n\nHelius-Default means a default Solana RPC endpoint (staked) under Developer plan.",
+          "description": "The success rate of transaction landing, calculated by dividing successful confirmations by total attempts over the selected time range. Data grouped by provider and displayed as a percentage.\n\nAttempts where the fee wallet had ≤ 0.0002 SOL at probe time are excluded from the denominator, so wallet drain doesn't penalize providers.\n\nChainstack-Default means a default Solana RPC endpoint (not bloXroute) under Growth plan.\n\nChainstack-Warp means a Solana Trader Node (bloXroute) under Growth plan.\n\nHelius-Default means a default Solana RPC endpoint (staked) under Developer plan.",
           "fieldConfig": {
             "defaults": {
               "custom": {
@@ -4618,7 +4618,7 @@
               },
               "disableTextWrap": false,
               "editorMode": "code",
-              "expr": "sum(count_over_time(transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", metric_type=\"slot_latency\", api_method=\"sendTransaction\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", metric_type=\"slot_latency\", api_method=\"sendTransaction\"}[$__range])) by (provider)",
+              "expr": "sum(count_over_time(transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", metric_type=\"slot_latency\", api_method=\"sendTransaction\", response_status=\"success\"}[$__range])) by (provider)\r\n/\r\nsum(count_over_time(\r\n  (\r\n    transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", metric_type=\"slot_latency\", api_method=\"sendTransaction\"}\r\n    unless ignoring(metric_type)\r\n    (transaction_landing_latency{blockchain=\"Solana\", source_region=\"fra1\", metric_type=\"signer_balance\", response_status=\"failed\"} <= 200000)\r\n  )[$__range:]\r\n)) by (provider)",
               "format": "table",
               "fullMetaSearch": false,
               "includeNullMetadata": true,


### PR DESCRIPTION
## Summary

The landing-rate table denominator counted wallet-drain failures as if they were provider failures, dragging the percentage down across **all providers simultaneously** during drain events. PR #84 added the `signer_balance` value-type, which lets us filter those attempts out cleanly at query time.

## What changed

**Before:** \`successes ÷ all_attempts\`

**After:** \`successes ÷ (all_attempts − attempts_where_wallet_was_empty)\`

In PromQL, this adds one \`unless ignoring(metric_type)\` clause to the denominator's selector:

\`\`\`promql
transaction_landing_latency{... metric_type="slot_latency" ...}
unless ignoring(metric_type)
(transaction_landing_latency{... metric_type="signer_balance", response_status="failed"} <= 200000)
\`\`\`

That clause matches at the same scrape time and drops samples where:
- \`signer_balance\` was emitted with \`response_status="failed"\` (matches only failure rows, never successes — successes have \`response_status="success"\` which doesn't match)
- value ≤ 200,000 lamports (2× Syncro tip cost; the largest single-probe cost)

## Behavior in three regimes

| Wallet state | Before | After |
|---|---|---|
| Healthy (>200k lamports) | Accurate | **Unchanged** — predicate never matches |
| Fully drained (<5k lamports) | Pessimistic — provider failures contaminated by our wallet | **Accurate** — those attempts excluded |
| Borderline (5k–200k lamports, brief drain window) | Pessimistic | Slightly optimistic for direct probes; correct for Syncro |

## Why threshold = 200,000 lamports

| Probe | Cost |
|---|---|
| Direct (Chainstack/Alchemy/Helius/Quicknode/dRPC) | ~5,050 lamports (base + priority) |
| Syncro | ~105,050 lamports (Syncro tip 100k + base + priority) |
| Threshold | **200,000** (2× max single-probe cost) |

A more principled long-term fix would emit \`min_required_lamports\` per probe and filter \`unless signer_balance < min_required_lamports\` — that's a code change for later. 200k is the simplest defensible compromise.

## Backward compatibility

Historical data (before PR #84) has no \`signer_balance\` series. \`unless\` requires a matching right-side sample to filter, so historical periods are **unchanged** — the new query degrades gracefully to the old behavior when no balance data is present.

## Scope

- 2 files: \`dashboards/dashboards/compare-dashboard-solana.json\` (global) and \`compare-dashboard-solana-eu.json\` (EU regional)
- 1 panel per file: "Landing rate" (table)
- 4 lines changed total (query + description in each file)
- us-west and singapore dashboards have no landing-rate panel (landing cron is fra1-only) — no change needed

## Not pushed to Grafana

This PR updates only the source-of-truth JSON files. The Grafana UI will not reflect the change until \`grafana_sync.py push\` is run after merge.

## Test plan

- [x] JSON validates cleanly (`json.load` on both files)
- [x] Diff scope confirmed (4 lines per file, only Landing rate panel touched)
- [x] PromQL syntax sanity-checked: \`unless ignoring(metric_type)\` correctly matches by label set excluding metric_type
- [ ] **Post-merge**: run \`grafana_sync.py push\` for both dashboards; verify table still renders; verify next drain event shows fair landing rates

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated "Landing rate" panel descriptions in Solana dashboards to clarify that success rate calculations exclude attempts with insufficient wallet balance at probe time.

* **Updates**
  * Modified metric queries to exclude low-balance attempts from success rate measurements, improving accuracy of landing rate statistics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/chainstacklabs/compare-dashboard-functions/pull/85?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->