### PR TITLE
fix(solana-write): pass Signature object to RPC; quiet Syncro 429 noise

### DIFF
--- a/metrics/p2p_syncro_landing_rate.py
+++ b/metrics/p2p_syncro_landing_rate.py
@@ -17,6 +17,7 @@ from solana.rpc.async_api import AsyncClient
 from solders.compute_budget import set_compute_unit_limit, set_compute_unit_price
 from solders.instruction import Instruction
 from solders.pubkey import Pubkey
+from solders.signature import Signature
 from solders.system_program import TransferParams, transfer
 from solders.transaction import Transaction
 
@@ -103,7 +104,7 @@ class P2PSyncroLandingMetric(SolanaLandingMetric):
             start_slot: int = await self._get_slot(read_client)
             start_time: float = time.monotonic()
 
-            signature: str = await self._submit(tx_client, tx, tag=SYNCRO_LOG_TAG)
+            signature: Signature = await self._submit(tx_client, tx, tag=SYNCRO_LOG_TAG)
             logging.info(
                 f"{SYNCRO_LOG_TAG} submitted sig={signature} start_slot={start_slot} "
                 f"{self._log_ctx()}"

--- a/metrics/solana_landing_rate.py
+++ b/metrics/solana_landing_rate.py
@@ -21,6 +21,7 @@ from solders.rpc.responses import (
     GetSlotResp,
     SendTransactionResp,
 )
+from solders.signature import Signature
 from solders.transaction import Transaction
 from solders.transaction_status import TransactionConfirmationStatus, TransactionStatus
 
@@ -30,6 +31,27 @@ from common.metrics_handler import MetricsHandler
 from config.defaults import MetricsServiceConfig
 
 LOG_TAG = "[solana-landing]"
+
+
+def _is_rate_limited_exc(exc: BaseException) -> bool:
+    """Check if an exception chain bottoms out in an ignored HTTP status.
+
+    ``SolanaRpcException`` wraps ``httpx.HTTPStatusError`` for 4xx responses
+    from the upstream RPC. Walk ``__cause__``/``__context__`` chains and inspect
+    ``.response.status_code`` (httpx-style). Returns True for any status in
+    ``IGNORED_HTTP_ERRORS`` (401/403/404/429) — these are policy responses, not
+    bugs.
+    """
+    seen: set[int] = set()
+    current: Optional[BaseException] = exc
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        response = getattr(current, "response", None)
+        status_code = getattr(response, "status_code", None)
+        if status_code in MetricsServiceConfig.IGNORED_HTTP_ERRORS:
+            return True
+        current = current.__cause__ or current.__context__
+    return False
 
 
 class RegionCode(str, Enum):
@@ -131,7 +153,9 @@ class SolanaLandingMetric(HttpMetric):
             raise ValueError(f"getSlot returned empty {self._log_ctx()}")
         return response.value
 
-    async def _check_status(self, client: AsyncClient, signature: str) -> int | None:
+    async def _check_status(
+        self, client: AsyncClient, signature: Signature
+    ) -> int | None:
         """Check single transaction status.
 
         Returns the confirmation slot if the tx is Confirmed/Finalized, ``None``
@@ -141,7 +165,7 @@ class SolanaLandingMetric(HttpMetric):
         full polling timeout.
         """
         response: GetSignatureStatusesResp = await client.get_signature_statuses(
-            [signature]  # type: ignore
+            [signature]
         )
         if not response or not response.value:
             return None
@@ -168,7 +192,7 @@ class SolanaLandingMetric(HttpMetric):
         return None
 
     async def _wait_for_confirmation(
-        self, client: AsyncClient, signature: str, timeout: int
+        self, client: AsyncClient, signature: Signature, timeout: int
     ) -> int:
         """Wait for transaction confirmation using direct status checks."""
         self._last_status = None
@@ -227,24 +251,39 @@ class SolanaLandingMetric(HttpMetric):
 
     async def _submit(
         self, client: AsyncClient, tx: Transaction, tag: str = LOG_TAG
-    ) -> str:
+    ) -> Signature:
         """Send the transaction; log RPC errors with context before re-raising.
 
-        Returns the signature as a string. Falsy response is treated as a send
-        failure and raises ``ValueError`` with provider context.
+        Returns the ``Signature`` object from solders so it can be passed
+        directly to downstream ``get_signature_statuses`` calls (which require
+        ``Signature``, not ``str``). For log lines, ``Signature.__str__``
+        renders the same base58 form a raw string would.
+
+        Rate-limit responses (HTTP 401/403/404/429 wrapped in
+        ``SolanaRpcException``) are logged at WARNING instead of ERROR — the
+        429 from Syncro's 1-RPS public endpoint is expected intermittent noise,
+        not a regression. The exception still propagates so the metric framework
+        treats it as a send failure (which it is — we couldn't land via this
+        path this scrape).
         """
         try:
             signature_response: SendTransactionResp = await client.send_transaction(
                 tx, TxOpts(skip_preflight=True, max_retries=0)
             )
         except Exception as e:
