### PR TITLE
feat(robinhood): add Robinhood Chain read metrics + v2 verification

### DIFF
--- a/api/read/robinhood.py
+++ b/api/read/robinhood.py
@@ -1,0 +1,35 @@
+"""Vercel cron entry point for Robinhood metrics collection."""
+
+from common.metrics_handler import BaseVercelHandler, MetricsHandler
+from config.defaults import MetricsServiceConfig
+from metrics.ethereum import (
+    WSBlockLatencyMetric,
+)
+from metrics.robinhood import (
+    HTTPAccBalanceLatencyMetric,
+    HTTPBlockNumberLatencyMetric,
+    HTTPDebugTraceBlockByNumberLatencyMetric,
+    HTTPDebugTraceTxLatencyMetric,
+    HTTPEthCallLatencyMetric,
+    HTTPGetLogsLatencyMetric,
+    HTTPTxReceiptLatencyMetric,
+)
+
+METRIC_NAME = f"{MetricsServiceConfig.METRIC_PREFIX}response_latency_seconds"
+
+METRICS = [
+    (WSBlockLatencyMetric, METRIC_NAME),
+    (HTTPBlockNumberLatencyMetric, METRIC_NAME),
+    (HTTPEthCallLatencyMetric, METRIC_NAME),
+    (HTTPAccBalanceLatencyMetric, METRIC_NAME),
+    (HTTPDebugTraceBlockByNumberLatencyMetric, METRIC_NAME),
+    (HTTPDebugTraceTxLatencyMetric, METRIC_NAME),
+    (HTTPTxReceiptLatencyMetric, METRIC_NAME),
+    (HTTPGetLogsLatencyMetric, METRIC_NAME),
+]
+
+
+class handler(BaseVercelHandler):
+    """Vercel HTTP handler for Robinhood metric collection."""
+
+    metrics_handler = MetricsHandler("Robinhood", METRICS)

