### PR TITLE
fix: rotate which provider is measured first each round

### DIFF
--- a/common/metrics_handler.py
+++ b/common/metrics_handler.py
@@ -18,6 +18,43 @@ from common.state.blockchain_state import BlockchainState
 from config.defaults import MetricsServiceConfig
 
 
+def rotate_providers(
+    providers: list[dict[str, Any]], now: float
+) -> list[dict[str, Any]]:
+    """Rotate which provider is measured first, once per cron period.
+
+    The first request through the measurement gate is reliably slower than the
+    ones behind it. Measured in production over 21h across all three probe
+    regions, the leading provider's first metric runs ~+9 to +12ms slower at
+    p50 than its own later metrics against the same endpoint in the same
+    round, and carries a 13-25% tail over 100ms that no other position shows.
+
+    The cause is not established — it reproduces only on Vercel, not from a
+    cluster running the same code, same endpoint, same concurrency and the
+    same CPU budget. So this does not try to remove the cost; it removes the
+    *bias*. Without rotation the cost lands on whoever is first in ENDPOINTS
+    every single round, which is a property of list position, not of the
+    provider. Rotating by cron period spreads it evenly, so over any window
+    longer than N periods each provider leads an equal share of rounds.
+
+    Keyed on wall-clock rather than a counter because each cron invocation is
+    a fresh process with no memory of the last one.
+
+    Args:
+        providers: Providers for this blockchain, in ENDPOINTS order.
+        now: Unix timestamp; quantised to the cron period so every metric in
+            a round shares one ordering.
+
+    Returns:
+        The same providers, rotated left by the current period index.
+    """
+    if len(providers) < 2:
+        return providers
+    period = int(now // MetricsServiceConfig.CRON_PERIOD_SECONDS)
+    offset = period % len(providers)
+    return providers[offset:] + providers[:offset]
+
+
 class MetricsHandler:
     """Manages collection and pushing of blockchain metrics."""
 
@@ -267,7 +304,7 @@ class MetricsHandler:
             gate = asyncio.Semaphore(1)
             collection_tasks = [
                 self.collect_metrics(provider, config, state_data, gate, deadline)
-                for provider in rpc_providers
+                for provider in rotate_providers(rpc_providers, time.time())
             ]
             await asyncio.gather(*collection_tasks, return_exceptions=True)
 

--- a/config/defaults.py
+++ b/config/defaults.py
@@ -23,6 +23,11 @@ class MetricsServiceConfig:
     METRIC_REQUEST_TIMEOUT = 55
     METRIC_MAX_LATENCY = 55
 
+    # Read crons fire every 3 minutes (see the schedules in vercel*.json).
+    # Used to quantise the provider rotation so every metric in a round agrees
+    # on the ordering, and so the lead position advances once per round.
+    CRON_PERIOD_SECONDS = 180
+
     # Wall-clock budget for one invocation's collection phase, measured from
     # the START of the handler so it covers the state fetch too. Timed metrics
     # run one at a time (see BaseMetric.serialise_measurement), so the round

--- a/tests/test_provider_rotation.py
+++ b/tests/test_provider_rotation.py
@@ -1,0 +1,73 @@
+"""Self-check for provider rotation: python tests/test_provider_rotation.py
+
+Fails if the lead position is not shared evenly, if the ordering is unstable
+within a single cron period, or if rotation loses/duplicates a provider.
+"""
+
+import collections
+import sys
+from pathlib import Path
+from typing import Any
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from common.metrics_handler import rotate_providers
+from config.defaults import MetricsServiceConfig
+
+P = MetricsServiceConfig.CRON_PERIOD_SECONDS
+
+
+def providers(n: int) -> list[dict[str, Any]]:
+    return [{"name": f"p{i}"} for i in range(n)]
+
+
+def main() -> None:
+    base = 1_786_000_000.0
+
+    # 1. Every provider leads an equal share of rounds.
+    for n in (2, 3, 4, 5):
+        ps = providers(n)
+        leads = collections.Counter(
+            rotate_providers(ps, base + r * P)[0]["name"] for r in range(n * 50)
+        )
+        assert len(leads) == n, f"only {len(leads)} of {n} providers ever led"
+        assert set(leads.values()) == {50}, f"uneven lead share for n={n}: {leads}"
+
+    # 2. Ordering is stable within a period — every metric in one round must
+    #    agree, otherwise providers interleave unpredictably.
+    ps = providers(4)
+    start = (base // P) * P
+    within = {
+        tuple(p["name"] for p in rotate_providers(ps, start + off))
+        for off in (0, 1, 30, 90, P - 1)
+    }
+    assert len(within) == 1, f"ordering changed inside one cron period: {within}"
+
+    # 3. Consecutive periods advance the lead by exactly one, cyclically.
+    #    (The absolute starting lead depends on the epoch, so assert the step
+    #    rather than a hardcoded first element.)
+    order = [p["name"] for p in ps]
+    seq = [rotate_providers(ps, start + r * P)[0]["name"] for r in range(len(ps) + 1)]
+    for a, b in zip(seq, seq[1:]):
+        expected = order[(order.index(a) + 1) % len(order)]
+        assert b == expected, f"lead went {a} -> {b}, expected {expected}: {seq}"
+    assert seq[0] == seq[-1], f"lead did not return after a full cycle: {seq}"
+
+    # 4. Rotation is a permutation — nothing lost, added or duplicated.
+    for r in range(8):
+        out = rotate_providers(ps, base + r * P)
+        assert sorted(p["name"] for p in out) == sorted(p["name"] for p in ps)
+        assert len(out) == len(ps)
+
+    # 5. Degenerate inputs are returned untouched.
+    assert rotate_providers([], base) == []
+    one = providers(1)
+    assert rotate_providers(one, base) == one
+
+    print(
+        "OK: lead position rotates evenly, is stable within a round, "
+        "and preserves the provider set"
+    )
+
+
+main()


### PR DESCRIPTION
## Problem

Serialising the measurements in #93 removed cross-request contention, but introduced a **position bias**: the first request through the gate is reliably slower than the ones behind it, and without rotation that cost lands on whoever is first in `ENDPOINTS` — every round, forever.

Measured in production over 21h with all three regions on the fixed code, comparing the leading provider's **first** metric against **its own later metric**, same endpoint, same round:

| region | pos-1 `eth_blockNumber` | pos-6 `eth_getTransactionReceipt` | penalty |
|---|---|---|---|
| fra1 | 19.6 ms | 9.2 ms | **+10.4** |
| sfo1 | 20.5 ms | 11.9 ms | **+8.6** |
| sin1 | 19.0 ms | 7.0 ms | **+12.0** |

Plus a **13% / 25% / 19%** tail over 100 ms that no other position shows. Every other provider is flat across positions.

The victim tracks list order, not the provider — it's Chainstack on Robinhood and Ethereum, **Alchemy on Base**. On Robinhood this alone makes `eth_blockNumber` read p95 178 ms against 60–70 ms for that provider's other light methods.

## What this does not claim

**The cause is not established.** It does not reproduce from a cluster running the same code against the same endpoint. I tested, and each produced at most **+0.6 ms** against the ~+10 ms seen in production:

- the original 32-way concurrency
- 4 concurrent WebSocket handshakes alongside the gated sequence (the gate-exempt path added in #93)
- a process-cold first request (ruling out CA-bundle / SSL-context / resolver warm-up — and `BlockchainState.get_data()` already makes HTTPS calls before any measurement, so the process is warm regardless)
- all of the above under a 250m CPU / 400Mi limit matched to the Vercel sandbox

I originally proposed a warm-up request to absorb a first-request cost. The evidence above falsified that premise, so it isn't in this PR.

## What this does

Removes the **bias**, not the cost. `rotate_providers()` advances the lead position once per cron period, so over any window longer than N periods each provider leads an equal share of rounds and the ranking reflects providers rather than their position in a config list.

Keyed on wall-clock quantised to `CRON_PERIOD_SECONDS`, because each invocation is a fresh process with no memory of the previous round — and quantising means every metric within a round agrees on the ordering.

## Verification

- `tests/test_provider_rotation.py` — asserts equal lead share across 2/3/4/5 providers, stable ordering within a period, single-step advance per period, permutation safety, and degenerate inputs. Mutation-tested: pinning `offset = 0` fails it.
- `tests/test_measurement_gate.py` still passes.
- `black`, `ruff` clean; **no new mypy errors** vs `master`.

## Follow-ups, not in this PR

1. **Removing the cost** needs a diagnostic inside the Vercel runtime — passive capture at our edge can't separate the probe from ~7,000 other clients.
2. **The scoring formula is worth revisiting.** The harmonic mean I introduced in #93 rewards providers that are very fast on a few methods and ignores slow ones, because it is dominated by the smallest values. On Base that currently ranks dRPC #2 (p50 232 ms / p95 450 ms / 99.73% availability) above Chainstack #4 (52 ms / 238 ms / 99.85%) — the headline figures and the rank disagree, which is confusing to readers. Neither arithmetic nor harmonic matches what the page displays; worth deciding deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metrics collection now rotates provider priority every three minutes, helping distribute lead usage more evenly.
  * Provider ordering remains stable during each scheduling period and advances cyclically between periods.
  * Configurable scheduling supports consistent provider rotation behavior.

* **Reliability**
  * Provider lists remain unchanged when empty or containing only one provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->