-            logging.error(f"{tag} sendTransaction failed {self._log_ctx()}: {e!r}")
+            if _is_rate_limited_exc(e):
+                logging.warning(
+                    f"{tag} sendTransaction rate-limited {self._log_ctx()}: "
+                    f"{type(e).__name__}"
+                )
+            else:
+                logging.error(f"{tag} sendTransaction failed {self._log_ctx()}: {e!r}")
             raise
         if not signature_response or not signature_response.value:
             raise ValueError(
                 f"sendTransaction returned empty response {self._log_ctx()}"
             )
-        return str(signature_response.value)
+        return signature_response.value
 
     async def fetch_data(self) -> Optional[float]:
         """Send a memo transaction and return elapsed wall-clock time.
@@ -269,7 +308,7 @@ class SolanaLandingMetric(HttpMetric):
             start_slot: int = await self._get_slot(client)
             start_time: float = time.monotonic()
 
-            signature: str = await self._submit(client, tx)
+            signature: Signature = await self._submit(client, tx)
             logging.info(
                 f"{LOG_TAG} submitted sig={signature} start_slot={start_slot} "
                 f"{self._log_ctx()}"


### PR DESCRIPTION
## Summary

Two regressions from PR #84 visible in production logs at 2026-05-26 17:15. One is critical (landing-rate dashboard has been showing 0% for direct providers since deploy), the other is log noise.

## Issue 1 — TypeError in get_signature_statuses (critical)

\`\`\`
File "/var/task/metrics/solana_landing_rate.py", line 143, in _check_status
    response: GetSignatureStatusesResp = await client.get_signature_statuses([signature])
TypeError: argument 'signatures': 'str' object cannot be converted to 'Signature'
\`\`\`

**Root cause**: PR #84's \`_submit\` did \`return str(signature_response.value)\` — converting the \`Signature\` from solders to a base58 string for "logging clarity." That string then flowed through \`_wait_for_confirmation\` → \`_check_status\` → \`client.get_signature_statuses([signature])\`. solana 0.36.2 requires \`Signature\` objects in that argument, **not strings**.

**Impact**: every direct probe (Alchemy/Helius/Quicknode/dRPC/Chainstack/Chainstack_tx) since #84 deployed:
- send_transaction succeeded → got a valid Signature
- tx actually landed on-chain (confirmable on Solscan via the new memo)
- our polling threw TypeError instantly → \`collect_metric\` caught it → \`mark_failure\` → \`response_status=failed\`, \`slot_latency=0\`

The landing-rate dashboard has been reporting **0% landing for every direct provider** since #84 merged, despite the txs successfully landing on chain.

**Fix**: drop the \`str()\` cast. \`Signature.__str__\` already returns the base58 representation, so log f-strings like \`f"sig={signature}"\` produce identical output. The cast served no purpose and broke the downstream API contract.

- \`_submit\` return type: \`str\` → \`Signature\`
- \`_wait_for_confirmation\` and \`_check_status\` param types: \`str\` → \`Signature\`
- Removed now-unnecessary \`# type: ignore\` on the get_signature_statuses call

## Issue 2 — Noisy ERROR logs for expected Syncro 429s

\`\`\`
[error] [solana-landing-syncro] sendTransaction failed provider=P2P-Syncro region=fra1: SolanaRpcException()
[error] Metric error [SolanaRpcException] ... <class 'httpx.HTTPStatusError'> raised in "SendRawTransaction" endpoint request
httpx.HTTPStatusError: Client error '429 Too Many Requests' for url 'https://sfls-geo-fra.l2.p2p.org/public'
\`\`\`

**Root cause**: Syncro's public endpoint is rate-limited to 1 RPS *globally* (across all users, not per-IP). At our 15-min cadence we're way under, but Syncro user bursts can transiently push past the cap. PR #84's new explicit \`logging.error\` in \`_submit\` made this much louder than before.

**Fix**: small \`_is_rate_limited_exc\` helper that walks the exception cause chain and checks \`response.status_code\` against \`IGNORED_HTTP_ERRORS\` (401/403/404/429). When matched in \`_submit\`'s except block, log at **WARNING** instead of **ERROR**.

No metric behavior change — the failure is still a real send failure (we couldn't land via this path this scrape), and the dashboard fairly counts it as a Syncro landing failure. Just quieter logs.

## Test plan

- [x] Modules import cleanly
- [x] \`_submit\` return annotation is \`Signature\`
- [x] \`_check_status\` and \`_wait_for_confirmation\` accept \`Signature\`
- [x] \`_is_rate_limited_exc\` detects 429 via \`__cause__\` chain (httpx-style)
- [x] \`_is_rate_limited_exc\` detects 429 on direct \`.response.status_code\` attribute
- [x] All four \`IGNORED_HTTP_ERRORS\` codes (401/403/404/429) are detected
- [x] Non-429 errors (e.g. 500) are NOT flagged as rate-limited
- [x] black/ruff clean, mypy net unchanged (4 pre-existing errors, zero new)
- [ ] **Post-merge**: confirm direct providers report non-zero landing rate again on the dashboard within one cron tick (~15 min). Confirm Syncro 429s now log at WARNING level, not ERROR.

## Scope

2 files, 50 insertions / 10 deletions. No metric schema change, no dashboard change, no new dependencies.