--- a/api/support/update_state.py
+++ b/api/support/update_state.py
@@ -20,6 +20,7 @@ SUPPORTED_BLOCKCHAINS: list[str] = [
     "arbitrum",
     "bnb",
     "hyperliquid",
+    "robinhood",
 ]
 ALLOWED_PROVIDERS: set[str] = {
     "Chainstack"

--- a/api/support/verify_state.py
+++ b/api/support/verify_state.py
@@ -1,7 +1,7 @@
 """Verifier function: emits balance_verified + verifier_status for EVM chains.
 
 Per cron round (fra1-only, every 15 min). For each chain in
-[Ethereum, Base, Arbitrum, BNB]:
+[Ethereum, Base, Arbitrum, BNB, Robinhood]:
   - Compute VERIFY_BLOCK = latest_head - random(VERIFY_BLOCK_OFFSET_RANGES[chain]).
     Self-contained: no blob coordination with update_state.
   - Multi-provider stateRoot quorum at VERIFY_BLOCK.
@@ -56,6 +56,9 @@ PROBE_ADDRESSES: dict[str, str] = {
     "Base": "0x4200000000000000000000000000000000000006",  # WETH (OP Stack predeploy)
     "Arbitrum": "0x82aF49447D8a07e3bd95BD0d56f35241523fBab1",  # WETH
     "BNB": "0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c",  # WBNB
+    # WETH on Robinhood — same address as the v1 balance probe
+    # (metrics/robinhood.py) so the observed↔verified dashboard join lines up.
+    "Robinhood": "0x0bd7d308f8e1639fab988df18a8011f41eacad73",
 }
 
 METRIC_NAME = f"{MetricsServiceConfig.METRIC_PREFIX}response_latency_seconds"

--- a/common/state/blockchain_fetcher.py
+++ b/common/state/blockchain_fetcher.py
@@ -189,6 +189,7 @@ class BlockchainDataFetcher:
                 "arbitrum",
                 "bnb",
                 "hyperliquid",
+                "robinhood",
             ):
                 return await self._fetch_evm_data(blockchain)
             elif blockchain.lower() == "solana":

--- a/config/defaults.py
+++ b/config/defaults.py
@@ -60,11 +60,19 @@ class MetricsServiceConfig:
     #   Arbitrum max retention ≈   107 blocks (~27 s) — tightest; arb head
     #                            moves fast so we keep extra headroom for
     #                            in-cron drift.
+    #   Robinhood max retention ≈   128 blocks but only ~12.8 s (~100 ms
+    #                            blocks) — shortest wall-clock window of any
+    #                            chain. Kept at (30, 70): measured round is
+    #                            ~0.1 s with 1-7 block head-drift, so
+    #                            effective proof depth stays ~<100, leaving
+    #                            ~28 blocks of margin under the 128 prune edge
+    #                            for slower/cold prod rounds.
     VERIFY_BLOCK_OFFSET_RANGES: ClassVar[dict[str, tuple[int, int]]] = {
         "ethereum": (200, 500),
         "base": (60, 100),
         "arbitrum": (50, 70),
         "bnb": (30, 100),
+        "robinhood": (30, 70),
     }
 
 

--- a/config/defaults.py
+++ b/config/defaults.py
@@ -40,6 +40,7 @@ class MetricsServiceConfig:
         "arbitrum": (7200, 10000),
         "bnb": (7200, 10000),
         "hyperliquid": (3600, 7200),
+        "robinhood": (18000, 25000),
     }
 
     # Per-chain offset for the v2 verifier (eth_getProof at VERIFY_BLOCK).

--- a/endpoints.json.example
+++ b/endpoints.json.example
@@ -60,6 +60,12 @@
             "websocket_endpoint": "wss://solana-mainnet.core.chainstack.com/...",
             "http_endpoint": "https://solana-mainnet.core.chainstack.com/...",
             "tx_endpoint": "https://solana-mainnet.core.chainstack.com/..."
+        },
+        {
+            "blockchain": "Robinhood",
+            "name": "Chainstack",
+            "websocket_endpoint": "wss://robinhood-mainnet.core.chainstack.com/...",
+            "http_endpoint": "https://robinhood-mainnet.core.chainstack.com/..."
         }
     ]
 }

--- a/metrics/robinhood.py
+++ b/metrics/robinhood.py
@@ -1,0 +1,127 @@
+"""Robinhood (Arbitrum Orbit) EVM metrics implementation for HTTP endpoints."""
+
+from common.metric_types import (
+    EVMAccBalanceLatencyMetric,
+    EVMBlockNumberLatencyMetric,
+    HttpCallLatencyMetricBase,
+)
+
+# Verified active contracts on Robinhood mainnet (chain 4663), 2026-07-20.
+USDG = "0x5fc5360d0400a0fd4f2af552add042d716f1d168"  # busiest stablecoin (6 dec)
+TRANSFER_TOPIC = "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef"
+
+
+class HTTPEthCallLatencyMetric(HttpCallLatencyMetricBase):
+    """Collects response time for eth_call simulation."""
+
+    @property
+    def method(self) -> str:
+        """Return the RPC method name."""
+        return "eth_call"
+
+    @staticmethod
+    def get_params_from_state(state_data: dict) -> list:
+        """Get eth_call parameters for USDG balanceOf a known holder."""
+        return [
+            {
+                "to": USDG,
+                # balanceOf a known non-zero USDG holder (address in data below)
+                "data": "0x70a082310000000000000000000000008366a39cc670b4001a1121b8f6a443a643e40951",  # noqa: E501
+            },
+            "latest",
+        ]
+
+
+class HTTPTxReceiptLatencyMetric(HttpCallLatencyMetricBase):
+    """Collects latency for transaction receipt retrieval."""
+
+    @property
+    def method(self) -> str:
+        """Return the RPC method name."""
+        return "eth_getTransactionReceipt"
+
+    @staticmethod
+    def validate_state(state_data: dict) -> bool:
+        """Validate blockchain state contains transaction hash."""
+        return bool(state_data and state_data.get("tx"))
+
+    @staticmethod
+    def get_params_from_state(state_data: dict) -> list:
+        """Get parameters using transaction hash from state."""
+        return [state_data["tx"]]
+
+
+class HTTPAccBalanceLatencyMetric(EVMAccBalanceLatencyMetric):
+    """eth_getBalance latency for Robinhood."""
+
+    # WETH — most active contract on Robinhood; holds large native balance that
+    # changes block to block, so successive cron rounds sample different values.
+    probe_address = "0x0bd7d308f8e1639fab988df18a8011f41eacad73"
+
+
+class HTTPDebugTraceTxLatencyMetric(HttpCallLatencyMetricBase):
+    """Collects latency for transaction tracing."""
+
+    @property
+    def method(self) -> str:
+        """Return the RPC method name."""
+        return "debug_traceTransaction"
+
+    @staticmethod
+    def validate_state(state_data: dict) -> bool:
+        """Validate blockchain state contains transaction hash."""
+        return bool(state_data and state_data.get("tx"))
+
+    @staticmethod
+    def get_params_from_state(state_data: dict) -> list:
+        """Get parameters using transaction hash from state."""
+        return [state_data["tx"], {"tracer": "callTracer"}]
+
+
+class HTTPDebugTraceBlockByNumberLatencyMetric(HttpCallLatencyMetricBase):
+    """Collects call latency for the `debug_traceBlockByNumber` method."""
+
+    @property
+    def method(self) -> str:
+        """Return the RPC method name."""
+        return "debug_traceBlockByNumber"
+
+    @staticmethod
+    def get_params_from_state(state_data: dict) -> list:
+        """Get fixed parameters for latest block tracing."""
+        return ["latest", {"tracer": "callTracer"}]
+
+
+class HTTPBlockNumberLatencyMetric(EVMBlockNumberLatencyMetric):
+    """eth_blockNumber latency; captures raw block number for lag tracking."""
+
+
+class HTTPGetLogsLatencyMetric(HttpCallLatencyMetricBase):
+    """Collects call latency for the eth_getLogs method."""
+
+    @property
+    def method(self) -> str:
+        """Return the RPC method name."""
+        return "eth_getLogs"
+
+    @staticmethod
+    def validate_state(state_data: dict) -> bool:
+        """Validates that required old block number exists in state data."""
+        return bool(state_data and state_data.get("old_block"))
+
+    @staticmethod
+    def get_params_from_state(state_data: dict) -> list:
+        """Get parameters for USDG transfer logs from a recent block range."""
+        from_block_hex = state_data["old_block"]
+        from_block_int = int(from_block_hex, 16)
+        to_block_int: int = max(0, from_block_int + 100)
+        to_block_hex: str = hex(to_block_int)
+
+        return [
+            {
+                "fromBlock": from_block_hex,
+                "toBlock": to_block_hex,
+                "address": USDG,
+                "topics": [TRANSFER_TOPIC],
+            }
+        ]

--- a/vercel.fra1.json
+++ b/vercel.fra1.json
@@ -27,6 +27,10 @@
       "memory": 400,
       "maxDuration": 59
     },
+    "api/read/robinhood.py": {
+      "memory": 400,
+      "maxDuration": 59
+    },
     "api/read/test_blockchain.py": {
       "memory": 150,
       "maxDuration": 59
@@ -71,6 +75,10 @@
     },
     {
       "path": "/api/read/hyperliquid",
+      "schedule": "*/3 * * * *"
+    },
+    {
+      "path": "/api/read/robinhood",
       "schedule": "*/3 * * * *"
     },
     {

--- a/vercel.hnd1.json
+++ b/vercel.hnd1.json
@@ -14,6 +14,10 @@
     "api/read/hyperliquid.py": {
       "memory": 400,
       "maxDuration": 59
+    },
+    "api/read/robinhood.py": {
+      "memory": 400,
+      "maxDuration": 59
     }
   },
   "crons": [
@@ -27,6 +31,10 @@
     },
     {
       "path": "/api/read/hyperliquid",
+      "schedule": "*/3 * * * *"
+    },
+    {
+      "path": "/api/read/robinhood",
       "schedule": "*/3 * * * *"
     }
   ]

--- a/vercel.json
+++ b/vercel.json
@@ -27,6 +27,10 @@
       "memory": 400,
       "maxDuration": 59
     },
+    "api/read/robinhood.py": {
+      "memory": 400,
+      "maxDuration": 59
+    },
     "api/read/test_blockchain.py": {
       "memory": 150,
       "maxDuration": 59
@@ -67,6 +71,10 @@
     },
     {
       "path": "/api/read/hyperliquid",
+      "schedule": "*/3 * * * *"
+    },
+    {
+      "path": "/api/read/robinhood",
       "schedule": "*/3 * * * *"
     },
     {

--- a/vercel.sfo1.json
+++ b/vercel.sfo1.json
@@ -27,6 +27,10 @@
       "memory": 400,
       "maxDuration": 59
     },
+    "api/read/robinhood.py": {
+      "memory": 400,
+      "maxDuration": 59
+    },
     "api/read/test_blockchain.py": {
       "memory": 150,
       "maxDuration": 59
@@ -55,6 +59,10 @@
     },
     {
       "path": "/api/read/hyperliquid",
+      "schedule": "*/3 * * * *"
+    },
+    {
+      "path": "/api/read/robinhood",
       "schedule": "*/3 * * * *"
     },
     {


### PR DESCRIPTION
Adds Robinhood Chain (Arbitrum Orbit, `nitro/v3.11.2`, chain ID 4663) to the read-metrics functions **and** the v2 proof-anchored balance verifier, mirroring the arbitrum EVM path.

## What
**v1 read metrics**
- `metrics/robinhood.py` — 8 EVM latency metrics (copy of arbitrum) with Robinhood addresses.
- `api/read/robinhood.py` — cron entry point (`MetricsHandler("Robinhood", …)`), incl WS newHeads.
- `config/defaults.py` — `BLOCK_OFFSET_RANGES["robinhood"] = (18000, 25000)`.
- `api/support/update_state.py` — `robinhood` added to `SUPPORTED_BLOCKCHAINS`.
- `common/state/blockchain_fetcher.py` — `robinhood` added to the EVM fetch tuple.
- `vercel.json` + `vercel.{fra1,sfo1,hnd1}.json` — `*/3` cron (regions matching arbitrum; not sin1).
- `endpoints.json.example` — Robinhood Chainstack provider entry.

**v2 data-correctness (verify_state)**
- `config/defaults.py` — `VERIFY_BLOCK_OFFSET_RANGES["robinhood"] = (30, 70)`.
- `api/support/verify_state.py` — WETH added to `PROBE_ADDRESSES` (same address as v1 balance probe, so observed↔verified dashboards join). Auto-included via `chains = list(PROBE_ADDRESSES)`; verify_state cron already registered, no vercel change.

## Why these values
- **Template = arbitrum:** chain is an Arbitrum Orbit / Nitro stack.
- **Probe addrs (verified live):** WETH `0x0bd7d308…` (native balance probe, most active), USDG `0x5fc5360d…` (eth_call + eth_getLogs token), USDG holder `0x8366a39c…` (non-zero balanceOf).
- **v1 offset (18000, 25000):** ~100 ms blocks → ~30–42 min depth, matching arbitrum's wall-clock depth. State retained past −50000.
- **v2 offset (30, 70):** proof/trie window measured at exactly 128 blocks (works ≤−100, fails ≥−128) — only ~12.8 s at 100 ms blocks, shortest of any chain. Measured round ~0.1 s with 1–7 block head-drift, so effective proof depth stays ~<100, ~28-block margin under the prune edge for slower/cold prod rounds.

## Verification
- State fetch via changed path: non-empty block/tx/old_block, ~30.6 min depth.
- Headless read run: all 8 metrics `response_status=success`, incl `eth_subscribe` (WSS works).
- verify_state end-to-end (3 rounds): 4-provider stateRoot quorum (Chainstack/Quicknode/Alchemy/dRPC) all agree, MPT proof verified, `verifier_status=0`, `balance_verified` matches every provider's observed balance.
- ruff clean on new/changed files; verify_state.py + defaults.py mypy-clean; no new mypy errors vs the arbitrum template.

## Out of scope
- Grafana dashboard panels (separate `dashboards/` subproject).

## Manual follow-up (not in this PR)
- Deploy to Vercel + add the Robinhood providers to the production `ENDPOINTS` env var — read crons + verifier error without them.
